### PR TITLE
Add TokenRef

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -116,6 +116,11 @@ public class Shorthand {
     public static ComparisonExpression ltNum(final ValueExpression p) { return new LtNum(null, p); }
     public static ComparisonExpression ltNum(final ValueExpression c, final ValueExpression p) { return new LtNum(c, p); }
 
+    public final static Reducer ADD_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return add(l, r); } };
+    public final static Reducer MUL_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return mul(l, r); } };
+    public final static Reducer CAT_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return cat(l, r); } };
+    public final static Reducer SUB_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return sub(l, r); } };
+
     public static byte[] toByteArray(final int... bytes) {
         final byte[] out = new byte[bytes.length];
         for (int i = 0; i < bytes.length; i++) {

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -84,7 +84,8 @@ public class Shorthand {
     public static ValueExpression con(final int... values) { return con(new Encoding(), values); }
     public static final ValueExpression self = new Self();
     public static ValueExpression len(final ValueExpression v) { return new Len(v); }
-    public static ValueExpression ref(final String s) { return new Ref(s); }
+    public static ValueExpression ref(final String s) { return new NameRef(s); }
+    public static ValueExpression ref(final Token d) { return new TokenRef(d); }
     public static ValueExpression first(final ValueExpression o) { return new First(o); }
     public static ValueExpression last(final ValueExpression o) { return new Last(o); }
     public static ValueExpression offset(final ValueExpression o) { return new Offset(o); }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -115,7 +115,7 @@ public class ParseGraph implements ParseItem {
     }
 
     public ParseValue get(final String name) {
-        return ByName.get(this, name);
+        return ByName.getValue(this, name);
     }
 
     public ParseItem get(final Token definition) {

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByItem.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByItem.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.data.selection;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 
+import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.ParseGraph.EMPTY;
 
 public class ByItem {
@@ -28,14 +29,15 @@ public class ByItem {
      * @return The partial graph of the provided graph starting past (bottom-up) the provided lastHead
      */
     public static ParseGraph getGraphAfter(final ParseGraph graph, final ParseItem lastHead) {
-        return getGraphAfter(graph, lastHead, EMPTY);
+        checkNotNull(graph, "graph");
+        return getGraphAfterRecursive(graph, lastHead);
     }
 
-    private static ParseGraph getGraphAfter(final ParseGraph graph, final ParseItem lastHead, final ParseGraph result) {
+    private static ParseGraph getGraphAfterRecursive(final ParseGraph graph, final ParseItem lastHead) {
         if (graph.isEmpty()) { return EMPTY; }
         final ParseItem head = graph.head;
-        if (head == lastHead) { return result; }
+        if (head == lastHead) { return EMPTY; }
         // TODO: How can we do this without calling the (previously private) constructor? (#64)
-        return new ParseGraph(head, getGraphAfter(graph.tail, lastHead, result), graph.definition);
+        return new ParseGraph(head, getGraphAfter(graph.tail, lastHead), graph.definition);
     }
 }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
@@ -21,6 +21,8 @@ import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.ParseValueList;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class ByName {
 
     /**
@@ -28,15 +30,15 @@ public class ByName {
      * @param name Name of the value
      * @return The first value (bottom-up) with the provided name in the provided graph
      */
-    public static ParseValue get(final ParseGraph graph, final String name) {
+    public static ParseValue getValue(final ParseGraph graph, final String name) {
         if (graph.isEmpty()) { return null; }
         final ParseItem head = graph.head;
         if (head.isValue() && head.asValue().matches(name)) { return head.asValue(); }
         if (head.isGraph()) {
-            final ParseValue val = get(head.asGraph(), name);
+            final ParseValue val = getValue(head.asGraph(), name);
             if (val != null) { return val; }
         }
-        return get(graph.tail, name);
+        return getValue(graph.tail, name);
     }
 
     /**
@@ -44,16 +46,18 @@ public class ByName {
      * @param name Name of the value
      * @return All values with the provided name in this graph
      */
-    public static ParseValueList getAll(ParseGraph graph, String name) {
-        return getAll(graph, name, ParseValueList.EMPTY);
+    public static ParseValueList getAllValues(final ParseGraph graph, final String name) {
+        checkNotNull(graph, "graph");
+        checkNotNull(name, "name");
+        return getAllValuesRecursive(graph, name);
     }
 
-    private static ParseValueList getAll(final ParseGraph graph, final String name, final ParseValueList result) {
-        if (graph.isEmpty()) { return result; }
-        final ParseValueList tailResults = getAll(graph.tail, name, result);
+    private static ParseValueList getAllValuesRecursive(final ParseGraph graph, final String name) {
+        if (graph.isEmpty()) { return ParseValueList.EMPTY; }
+        final ParseValueList tailResults = getAllValuesRecursive(graph.tail, name);
         final ParseItem head = graph.head;
         if (head.isValue() && head.asValue().matches(name)) { return tailResults.add(head.asValue()); }
-        if (head.isGraph()) { return tailResults.add(getAll(head.asGraph(), name, result)); }
+        if (head.isGraph()) { return tailResults.add(getAllValuesRecursive(head.asGraph(), name)); }
         return tailResults;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
@@ -31,6 +31,8 @@ public class ByName {
      * @return The first value (bottom-up) with the provided name in the provided graph
      */
     public static ParseValue getValue(final ParseGraph graph, final String name) {
+        checkNotNull(graph, "graph");
+        checkNotNull(name, "name");
         if (graph.isEmpty()) { return null; }
         final ParseItem head = graph.head;
         if (head.isValue() && head.asValue().matches(name)) { return head.asValue(); }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
@@ -21,6 +21,8 @@ import io.parsingdata.metal.data.ParseGraphList;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseValue;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class ByOffset {
 
     public static boolean hasGraphAtRef(final ParseGraph graph, final long ref) {
@@ -28,6 +30,7 @@ public class ByOffset {
     }
 
     public static ParseGraph findRef(final ParseGraphList graphs, final long ref) {
+        checkNotNull(graphs, "graphs");
         if (graphs.isEmpty()) { return null; }
         final ParseGraph res = findRef(graphs.tail, ref);
         if (res != null) { return res; }
@@ -38,6 +41,7 @@ public class ByOffset {
     }
 
     public static ParseValue getLowestOffsetValue(final ParseGraph graph) {
+        checkNotNull(graph, "graph");
         if (!graph.containsValue()) { throw new IllegalStateException("Cannot determine lowest offset if graph does not contain a value."); }
         final ParseItem head = graph.head;
         if (head.isValue()) {

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
@@ -16,12 +16,13 @@
 
 package io.parsingdata.metal.data.selection;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseItemList;
+import io.parsingdata.metal.data.ParseValueList;
 import io.parsingdata.metal.token.Token;
+
+import static io.parsingdata.metal.Util.checkNotNull;
 
 public class ByToken {
 
@@ -41,6 +42,7 @@ public class ByToken {
     }
 
     public static ParseItemList getAll(final ParseGraph graph, final Token definition) {
+        checkNotNull(graph, "graph");
         checkNotNull(definition, "definition");
         return getAllRecursive(graph, definition);
     }
@@ -51,8 +53,29 @@ public class ByToken {
         final ParseItemList results = graph.definition == definition ? tailResults.add(graph) : tailResults;
         final ParseItem head = graph.head;
         if (head.isValue() && head.asValue().definition == definition) { return results.add(head); }
+        if (head.isRef() && head.asRef().definition == definition) { return results.add(head); }
         if (head.isGraph()) { return results.add(getAllRecursive(head.asGraph(), definition)); }
         return results;
+    }
+
+    /**
+     * @param graph The graph to search
+     * @param definition The token to match the ParseItem's definition field
+     * @return All values with the provided name in this graph
+     */
+    public static ParseValueList getAllValues(final ParseGraph graph, final Token definition) {
+        checkNotNull(graph, "graph");
+        checkNotNull(definition, "definition");
+        return getAllValuesRecursive(graph, definition);
+    }
+
+    private static ParseValueList getAllValuesRecursive(final ParseGraph graph, final Token definition) {
+        if (graph.isEmpty()) { return ParseValueList.EMPTY; }
+        final ParseValueList tailResults = getAllValuesRecursive(graph.tail, definition);
+        final ParseItem head = graph.head;
+        if (head.isValue() && head.asValue().definition == definition) { return tailResults.add(head.asValue()); }
+        if (head.isGraph()) { return tailResults.add(getAllValuesRecursive(head.asGraph(), definition)); }
+        return tailResults;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
@@ -29,6 +29,7 @@ public class ByToken {
     private ByToken() {}
 
     public static ParseItem get(final ParseGraph graph, final Token definition) {
+        checkNotNull(graph, "graph");
         checkNotNull(definition, "definition");
         if (graph.definition == definition) { return graph; }
         if (graph.isEmpty()) { return null; }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByType.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByType.java
@@ -20,9 +20,12 @@ import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseGraphList;
 import io.parsingdata.metal.data.ParseItem;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class ByType {
 
     public static ParseGraphList getRefs(final ParseGraph graph) {
+        checkNotNull(graph, "graph");
         return getRefs(graph, graph);
     }
 
@@ -34,6 +37,7 @@ public class ByType {
     }
 
     public static ParseGraphList getGraphs(final ParseGraph graph) {
+        checkNotNull(graph, "graph");
         return getNestedGraphs(graph).add(graph);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -1,6 +1,20 @@
-package io.parsingdata.metal.expression.value.reference;
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static io.parsingdata.metal.Util.checkNotNull;
+package io.parsingdata.metal.expression.value.reference;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
@@ -10,6 +24,8 @@ import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.OptionalValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
+
+import static io.parsingdata.metal.Util.checkNotNull;
 
 public class Count implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value.reference;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.OptionalValue;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 import static io.parsingdata.metal.Util.checkNotNull;
@@ -34,7 +35,11 @@ public class First implements ValueExpression {
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
         final OptionalValueList list = _op.eval(env, enc);
-        return list.isEmpty() ? list : OptionalValueList.create(list.reverse().head);
+        return list.isEmpty() ? list : OptionalValueList.create(getFirst(list));
+    }
+
+    private OptionalValue getFirst(final OptionalValueList list) {
+        return list.tail.isEmpty() ? list.head : getFirst(list.tail);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/NameRef.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/NameRef.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value.reference;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.OptionalValueList;
+import io.parsingdata.metal.data.selection.ByName;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.ValueExpression;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
+public class NameRef implements ValueExpression {
+
+    private final String _name;
+
+    public NameRef(final String name) {
+        _name = checkNotNull(name, "name");
+    }
+
+    @Override
+    public OptionalValueList eval(final Environment env, final Encoding enc) {
+        return OptionalValueList.create(ByName.getAllValues(env.order, _name));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + _name + ")";
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/TokenRef.java
@@ -18,28 +18,29 @@ package io.parsingdata.metal.expression.value.reference;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
-import io.parsingdata.metal.data.selection.ByName;
+import io.parsingdata.metal.data.selection.ByToken;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.token.Token;
 
 import static io.parsingdata.metal.Util.checkNotNull;
 
-public class Ref implements ValueExpression {
+public class TokenRef implements ValueExpression {
 
-    private final String _name;
+    private final Token definition;
 
-    public Ref(final String name) {
-        _name = checkNotNull(name, "name");
+    public TokenRef(final Token definition) {
+        this.definition = checkNotNull(definition, "definition");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return OptionalValueList.create(ByName.getAll(env.order, _name));
+        return OptionalValueList.create(ByToken.getAllValues(env.order, definition));
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _name + ")";
+        return getClass().getSimpleName() + "(" + definition + ")";
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -25,10 +25,7 @@ import io.parsingdata.metal.expression.logical.And;
 import io.parsingdata.metal.expression.logical.Not;
 import io.parsingdata.metal.expression.value.*;
 import io.parsingdata.metal.expression.value.arithmetic.Neg;
-import io.parsingdata.metal.expression.value.reference.First;
-import io.parsingdata.metal.expression.value.reference.NameRef;
-import io.parsingdata.metal.expression.value.reference.Offset;
-import io.parsingdata.metal.expression.value.reference.TokenRef;
+import io.parsingdata.metal.expression.value.reference.*;
 import io.parsingdata.metal.token.*;
 import org.junit.Assert;
 import org.junit.Test;
@@ -68,11 +65,13 @@ public class ArgumentsTest {
             { Offset.class, new Object[] { null } },
             { NameRef.class, new Object[] { null } },
             { TokenRef.class, new Object[] { null } },
+            { Count.class, new Object[] { null } },
             // Derived from BinaryValueExpression
             { Cat.class, new Object[] { VALID_VE, null } },
             { Cat.class, new Object[] { null, VALID_VE } },
             // Derived from UnaryValueExpression
             { Neg.class, new Object[] { null } },
+            { Len.class, new Object[] { null } },
             // Derived from BinaryLogicalExpression
             { And.class, new Object[] { VALID_E, null } },
             { And.class, new Object[] { null, VALID_E } },

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -26,8 +26,9 @@ import io.parsingdata.metal.expression.logical.Not;
 import io.parsingdata.metal.expression.value.*;
 import io.parsingdata.metal.expression.value.arithmetic.Neg;
 import io.parsingdata.metal.expression.value.reference.First;
+import io.parsingdata.metal.expression.value.reference.NameRef;
 import io.parsingdata.metal.expression.value.reference.Offset;
-import io.parsingdata.metal.expression.value.reference.Ref;
+import io.parsingdata.metal.expression.value.reference.TokenRef;
 import io.parsingdata.metal.token.*;
 import org.junit.Assert;
 import org.junit.Test;
@@ -65,7 +66,8 @@ public class ArgumentsTest {
             { FoldRight.class, new Object[] { null, VALID_REDUCER, VALID_VE } },
             { First.class, new Object[] { null } },
             { Offset.class, new Object[] { null } },
-            { Ref.class, new Object[] { null } },
+            { NameRef.class, new Object[] { null } },
+            { TokenRef.class, new Object[] { null } },
             // Derived from BinaryValueExpression
             { Cat.class, new Object[] { VALID_VE, null } },
             { Cat.class, new Object[] { null, VALID_VE } },

--- a/core/src/test/java/io/parsingdata/metal/ReducersTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReducersTest.java
@@ -19,8 +19,6 @@ package io.parsingdata.metal;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
-import io.parsingdata.metal.expression.value.Reducer;
-import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 import org.junit.runners.Parameterized.Parameters;
@@ -67,24 +65,19 @@ public class ReducersTest extends ParameterizedParse {
         super(token, env, enc, result);
     }
 
-    private final static Reducer addReducer = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return add(l, r); } };
-    private final static Reducer mulReducer = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return mul(l, r); } };
-    private final static Reducer catReducer = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return cat(l, r); } };
-    private final static Reducer subReducer = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return sub(l, r); } };
-
-    private final static Token reduceAddA = token(1, eq(fold(ref("a"), addReducer)));
-    private final static Token reduceAddOffsetA = token(1, eq(fold(offset(ref("a")), addReducer)));
-    private final static Token reduceAddAInit0 = token(1, eq(fold(ref("a"), addReducer, con(0))));
-    private final static Token reduceAddAInit1 = token(1, eq(fold(ref("a"), addReducer, con(1))));
-    private final static Token reduceMulA = token(1, eq(fold(ref("a"), mulReducer)));
-    private final static Token reduceAllAplusMulA = token(1, eq(add(fold(ref("a"), addReducer), fold(ref("a"), mulReducer))));
-    private final static Token reduceCatA = token(3, eq(fold(ref("a"), catReducer)));
-    private final static Token reduceCatAToNumBE = token(3, eqNum(fold(ref("a"), catReducer)), enc());
-    private final static Token reduceCatAToNumLE = token(3, eqNum(fold(ref("a"), catReducer)), le());
-    private final static Token foldLeftSubA = token(1, eq(foldLeft(ref("a"), subReducer)));
-    private final static Token foldLeftSubAInit2 = token(1, eq(foldLeft(ref("a"), subReducer, con(2))));
-    private final static Token foldRightSubA = token(1, eq(foldRight(ref("a"), subReducer)));
-    private final static Token foldRightSubAInit2 = token(1, eq(foldRight(ref("a"), subReducer, con(2))));
+    private final static Token reduceAddA = token(1, eq(fold(ref("a"), ADD_REDUCER)));
+    private final static Token reduceAddOffsetA = token(1, eq(fold(offset(ref("a")), ADD_REDUCER)));
+    private final static Token reduceAddAInit0 = token(1, eq(fold(ref("a"), ADD_REDUCER, con(0))));
+    private final static Token reduceAddAInit1 = token(1, eq(fold(ref("a"), ADD_REDUCER, con(1))));
+    private final static Token reduceMulA = token(1, eq(fold(ref("a"), MUL_REDUCER)));
+    private final static Token reduceAllAplusMulA = token(1, eq(add(fold(ref("a"), ADD_REDUCER), fold(ref("a"), MUL_REDUCER))));
+    private final static Token reduceCatA = token(3, eq(fold(ref("a"), CAT_REDUCER)));
+    private final static Token reduceCatAToNumBE = token(3, eqNum(fold(ref("a"), CAT_REDUCER)), enc());
+    private final static Token reduceCatAToNumLE = token(3, eqNum(fold(ref("a"), CAT_REDUCER)), le());
+    private final static Token foldLeftSubA = token(1, eq(foldLeft(ref("a"), SUB_REDUCER)));
+    private final static Token foldLeftSubAInit2 = token(1, eq(foldLeft(ref("a"), SUB_REDUCER, con(2))));
+    private final static Token foldRightSubA = token(1, eq(foldRight(ref("a"), SUB_REDUCER)));
+    private final static Token foldRightSubAInit2 = token(1, eq(foldRight(ref("a"), SUB_REDUCER, con(2))));
 
     private static Token token(final long size, final Expression pred, final Encoding enc) {
         return seq(any("a"),

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -19,7 +19,6 @@ package io.parsingdata.metal;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
-import io.parsingdata.metal.expression.value.Reducer;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
@@ -68,7 +67,7 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
             { "[1, 2, 3] a, b, offset(first(c))", refList("a", "b", offset(first(ref("c")))), stream(1, 2, 3), enc(), false },
             { "[1, 2, 3, 3] a, a, a, last(ref(a.definition))", refMatch(eq(last(ref(refAny)))), stream(1, 2, 3, 3), enc(), true },
             { "[1, 2, 3, 1] a, a, a, first(ref(a.definition))", refMatch(eq(first(ref(refAny)))), stream(1, 2, 3, 1), enc(), true },
-            { "[1, 2, 3, 6] a, a, a, first(ref(a.definition))", refMatch(eq(first(fold(ref(refAny), addReducer)))), stream(1, 2, 3, 6), enc(), true },
+            { "[1, 2, 3, 6] a, a, a, first(fold(ref(a.definition), add))", refMatch(eq(first(fold(ref(refAny), ADD_REDUCER)))), stream(1, 2, 3, 6), enc(), true },
             { "[1, 2, 3, 2] a, a, a, last(ref(a.definition))", refMatch(eq(last(ref(refAny)))), stream(1, 2, 3, 2), enc(), false }
         });
     }
@@ -91,7 +90,6 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
     }
 
     private static final Token refAny = any("a");
-    private final static Reducer addReducer = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return add(l, r); } };
 
     private static Token refMatch(final Expression pred) {
         return

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -18,6 +18,8 @@ package io.parsingdata.metal;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.Expression;
+import io.parsingdata.metal.expression.value.Reducer;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
@@ -63,7 +65,11 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
             { "[1, 2, 1] a, a, offset(first(a))", refList("a", "a", offset(first(ref("a")))), stream(1, 2, 1), enc(), false },
             { "[2, 1, 0] a, a, offset(first(a))", refList("a", "a", offset(first(ref("a")))), stream(2, 1, 0), enc(), true },
             { "[1, 2, 2] a, b, offset(first(z))", refList("a", "b", offset(first(ref("z")))), stream(1, 2, 2), enc(), true },
-            { "[1, 2, 3] a, b, offset(first(c))", refList("a", "b", offset(first(ref("c")))), stream(1, 2, 3), enc(), false }
+            { "[1, 2, 3] a, b, offset(first(c))", refList("a", "b", offset(first(ref("c")))), stream(1, 2, 3), enc(), false },
+            { "[1, 2, 3, 3] a, a, a, last(ref(a.definition))", refMatch(eq(last(ref(refAny)))), stream(1, 2, 3, 3), enc(), true },
+            { "[1, 2, 3, 1] a, a, a, first(ref(a.definition))", refMatch(eq(first(ref(refAny)))), stream(1, 2, 3, 1), enc(), true },
+            { "[1, 2, 3, 6] a, a, a, first(ref(a.definition))", refMatch(eq(first(fold(ref(refAny), addReducer)))), stream(1, 2, 3, 6), enc(), true },
+            { "[1, 2, 3, 2] a, a, a, last(ref(a.definition))", refMatch(eq(last(ref(refAny)))), stream(1, 2, 3, 2), enc(), false }
         });
     }
 
@@ -82,6 +88,15 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
         return seq(any(first),
                    any(second),
                    def("z", con(1), eq(exp)));
+    }
+
+    private static final Token refAny = any("a");
+    private final static Reducer addReducer = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return add(l, r); } };
+
+    private static Token refMatch(final Expression pred) {
+        return
+            seq(repn(refAny, con(3)),
+                def("b", con(1), pred));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -53,8 +53,10 @@ public class ToStringTest {
         return prefix + count++;
     }
 
+    private Token t() { return any("a"); }
+
     private ValueExpression v() {
-        return neg(add(div(mod(mul(sub(ref(n()), first(ref(n()))), con(1)), cat(ref(n()), ref(n()))), add(self, add(offset(ref(n())), currentOffset))), elvis(ref(n()), ref(n()))));
+        return neg(add(div(mod(mul(sub(ref(n()), first(ref(n()))), con(1)), cat(ref(n()), ref(t()))), add(self, add(offset(ref(n())), currentOffset))), elvis(ref(n()), ref(n()))));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -124,7 +124,7 @@ public class TreeTest {
     @Test
     public void checkRegularTreeFlat() {
         Assert.assertTrue(_regular.succeeded());
-        final ParseValueList nrs = ByName.getAll(_regular.getEnvironment().order, "nr");
+        final ParseValueList nrs = ByName.getAllValues(_regular.getEnvironment().order, "nr");
         for (int i = 0; i < 7; i++) {
             Assert.assertTrue(contains(nrs, i));
         }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -209,7 +209,7 @@ public class ByTokenTest {
     public void compareGetAllNameWithGetAllToken() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2, 3, 4, 5), SEQ_REP);
 
-        ParseValueList valueList = ByName.getAll(graph, "value2");
+        ParseValueList valueList = ByName.getAllValues(graph, "value2");
         ParseItemList itemList = ByToken.getAll(graph, DEF2);
 
         while (valueList.head != null) {

--- a/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
@@ -1,24 +1,33 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.parsingdata.metal.expression.value;
-
-import static io.parsingdata.metal.Shorthand.con;
-import static io.parsingdata.metal.Shorthand.count;
-import static io.parsingdata.metal.Shorthand.def;
-import static io.parsingdata.metal.Shorthand.eq;
-import static io.parsingdata.metal.Shorthand.ref;
-import static io.parsingdata.metal.Shorthand.rep;
-import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
-
-import java.util.Arrays;
-import java.util.Collection;
-
-import org.junit.runners.Parameterized.Parameters;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static io.parsingdata.metal.Shorthand.*;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 public class CountTest extends ParameterizedParse {
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -113,7 +113,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void toStringTest() {
-        assertThat(elvisExpression.toString(), is(equalTo("Elvis(Ref(a),Ref(b))")));
+        assertThat(elvisExpression.toString(), is(equalTo("Elvis(NameRef(a),NameRef(b))")));
     }
 
 }


### PR DESCRIPTION
Resolve #39: Added TokenRef to reference ParseValues in the graph by definition. Renamed Ref to NameRef. In Shorthand they are both overloads of ref. Resolve #62: Remove reverse() call from First implementation.