### PR TITLE
Up the coverage of ParseRef and ParseValue

### DIFF
--- a/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
+++ b/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
@@ -23,7 +23,7 @@ import io.parsingdata.metal.data.ParseValue;
 
 public class ByOffset {
 
-    public static boolean hasGraphAtRef(ParseGraph graph, long ref) {
+    public static boolean hasGraphAtRef(final ParseGraph graph, final long ref) {
         return findRef(ByType.getGraphs(graph), ref) != null;
     }
 
@@ -37,7 +37,7 @@ public class ByOffset {
         return null;
     }
 
-    public static ParseValue getLowestOffsetValue(ParseGraph graph) {
+    public static ParseValue getLowestOffsetValue(final ParseGraph graph) {
         if (!graph.containsValue()) { throw new IllegalStateException("Cannot determine lowest offset if graph does not contain a value."); }
         final ParseItem head = graph.head;
         if (head.isValue()) {
@@ -46,7 +46,7 @@ public class ByOffset {
         return getLowestOffsetValue(graph.tail);
     }
 
-    private static ParseValue getLowestOffsetValue(ParseGraph graph, final ParseValue lowest) {
+    private static ParseValue getLowestOffsetValue(final ParseGraph graph, final ParseValue lowest) {
         if (!graph.containsValue()) { return lowest; }
         final ParseItem head = graph.head;
         if (head.isValue()) {

--- a/src/test/java/io/parsingdata/metal/data/ParseRefTest.java
+++ b/src/test/java/io/parsingdata/metal/data/ParseRefTest.java
@@ -34,6 +34,11 @@ public class ParseRefTest {
     }
 
     @Test
+    public void toStringTest() {
+        assertThat(_ref.toString(), is("ParseRef(0)"));
+    }
+
+    @Test
     public void refIsARef() {
         assertTrue(_ref.isRef());
         assertThat(_ref.asRef(), is(sameInstance(_ref)));

--- a/src/test/java/io/parsingdata/metal/data/ParseRefTest.java
+++ b/src/test/java/io/parsingdata/metal/data/ParseRefTest.java
@@ -1,0 +1,60 @@
+package io.parsingdata.metal.data;
+
+import static io.parsingdata.metal.Shorthand.*;
+import static junit.framework.TestCase.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import io.parsingdata.metal.token.Token;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ParseRefTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Token _definition;
+    private ParseRef _ref;
+
+    @Before
+    public void setUp() {
+        _definition = sub(def("value", 1), con(0));
+        _ref = new ParseRef(0L, _definition);
+    }
+
+    @Test
+    public void state() {
+        assertThat(_ref.location, is(0L));
+        assertThat(_ref.getDefinition(), is(_definition));
+    }
+
+    @Test
+    public void refIsARef() {
+        assertTrue(_ref.isRef());
+        assertThat(_ref.asRef(), is(sameInstance(_ref)));
+    }
+
+    @Test
+    public void refIsNotAValue() {
+        assertFalse(_ref.isValue());
+
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Cannot convert ParseRef to ParseValue");
+        _ref.asValue();
+    }
+
+    @Test
+    public void refIsNotAGraph() {
+        assertFalse(_ref.isGraph());
+
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Cannot convert ParseRef to ParseGraph");
+        _ref.asGraph();
+    }
+
+}

--- a/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -1,0 +1,84 @@
+package io.parsingdata.metal.data;
+
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static junit.framework.TestCase.assertFalse;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import io.parsingdata.metal.token.Token;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ParseValueTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Token _definition;
+    private ParseValue _value;
+
+    @Before
+    public void setUp() {
+        _definition = def("value", 1);
+        _value = new ParseValue("scope", "value", _definition, 0, new byte[] { 1 }, enc());
+    }
+
+    @Test
+    public void state() {
+        assertThat(_value.getScope(), is("scope"));
+        assertThat(_value.getName(), is("value"));
+        assertThat(_value.getFullName(), is("scope.value"));
+        assertThat(_value.getDefinition(), is(_definition));
+        assertThat(_value.getOffset(), is(0L));
+        assertThat(_value.getValue(), is(equalTo(new byte[] { 1 })));
+    }
+
+    @Test
+    public void matching() {
+        assertTrue(_value.matches("value"));
+        assertTrue(_value.matches("scope.value"));
+
+        assertFalse(_value.matches("lue"));
+        assertFalse(_value.matches(".value"));
+        assertFalse(_value.matches("cope.value"));
+    }
+
+    @Test
+    public void toStringTest() {
+        assertThat(_value.toString(), is("ParseValue(value:ParseValue(01))"));
+
+        // TODO #18 Improve ParseValue toString()
+        // assertThat(_value.toString(), is("ParseValue(value:01)"));
+    }
+
+    @Test
+    public void valueIsAValue() {
+        assertTrue(_value.isValue());
+        assertThat(_value.asValue(), is(sameInstance(_value)));
+    }
+
+    @Test
+    public void valueIsNotARef() {
+        assertFalse(_value.isRef());
+
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Cannot convert ParseValue to ParseRef");
+        _value.asRef();
+    }
+
+    @Test
+    public void valueIsNotAGraph() {
+        assertFalse(_value.isGraph());
+
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Cannot convert ParseValue to ParseGraph");
+        _value.asGraph();
+    }
+
+}


### PR DESCRIPTION
Added some unit tests for `ParseRef` and `ParseValue`, which now have 100% coverage, pushing the overall coverage up another percent.

I've also created #18 due to the strange `toString()` behaviour in `ParseValue` (see the unit test).