### PR TITLE
Make immutable fields public, improve naming, remove getters from ParseResult

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -116,10 +116,10 @@ public class Shorthand {
     public static ComparisonExpression ltNum(final ValueExpression p) { return new LtNum(null, p); }
     public static ComparisonExpression ltNum(final ValueExpression c, final ValueExpression p) { return new LtNum(c, p); }
 
-    public final static Reducer ADD_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return add(l, r); } };
-    public final static Reducer MUL_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return mul(l, r); } };
-    public final static Reducer CAT_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return cat(l, r); } };
-    public final static Reducer SUB_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return sub(l, r); } };
+    public final static Reducer ADD_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return add(left, right); } };
+    public final static Reducer MUL_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return mul(left, right); } };
+    public final static Reducer CAT_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return cat(left, right); } };
+    public final static Reducer SUB_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return sub(left, right); } };
 
     public static byte[] toByteArray(final int... bytes) {
         final byte[] out = new byte[bytes.length];

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -31,90 +31,90 @@ import io.parsingdata.metal.token.*;
 
 public class Shorthand {
 
-    public static Token def(final String name, final ValueExpression size, final Expression pred, final Encoding encoding) { return new Def(name, size, pred, encoding); }
-    public static Token def(final String name, final ValueExpression size, final Expression pred) { return def(name, size, pred, null); }
-    public static Token def(final String name, final ValueExpression size, final Encoding enc) { return def(name, size, null, enc); }
+    public static Token def(final String name, final ValueExpression size, final Expression predicate, final Encoding encoding) { return new Def(name, size, predicate, encoding); }
+    public static Token def(final String name, final ValueExpression size, final Expression predicate) { return def(name, size, predicate, null); }
+    public static Token def(final String name, final ValueExpression size, final Encoding encoding) { return def(name, size, null, encoding); }
     public static Token def(final String name, final ValueExpression size) { return def(name, size, null, null); }
-    public static Token def(final String name, final long size, final Expression pred, final Encoding encoding) { return def(name, con(size), pred, encoding); }
-    public static Token def(final String name, final long size, final Expression pred) { return def(name, size, pred, null); }
-    public static Token def(final String name, final long size, final Encoding enc) { return def(name, size, null, enc); }
+    public static Token def(final String name, final long size, final Expression predicate, final Encoding encoding) { return def(name, con(size), predicate, encoding); }
+    public static Token def(final String name, final long size, final Expression predicate) { return def(name, size, predicate, null); }
+    public static Token def(final String name, final long size, final Encoding encoding) { return def(name, size, null, encoding); }
     public static Token def(final String name, final long size) { return def(name, size, null, null); }
-    public static Token cho(final Encoding e, final Token... tokens) { return new Cho(e, tokens); }
+    public static Token cho(final Encoding encoding, final Token... tokens) { return new Cho(encoding, tokens); }
     public static Token cho(final Token... tokens) { return cho(null, tokens); }
-    public static Token rep(final Token t, final Encoding e) { return new Rep(t, e); }
-    public static Token rep(final Token t) { return new Rep(t, null); }
-    public static Token repn(final Token t, final ValueExpression n, final Encoding e) { return new RepN(t, n, e); }
-    public static Token repn(final Token t, final ValueExpression n) { return new RepN(t, n, null); }
-    public static Token seq(final Encoding e, final Token... tokens) { return new Seq(e, tokens); }
+    public static Token rep(final Token token, final Encoding encoding) { return new Rep(token, encoding); }
+    public static Token rep(final Token token) { return new Rep(token, null); }
+    public static Token repn(final Token token, final ValueExpression n, final Encoding encoding) { return new RepN(token, n, encoding); }
+    public static Token repn(final Token token, final ValueExpression n) { return new RepN(token, n, null); }
+    public static Token seq(final Encoding encoding, final Token... tokens) { return new Seq(encoding, tokens); }
     public static Token seq(final Token... tokens) { return seq(null, tokens); }
-    public static Token str(final String n, final Token t, final Encoding e) { return str(n, t, e, null, null); }
-    public static Token str(final String n, final Token t) { return str(n, t, null, null, null); }
-    public static Token str(final String n, final Token t, final Encoding e, final StructSink s) { return new Str(n, t, e, s, null); }
-    public static Token str(final String n, final Token t, final StructSink s) { return str(n, t, null, s, null); }
-    public static Token str(final String n, final Token t, final Encoding e, final StructSink s, final Expression p) { return new Str(n, t, e, s, p); }
-    public static Token str(final String n, final Token t, final StructSink s, final Expression p) { return str(n, t, null, s, p); }
-    public static Token sub(final Token t, final ValueExpression a, final Encoding e) { return new io.parsingdata.metal.token.Sub(t, a, e); }
-    public static Token sub(final Token t, final ValueExpression a) { return sub(t, a, null); }
-    public static Token pre(final Token t, final Expression p, final Encoding e) { return new Pre(t, p, e); }
-    public static Token pre(final Token t, final Expression p) { return pre(t, p, null); }
-    public static Token whl(final Token t, final Expression p, final Encoding e) { return new While(t, p, e); }
-    public static Token whl(final Token t, final Expression p) { return whl(t, p, null); }
-    public static Token opt(final Token t, final Encoding e) { return new Opt(t, e); }
-    public static Token opt(final Token t) { return opt(t, null); }
-    public static Token nod(final ValueExpression s, final Encoding e) { return new Nod(s, e); }
-    public static Token nod(final ValueExpression s) { return new Nod(s, null); }
+    public static Token str(final String scope, final Token token, final Encoding encoding) { return str(scope, token, encoding, null, null); }
+    public static Token str(final String scope, final Token token) { return str(scope, token, null, null, null); }
+    public static Token str(final String scope, final Token token, final Encoding encoding, final StructSink sink) { return new Str(scope, token, encoding, sink, null); }
+    public static Token str(final String scope, final Token token, final StructSink sink) { return str(scope, token, null, sink, null); }
+    public static Token str(final String scope, final Token token, final Encoding encoding, final StructSink sink, final Expression predicate) { return new Str(scope, token, encoding, sink, predicate); }
+    public static Token str(final String scope, final Token token, final StructSink sink, final Expression predicate) { return str(scope, token, null, sink, predicate); }
+    public static Token sub(final Token token, final ValueExpression address, final Encoding encoding) { return new io.parsingdata.metal.token.Sub(token, address, encoding); }
+    public static Token sub(final Token token, final ValueExpression address) { return sub(token, address, null); }
+    public static Token pre(final Token token, final Expression predicate, final Encoding encoding) { return new Pre(token, predicate, encoding); }
+    public static Token pre(final Token token, final Expression predicate) { return pre(token, predicate, null); }
+    public static Token whl(final Token token, final Expression predicate, final Encoding encoding) { return new While(token, predicate, encoding); }
+    public static Token whl(final Token token, final Expression predicate) { return whl(token, predicate, null); }
+    public static Token opt(final Token token, final Encoding encoding) { return new Opt(token, encoding); }
+    public static Token opt(final Token token) { return opt(token, null); }
+    public static Token nod(final ValueExpression size, final Encoding encoding) { return new Nod(size, encoding); }
+    public static Token nod(final ValueExpression size) { return new Nod(size, null); }
 
-    public static BinaryValueExpression add(final ValueExpression l, final ValueExpression r) { return new Add(l, r); }
-    public static BinaryValueExpression div(final ValueExpression l, final ValueExpression r) { return new Div(l, r); }
-    public static BinaryValueExpression mul(final ValueExpression l, final ValueExpression r) { return new Mul(l, r); }
-    public static BinaryValueExpression sub(final ValueExpression l, final ValueExpression r) { return new Sub(l, r); }
-    public static BinaryValueExpression mod(final ValueExpression l, final ValueExpression r) { return new Mod(l, r); }
-    public static UnaryValueExpression neg(final ValueExpression v) { return new Neg(v); }
-    public static BinaryValueExpression and(final ValueExpression l, final ValueExpression r) { return new io.parsingdata.metal.expression.value.bitwise.And(l, r); }
-    public static BinaryValueExpression or(final ValueExpression l, final ValueExpression r) { return new io.parsingdata.metal.expression.value.bitwise.Or(l, r); }
-    public static UnaryValueExpression not(final ValueExpression v) { return new io.parsingdata.metal.expression.value.bitwise.Not(v); }
-    public static BinaryValueExpression shl(final ValueExpression l, final ValueExpression r) { return new ShiftLeft(l, r); }
-    public static BinaryValueExpression shr(final ValueExpression l, final ValueExpression r) { return new ShiftRight(l, r); }
-    public static ValueExpression con(final long v) { return con(v, new Encoding()); }
-    public static ValueExpression con(final long v, final Encoding encoding) { return con(ConstantFactory.createFromNumeric(v, encoding)); }
-    public static ValueExpression con(final String s) { return con(s, new Encoding()); }
-    public static ValueExpression con(final String s, final Encoding encoding) { return con(ConstantFactory.createFromString(s, encoding)); }
-    public static ValueExpression con(final Value v) { return new Const(v); }
-    public static ValueExpression con(final Encoding enc, final int... values) { return new Const(new Value(toByteArray(values), enc)); }
+    public static BinaryValueExpression add(final ValueExpression left, final ValueExpression right) { return new Add(left, right); }
+    public static BinaryValueExpression div(final ValueExpression left, final ValueExpression right) { return new Div(left, right); }
+    public static BinaryValueExpression mul(final ValueExpression left, final ValueExpression right) { return new Mul(left, right); }
+    public static BinaryValueExpression sub(final ValueExpression left, final ValueExpression right) { return new Sub(left, right); }
+    public static BinaryValueExpression mod(final ValueExpression left, final ValueExpression right) { return new Mod(left, right); }
+    public static UnaryValueExpression neg(final ValueExpression operand) { return new Neg(operand); }
+    public static BinaryValueExpression and(final ValueExpression left, final ValueExpression right) { return new io.parsingdata.metal.expression.value.bitwise.And(left, right); }
+    public static BinaryValueExpression or(final ValueExpression left, final ValueExpression right) { return new io.parsingdata.metal.expression.value.bitwise.Or(left, right); }
+    public static UnaryValueExpression not(final ValueExpression operand) { return new io.parsingdata.metal.expression.value.bitwise.Not(operand); }
+    public static BinaryValueExpression shl(final ValueExpression left, final ValueExpression right) { return new ShiftLeft(left, right); }
+    public static BinaryValueExpression shr(final ValueExpression left, final ValueExpression right) { return new ShiftRight(left, right); }
+    public static ValueExpression con(final long value) { return con(value, new Encoding()); }
+    public static ValueExpression con(final long value, final Encoding encoding) { return con(ConstantFactory.createFromNumeric(value, encoding)); }
+    public static ValueExpression con(final String value) { return con(value, new Encoding()); }
+    public static ValueExpression con(final String value, final Encoding encoding) { return con(ConstantFactory.createFromString(value, encoding)); }
+    public static ValueExpression con(final Value value) { return new Const(value); }
+    public static ValueExpression con(final Encoding encoding, final int... values) { return new Const(new Value(toByteArray(values), encoding)); }
     public static ValueExpression con(final int... values) { return con(new Encoding(), values); }
     public static final ValueExpression self = new Self();
-    public static ValueExpression len(final ValueExpression v) { return new Len(v); }
-    public static ValueExpression ref(final String s) { return new NameRef(s); }
-    public static ValueExpression ref(final Token d) { return new TokenRef(d); }
-    public static ValueExpression first(final ValueExpression o) { return new First(o); }
-    public static ValueExpression last(final ValueExpression o) { return new Last(o); }
-    public static ValueExpression offset(final ValueExpression o) { return new Offset(o); }
+    public static ValueExpression len(final ValueExpression operand) { return new Len(operand); }
+    public static ValueExpression ref(final String name) { return new NameRef(name); }
+    public static ValueExpression ref(final Token definition) { return new TokenRef(definition); }
+    public static ValueExpression first(final ValueExpression operand) { return new First(operand); }
+    public static ValueExpression last(final ValueExpression operand) { return new Last(operand); }
+    public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
     public static final ValueExpression currentOffset = new CurrentOffset();
-    public static ValueExpression cat(final ValueExpression l, final ValueExpression r) { return new Cat(l, r); }
-    public static ValueExpression elvis(final ValueExpression l, final ValueExpression r) { return new Elvis(l, r); }
-    public static ValueExpression count(final ValueExpression o) { return new Count(o); }
+    public static ValueExpression cat(final ValueExpression left, final ValueExpression right) { return new Cat(left, right); }
+    public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
+    public static ValueExpression count(final ValueExpression operand) { return new Count(operand); }
     public static ValueExpression foldLeft(final ValueExpression values, final Reducer reducer) { return new FoldLeft(values, reducer, null); }
-    public static ValueExpression foldLeft(final ValueExpression values, final Reducer reducer, final ValueExpression i) { return new FoldLeft(values, reducer, i); }
+    public static ValueExpression foldLeft(final ValueExpression values, final Reducer reducer, final ValueExpression initial) { return new FoldLeft(values, reducer, initial); }
     public static ValueExpression foldRight(final ValueExpression values, final Reducer reducer) { return new FoldRight(values, reducer, null); }
-    public static ValueExpression foldRight(final ValueExpression values, final Reducer reducer, final ValueExpression i) { return new FoldRight(values, reducer, i); }
+    public static ValueExpression foldRight(final ValueExpression values, final Reducer reducer, final ValueExpression initial) { return new FoldRight(values, reducer, initial); }
     public static ValueExpression fold(final ValueExpression values, final Reducer reducer) { return foldRight(values, reducer); }
-    public static ValueExpression fold(final ValueExpression values, final Reducer reducer, final ValueExpression i) { return foldRight(values, reducer, i); }
+    public static ValueExpression fold(final ValueExpression values, final Reducer reducer, final ValueExpression initial) { return foldRight(values, reducer, initial); }
 
-    public static BinaryLogicalExpression and(final Expression l, final Expression r) { return new And(l, r); }
-    public static BinaryLogicalExpression or(final Expression l, final Expression r) { return new Or(l, r); }
-    public static UnaryLogicalExpression not(final Expression e) { return new Not(e); }
+    public static BinaryLogicalExpression and(final Expression left, final Expression right) { return new And(left, right); }
+    public static BinaryLogicalExpression or(final Expression left, final Expression right) { return new Or(left, right); }
+    public static UnaryLogicalExpression not(final Expression operand) { return new Not(operand); }
     public static Expression expTrue() { return new True(); }
 
-    public static ComparisonExpression eq(final ValueExpression p) { return new Eq(null, p); }
-    public static ComparisonExpression eq(final ValueExpression c, final ValueExpression p) { return new Eq(c, p); }
-    public static ComparisonExpression eqStr(final ValueExpression p) { return new EqStr(null, p); }
-    public static ComparisonExpression eqStr(final ValueExpression c, final ValueExpression p) { return new EqStr(c, p); }
-    public static ComparisonExpression eqNum(final ValueExpression p) { return new EqNum(null, p); }
-    public static ComparisonExpression eqNum(final ValueExpression c, final ValueExpression p) { return new EqNum(c, p); }
-    public static ComparisonExpression gtNum(final ValueExpression p) { return new GtNum(null, p); }
-    public static ComparisonExpression gtNum(final ValueExpression c, final ValueExpression p) { return new GtNum(c, p); }
-    public static ComparisonExpression ltNum(final ValueExpression p) { return new LtNum(null, p); }
-    public static ComparisonExpression ltNum(final ValueExpression c, final ValueExpression p) { return new LtNum(c, p); }
+    public static ComparisonExpression eq(final ValueExpression predicate) { return new Eq(null, predicate); }
+    public static ComparisonExpression eq(final ValueExpression value, final ValueExpression predicate) { return new Eq(value, predicate); }
+    public static ComparisonExpression eqStr(final ValueExpression predicate) { return new EqStr(null, predicate); }
+    public static ComparisonExpression eqStr(final ValueExpression value, final ValueExpression predicate) { return new EqStr(value, predicate); }
+    public static ComparisonExpression eqNum(final ValueExpression predicate) { return new EqNum(null, predicate); }
+    public static ComparisonExpression eqNum(final ValueExpression value, final ValueExpression predicate) { return new EqNum(value, predicate); }
+    public static ComparisonExpression gtNum(final ValueExpression predicate) { return new GtNum(null, predicate); }
+    public static ComparisonExpression gtNum(final ValueExpression value, final ValueExpression predicate) { return new GtNum(value, predicate); }
+    public static ComparisonExpression ltNum(final ValueExpression predicate) { return new LtNum(null, predicate); }
+    public static ComparisonExpression ltNum(final ValueExpression value, final ValueExpression predicate) { return new LtNum(value, predicate); }
 
     public final static Reducer ADD_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return add(left, right); } };
     public final static Reducer MUL_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return mul(left, right); } };

--- a/core/src/main/java/io/parsingdata/metal/data/OptionalValueList.java
+++ b/core/src/main/java/io/parsingdata/metal/data/OptionalValueList.java
@@ -58,7 +58,7 @@ public class OptionalValueList {
 
     public boolean containsEmpty() {
         if (isEmpty()) { return false; }
-        return !this.head.isPresent() || this.tail.containsEmpty();
+        return !head.isPresent() || tail.containsEmpty();
     }
 
     public OptionalValueList reverse() {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -63,26 +63,26 @@ public class ParseGraph implements ParseItem {
     }
 
     public ParseGraph add(final ParseValue head) {
-        if (branched) { return new ParseGraph(this.head.asGraph().add(head), tail, this.definition, true); }
-        return new ParseGraph(head, this, this.definition);
+        if (branched) { return new ParseGraph(this.head.asGraph().add(head), tail, definition, true); }
+        return new ParseGraph(head, this, definition);
     }
 
     public ParseGraph add(final ParseRef ref) {
-        if (branched) { return new ParseGraph(this.head.asGraph().add(ref), tail, this.definition, true); }
-        return new ParseGraph(ref, this, this.definition);
+        if (branched) { return new ParseGraph(head.asGraph().add(ref), tail, definition, true); }
+        return new ParseGraph(ref, this, definition);
     }
 
     public ParseGraph addBranch(final Token definition) {
-        if (branched) { return new ParseGraph(this.head.asGraph().addBranch(definition), tail, this.definition, true); }
+        if (branched) { return new ParseGraph(head.asGraph().addBranch(definition), tail, this.definition, true); }
         return new ParseGraph(new ParseGraph(definition), this, this.definition, true);
     }
 
     public ParseGraph closeBranch() {
         if (!branched) { throw new IllegalStateException("Cannot close branch that is not open."); }
         if (head.asGraph().branched) {
-            return new ParseGraph(head.asGraph().closeBranch(), tail, this.definition, true);
+            return new ParseGraph(head.asGraph().closeBranch(), tail, definition, true);
         }
-        return new ParseGraph(head, tail, this.definition, false);
+        return new ParseGraph(head, tail, definition, false);
     }
 
     public ParseGraphList getRefs() {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseResult.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseResult.java
@@ -18,25 +18,17 @@ package io.parsingdata.metal.data;
 
 public class ParseResult {
 
-    private final boolean _succeeded;
-    private final Environment _environment;
+    public final boolean succeeded;
+    public final Environment environment;
 
     public ParseResult(final boolean succeeded, final Environment environment) {
-        _succeeded = succeeded;
-        _environment = environment;
-    }
-
-    public boolean succeeded() {
-        return _succeeded;
-    }
-
-    public Environment getEnvironment() {
-        return _environment;
+        this.succeeded = succeeded;
+        this.environment = environment;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _succeeded + ", " + _environment + ")";
+        return getClass().getSimpleName() + "(" + succeeded + ", " + environment + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -38,11 +38,11 @@ public abstract class ComparisonExpression implements Expression {
 
     @Override
     public boolean eval(final Environment env, final Encoding enc) {
-        final OptionalValueList ocl = value == null ? OptionalValueList.create(OptionalValue.of(env.order.current())) : value.eval(env, enc);
-        if (ocl.isEmpty()) { return false; }
+        final OptionalValueList ovl = value == null ? OptionalValueList.create(OptionalValue.of(env.order.current())) : value.eval(env, enc);
+        if (ovl.isEmpty()) { return false; }
         final OptionalValueList opl = predicate.eval(env, enc);
-        if (ocl.size != opl.size) { return false; }
-        return compare(ocl, opl);
+        if (ovl.size != opl.size) { return false; }
+        return compare(ovl, opl);
     }
 
     private boolean compare(final OptionalValueList currents, final OptionalValueList predicates) {

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -16,8 +16,6 @@
 
 package io.parsingdata.metal.expression.comparison;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
@@ -26,21 +24,23 @@ import io.parsingdata.metal.expression.value.OptionalValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public abstract class ComparisonExpression implements Expression {
 
-    private final ValueExpression _current;
-    private final ValueExpression _predicate;
+    public final ValueExpression value;
+    public final ValueExpression predicate;
 
-    public ComparisonExpression(final ValueExpression current, final ValueExpression predicate) {
-        _current = current;
-        _predicate = checkNotNull(predicate, "predicate");
+    public ComparisonExpression(final ValueExpression value, final ValueExpression predicate) {
+        this.value = value;
+        this.predicate = checkNotNull(predicate, "predicate");
     }
 
     @Override
     public boolean eval(final Environment env, final Encoding enc) {
-        final OptionalValueList ocl = _current == null ? OptionalValueList.create(OptionalValue.of(env.order.current())) : _current.eval(env, enc);
+        final OptionalValueList ocl = value == null ? OptionalValueList.create(OptionalValue.of(env.order.current())) : value.eval(env, enc);
         if (ocl.isEmpty()) { return false; }
-        final OptionalValueList opl = _predicate.eval(env, enc);
+        final OptionalValueList opl = predicate.eval(env, enc);
         if (ocl.size != opl.size) { return false; }
         return compare(ocl, opl);
     }
@@ -52,11 +52,11 @@ public abstract class ComparisonExpression implements Expression {
         return compare(currents.tail, predicates.tail);
     }
 
-    public abstract boolean compare(final Value current, final Value predicate);
+    public abstract boolean compare(final Value left, final Value right);
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + (_current == null ? "" : _current + ",") + _predicate + ")";
+        return getClass().getSimpleName() + "(" + (value == null ? "" : value + ",") + predicate + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
@@ -21,14 +21,14 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Eq extends ComparisonExpression {
 
-    public Eq(final ValueExpression current, final ValueExpression predicate) {
-        super(current, predicate);
+    public Eq(final ValueExpression value, final ValueExpression predicate) {
+        super(value, predicate);
     }
 
     @Override
-    public boolean compare(final Value current, final Value predicate) {
-        final byte[] l = current.getValue();
-        final byte[] r = predicate.getValue();
+    public boolean compare(final Value left, final Value right) {
+        final byte[] l = left.getValue();
+        final byte[] r = right.getValue();
         if (l.length != r.length) { return false; }
         for (int i = 0; i < l.length; i++) {
             if (l[i] != r[i]) { return false; }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/EqNum.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/EqNum.java
@@ -21,13 +21,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class EqNum extends ComparisonExpression {
 
-    public EqNum(final ValueExpression current, final ValueExpression predicate) {
-        super(current, predicate);
+    public EqNum(final ValueExpression value, final ValueExpression predicate) {
+        super(value, predicate);
     }
 
     @Override
-    public boolean compare(final Value current, final Value predicate) {
-        return current.asNumeric().compareTo(predicate.asNumeric()) == 0;
+    public boolean compare(final Value left, final Value right) {
+        return left.asNumeric().compareTo(right.asNumeric()) == 0;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/EqStr.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/EqStr.java
@@ -21,13 +21,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class EqStr extends ComparisonExpression {
 
-    public EqStr(final ValueExpression current, final ValueExpression predicate) {
-        super(current, predicate);
+    public EqStr(final ValueExpression value, final ValueExpression predicate) {
+        super(value, predicate);
     }
 
     @Override
-    public boolean compare(final Value current, final Value predicate) {
-        return current.asString().equals(predicate.asString());
+    public boolean compare(final Value left, final Value right) {
+        return left.asString().equals(right.asString());
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/GtNum.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/GtNum.java
@@ -21,13 +21,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class GtNum extends ComparisonExpression {
 
-    public GtNum(final ValueExpression current, final ValueExpression predicate) {
-        super(current, predicate);
+    public GtNum(final ValueExpression value, final ValueExpression predicate) {
+        super(value, predicate);
     }
 
     @Override
-    public boolean compare(final Value current, final Value predicate) {
-        return current.asNumeric().compareTo(predicate.asNumeric()) > 0;
+    public boolean compare(final Value left, final Value right) {
+        return left.asNumeric().compareTo(right.asNumeric()) > 0;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/LtNum.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/LtNum.java
@@ -21,13 +21,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class LtNum extends ComparisonExpression {
 
-    public LtNum(final ValueExpression current, final ValueExpression predicate) {
-        super(current, predicate);
+    public LtNum(final ValueExpression value, final ValueExpression predicate) {
+        super(value, predicate);
     }
 
     @Override
-    public boolean compare(final Value current, final Value predicate) {
-        return current.asNumeric().compareTo(predicate.asNumeric()) < 0;
+    public boolean compare(final Value left, final Value right) {
+        return left.asNumeric().compareTo(right.asNumeric()) < 0;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/And.java
@@ -22,13 +22,13 @@ import io.parsingdata.metal.expression.Expression;
 
 public class And extends BinaryLogicalExpression {
 
-    public And(final Expression lop, final Expression rop) {
-        super(lop, rop);
+    public And(final Expression left, final Expression right) {
+        super(left, right);
     }
 
     @Override
     public boolean eval(final Environment env, final Encoding enc) {
-        return _lop.eval(env, enc) && _rop.eval(env, enc);
+        return left.eval(env, enc) && right.eval(env, enc);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/BinaryLogicalExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/BinaryLogicalExpression.java
@@ -16,23 +16,23 @@
 
 package io.parsingdata.metal.expression.logical;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
 import io.parsingdata.metal.expression.Expression;
+
+import static io.parsingdata.metal.Util.checkNotNull;
 
 public abstract class BinaryLogicalExpression implements LogicalExpression {
 
-    protected final Expression _lop;
-    protected final Expression _rop;
+    public final Expression left;
+    public final Expression right;
 
-    public BinaryLogicalExpression(final Expression lop, final Expression rop) {
-        _lop = checkNotNull(lop, "lop");
-        _rop = checkNotNull(rop, "rop");
+    public BinaryLogicalExpression(final Expression left, final Expression right) {
+        this.left = checkNotNull(left, "left");
+        this.right = checkNotNull(right, "right");
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _lop + "," + _rop + ")";
+        return getClass().getSimpleName() + "(" + left + "," + right + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/Not.java
@@ -22,13 +22,13 @@ import io.parsingdata.metal.expression.Expression;
 
 public class Not extends UnaryLogicalExpression {
 
-    public Not(final Expression op) {
-        super(op);
+    public Not(final Expression operand) {
+        super(operand);
     }
 
     @Override
     public boolean eval(final Environment env, final Encoding enc) {
-        return !_op.eval(env, enc);
+        return !operand.eval(env, enc);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/Or.java
@@ -22,13 +22,13 @@ import io.parsingdata.metal.expression.Expression;
 
 public class Or extends BinaryLogicalExpression {
 
-    public Or(final Expression lop, final Expression rop) {
-        super(lop, rop);
+    public Or(final Expression left, final Expression right) {
+        super(left, right);
     }
 
     @Override
     public boolean eval(final Environment env, final Encoding enc) {
-        return _lop.eval(env, enc) || _rop.eval(env, enc);
+        return left.eval(env, enc) || right.eval(env, enc);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/UnaryLogicalExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/UnaryLogicalExpression.java
@@ -16,21 +16,21 @@
 
 package io.parsingdata.metal.expression.logical;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
 import io.parsingdata.metal.expression.Expression;
+
+import static io.parsingdata.metal.Util.checkNotNull;
 
 public abstract class UnaryLogicalExpression implements LogicalExpression {
 
-    protected final Expression _op;
+    public final Expression operand;
 
-    public UnaryLogicalExpression(final Expression op) {
-        _op = checkNotNull(op, "op");
+    public UnaryLogicalExpression(final Expression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -34,17 +34,17 @@ import static io.parsingdata.metal.Util.checkNotNull;
  */
 public abstract class BinaryValueExpression implements ValueExpression {
 
-    private final ValueExpression lop;
-    private final ValueExpression rop;
+    public final ValueExpression left;
+    public final ValueExpression right;
 
-    public BinaryValueExpression(final ValueExpression lop, final ValueExpression rop) {
-        this.lop = checkNotNull(lop, "lop");
-        this.rop = checkNotNull(rop, "rop");
+    public BinaryValueExpression(final ValueExpression left, final ValueExpression right) {
+        this.left = checkNotNull(left, "left");
+        this.right = checkNotNull(right, "right");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return evalLists(lop.eval(env, enc), rop.eval(env, enc), env, enc);
+        return evalLists(left.eval(env, enc), right.eval(env, enc), env, enc);
     }
 
     private OptionalValueList evalLists(final OptionalValueList lvl, final OptionalValueList rvl, final Environment env, final Encoding enc) {
@@ -63,11 +63,11 @@ public abstract class BinaryValueExpression implements ValueExpression {
         return eval(left.get(), right.get(), env, enc);
     }
 
-    public abstract OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc);
+    public abstract OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc);
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + lop + "," + rop + ")";
+        return getClass().getSimpleName() + "(" + left + "," + right + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -21,14 +21,14 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public class Cat extends BinaryValueExpression {
 
-    public Cat(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public Cat(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        final byte[] lb = lv.getValue();
-        final byte[] rb = rv.getValue();
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        final byte[] lb = left.getValue();
+        final byte[] rb = right.getValue();
         final byte[] res = new byte[lb.length + rb.length];
         System.arraycopy(lb, 0, res, 0, lb.length);
         System.arraycopy(rb, 0, res, lb.length, rb.length);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -22,20 +22,20 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public class Const implements ValueExpression {
 
-    private final Value _val;
+    public final Value value;
 
-    public Const(final Value val) {
-        _val = val;
+    public Const(final Value value) {
+        this.value = value;
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return OptionalValueList.create(OptionalValue.of(_val));
+        return OptionalValueList.create(OptionalValue.of(value));
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _val.toString() + ")";
+        return getClass().getSimpleName() + "(" + value.toString() + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
@@ -16,11 +16,11 @@
 
 package io.parsingdata.metal.expression.value;
 
-import java.math.BigInteger;
-import java.util.BitSet;
-
 import io.parsingdata.metal.encoding.ByteOrder;
 import io.parsingdata.metal.encoding.Encoding;
+
+import java.math.BigInteger;
+import java.util.BitSet;
 
 public class ConstantFactory {
 
@@ -47,14 +47,14 @@ public class ConstantFactory {
         return new Encoding(enc.getSign(), enc.getCharset(), ByteOrder.BIG_ENDIAN);
     }
 
-    private static byte[] compact(final byte[] in, boolean signed) {
-        if (signed) { return in; }
-        if (in.length < 2) { return in; }
+    private static byte[] compact(final byte[] data, boolean signed) {
+        if (signed) { return data; }
+        if (data.length < 2) { return data; }
         // strip leading zero bytes
         int i = 0;
-        for (; i < in.length && in[i] == 0; i++);
-        final byte[] out = new byte[in.length - i];
-        System.arraycopy(in, i, out, 0, out.length);
+        for (; i < data.length && data[i] == 0; i++);
+        final byte[] out = new byte[data.length - i];
+        System.arraycopy(data, i, out, 0, out.length);
         return out;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -39,17 +39,17 @@ import static io.parsingdata.metal.Util.checkNotNull;
  * the values in the other list are returned at those locations).
  */
 public class Elvis implements ValueExpression {
-    private final ValueExpression lop;
-    private final ValueExpression rop;
+    public final ValueExpression left;
+    public final ValueExpression right;
 
-    public Elvis(final ValueExpression lop, final ValueExpression rop) {
-        this.lop = checkNotNull(lop, "lop");
-        this.rop = checkNotNull(rop, "rop");
+    public Elvis(final ValueExpression left, final ValueExpression right) {
+        this.left = checkNotNull(left, "left");
+        this.right = checkNotNull(right, "right");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return eval(lop.eval(env, enc), rop.eval(env, enc));
+        return eval(left.eval(env, enc), right.eval(env, enc));
     }
 
     private OptionalValueList eval(final OptionalValueList llist, final OptionalValueList rlist) {
@@ -60,6 +60,6 @@ public class Elvis implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + lop + "," + rop + ")";
+        return getClass().getSimpleName() + "(" + left + "," + right + ")";
     }
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
@@ -16,39 +16,39 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static io.parsingdata.metal.Shorthand.con;
-import static io.parsingdata.metal.Util.checkNotNull;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
 
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class FoldLeft implements ValueExpression {
 
-    private final ValueExpression _values;
-    private final Reducer _reducer;
-    private final ValueExpression _init;
+    public final ValueExpression values;
+    public final Reducer reducer;
+    public final ValueExpression initial;
 
-    public FoldLeft(final ValueExpression values, final Reducer reducer, final ValueExpression init) {
-        _values = checkNotNull(values, "values");
-        _reducer = checkNotNull(reducer, "reducer");
-        _init = init;
+    public FoldLeft(final ValueExpression values, final Reducer reducer, final ValueExpression initial) {
+        this.values = checkNotNull(values, "values");
+        this.reducer = checkNotNull(reducer, "reducer");
+        this.initial = initial;
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList init = _init != null ? _init.eval(env, enc) : OptionalValueList.EMPTY;
+        final OptionalValueList init = initial != null ? initial.eval(env, enc) : OptionalValueList.EMPTY;
         if (init.size > 1) {
             return OptionalValueList.EMPTY;
         }
-        final OptionalValueList values = _values.eval(env, enc).reverse();
+        final OptionalValueList values = this.values.eval(env, enc).reverse();
         if (values.isEmpty() || values.containsEmpty()) {
             return init;
         }
         if (!init.isEmpty()) {
-            return OptionalValueList.create(fold(env, enc, _reducer, init.head, values));
+            return OptionalValueList.create(fold(env, enc, reducer, init.head, values));
         }
-        return OptionalValueList.create(fold(env, enc, _reducer, values.head, values.tail));
+        return OptionalValueList.create(fold(env, enc, reducer, values.head, values.tail));
     }
 
     private OptionalValue fold(final Environment env, final Encoding enc, final Reducer reducer, final OptionalValue head, final OptionalValueList tail) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
@@ -16,39 +16,39 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static io.parsingdata.metal.Shorthand.con;
-import static io.parsingdata.metal.Util.checkNotNull;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
 
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class FoldRight implements ValueExpression {
 
-    private final ValueExpression _values;
-    private final Reducer _reducer;
-    private final ValueExpression _init;
+    public final ValueExpression values;
+    public final Reducer reducer;
+    public final ValueExpression initial;
 
-    public FoldRight(final ValueExpression values, final Reducer reducer, final ValueExpression init) {
-        _values = checkNotNull(values, "values");
-        _reducer = checkNotNull(reducer, "reducer");
-        _init = init;
+    public FoldRight(final ValueExpression values, final Reducer reducer, final ValueExpression initial) {
+        this.values = checkNotNull(values, "values");
+        this.reducer = checkNotNull(reducer, "reducer");
+        this.initial = initial;
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList init = _init != null ? _init.eval(env, enc) : OptionalValueList.EMPTY;
+        final OptionalValueList init = initial != null ? initial.eval(env, enc) : OptionalValueList.EMPTY;
         if (init.size > 1) {
             return OptionalValueList.EMPTY;
         }
-        final OptionalValueList values = _values.eval(env, enc);
+        final OptionalValueList values = this.values.eval(env, enc);
         if (values.isEmpty() || values.containsEmpty()) {
             return init;
         }
         if (!init.isEmpty()) {
-            return OptionalValueList.create(fold(env, enc, _reducer, init.head, values));
+            return OptionalValueList.create(fold(env, enc, reducer, init.head, values));
         }
-        return OptionalValueList.create(fold(env, enc, _reducer, values.head, values.tail));
+        return OptionalValueList.create(fold(env, enc, reducer, values.head, values.tail));
     }
 
     private OptionalValue fold(final Environment env, final Encoding enc, final Reducer reducer, final OptionalValue head, final OptionalValueList tail) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/OptionalValue.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/OptionalValue.java
@@ -20,10 +20,10 @@ import java.util.NoSuchElementException;
 
 public class OptionalValue {
 
-    private final Value _value;
+    private final Value value;
 
     private OptionalValue(final Value value) {
-        _value = value;
+        this.value = value;
     }
 
     private OptionalValue() {
@@ -39,12 +39,12 @@ public class OptionalValue {
     }
 
     public boolean isPresent() {
-        return _value != null;
+        return value != null;
     }
 
     public Value get() {
         if (isPresent()) {
-            return _value;
+            return value;
         } else {
             throw new NoSuchElementException("OptionalValue instance is empty.");
         }
@@ -52,7 +52,7 @@ public class OptionalValue {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + (!isPresent() ? "empty" : _value) + ")";
+        return getClass().getSimpleName() + "(" + (!isPresent() ? "empty" : value) + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reducer.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reducer.java
@@ -18,6 +18,6 @@ package io.parsingdata.metal.expression.value;
 
 public interface Reducer {
 
-    ValueExpression reduce(final ValueExpression l, final ValueExpression r);
+    ValueExpression reduce(final ValueExpression left, final ValueExpression right);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -24,15 +24,15 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 public abstract class UnaryValueExpression implements ValueExpression {
 
-    private final ValueExpression op;
+    public final ValueExpression operand;
 
-    public UnaryValueExpression(final ValueExpression op) {
-        this.op = checkNotNull(op, "op");
+    public UnaryValueExpression(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return eval(op.eval(env, enc), env, enc);
+        return eval(operand.eval(env, enc), env, enc);
     }
 
     private OptionalValueList eval(final OptionalValueList vl, final Environment env, final Encoding enc) {
@@ -40,11 +40,11 @@ public abstract class UnaryValueExpression implements ValueExpression {
         return eval(vl.tail, env, enc).add(vl.head.isPresent() ? eval(vl.head.get(), env, enc) : vl.head);
     }
 
-    public abstract OptionalValue eval(final Value v, final Environment env, final Encoding enc);
+    public abstract OptionalValue eval(final Value value, final Environment env, final Encoding enc);
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + op + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
@@ -16,44 +16,40 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.math.BigInteger;
-import java.util.BitSet;
-
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.encoding.ByteOrder;
 import io.parsingdata.metal.encoding.Encoding;
 
+import java.math.BigInteger;
+import java.util.BitSet;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class Value {
 
-    private final byte[] _data;
-    private final Encoding _enc;
+    private final byte[] data; // Private because array content is mutable.
+    public final Encoding enc;
 
     public Value(final byte[] data, final Encoding enc) {
-        _data = data.clone();
-        _enc = checkNotNull(enc, "enc");
+        this.data = data.clone();
+        this.enc = checkNotNull(enc, "enc");
     }
 
     public byte[] getValue() {
-        return _data.clone();
+        return data.clone();
     }
 
     public BigInteger asNumeric() {
-        return _enc.isSigned() ? new BigInteger(_enc.getByteOrder().apply(_data))
-                               : new BigInteger(1, _enc.getByteOrder().apply(_data));
+        return enc.isSigned() ? new BigInteger(enc.getByteOrder().apply(data))
+                              : new BigInteger(1, enc.getByteOrder().apply(data));
     }
 
     public String asString() {
-        return new String(_data, _enc.getCharset());
+        return new String(data, enc.getCharset());
     }
 
     public BitSet asBitSet() {
-        return BitSet.valueOf(_enc.getByteOrder() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN.apply(_data) : _data);
-    }
-
-    public Encoding getEncoding() {
-        return _enc;
+        return BitSet.valueOf(enc.getByteOrder() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN.apply(data) : data);
     }
 
     public OptionalValue operation(final ValueOperation op) {
@@ -62,7 +58,7 @@ public class Value {
 
     @Override
     public String toString() {
-        return "0x" + Util.bytesToHexString(_data);
+        return "0x" + Util.bytesToHexString(data);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ValueOperation.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ValueOperation.java
@@ -18,6 +18,6 @@ package io.parsingdata.metal.expression.value;
 
 public interface ValueOperation {
 
-    public OptionalValue execute(final Value value);
+    OptionalValue execute(final Value value);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
@@ -26,13 +26,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Add extends BinaryValueExpression {
 
-    public Add(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public Add(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(lv.asNumeric().add(rv.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().add(right.asNumeric()), enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
@@ -16,26 +16,22 @@
 
 package io.parsingdata.metal.expression.value.arithmetic;
 
-import java.math.BigInteger;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.BinaryValueExpression;
-import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.OptionalValue;
-import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.*;
+
+import java.math.BigInteger;
 
 public class Div extends BinaryValueExpression {
 
-    public Div(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public Div(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        if (rv.asNumeric().equals(BigInteger.ZERO)) { return OptionalValue.empty(); }
-        return OptionalValue.of(ConstantFactory.createFromNumeric(lv.asNumeric().divide(rv.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        if (right.asNumeric().equals(BigInteger.ZERO)) { return OptionalValue.empty(); }
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().divide(right.asNumeric()), enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
@@ -16,26 +16,22 @@
 
 package io.parsingdata.metal.expression.value.arithmetic;
 
-import java.math.BigInteger;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.BinaryValueExpression;
-import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.OptionalValue;
-import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.*;
+
+import java.math.BigInteger;
 
 public class Mod extends BinaryValueExpression {
 
-    public Mod(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public Mod(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        if (rv.asNumeric().compareTo(BigInteger.ZERO) < 0) { return OptionalValue.empty(); }
-        return OptionalValue.of(ConstantFactory.createFromNumeric(lv.asNumeric().mod(rv.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        if (right.asNumeric().compareTo(BigInteger.ZERO) < 0) { return OptionalValue.empty(); }
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().mod(right.asNumeric()), enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
@@ -26,13 +26,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Mul extends BinaryValueExpression {
 
-    public Mul(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public Mul(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(lv.asNumeric().multiply(rv.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().multiply(right.asNumeric()), enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
@@ -26,13 +26,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Neg extends UnaryValueExpression {
 
-    public Neg(final ValueExpression op) {
-        super(op);
+    public Neg(final ValueExpression operand) {
+        super(operand);
     }
 
     @Override
-    public OptionalValue eval(final Value v, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(v.asNumeric().negate(), enc));
+    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(value.asNumeric().negate(), enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
@@ -26,13 +26,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Sub extends BinaryValueExpression {
 
-    public Sub(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public Sub(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(lv.asNumeric().subtract(rv.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().subtract(right.asNumeric()), enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
@@ -16,27 +16,23 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
-import java.util.BitSet;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.BinaryValueExpression;
-import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.OptionalValue;
-import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.*;
+
+import java.util.BitSet;
 
 public class And extends BinaryValueExpression {
 
-    public And(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public And(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        final BitSet lbs = lv.asBitSet();
-        lbs.and(rv.asBitSet());
-        return OptionalValue.of(ConstantFactory.createFromBitSet(lbs, lv.getValue().length, enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        final BitSet lbs = left.asBitSet();
+        lbs.and(right.asBitSet());
+        return OptionalValue.of(ConstantFactory.createFromBitSet(lbs, left.getValue().length, enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
@@ -24,15 +24,15 @@ import java.util.BitSet;
 
 public class Not extends UnaryValueExpression {
 
-    public Not(final ValueExpression op) {
-        super(op);
+    public Not(final ValueExpression operand) {
+        super(operand);
     }
 
     @Override
-    public OptionalValue eval(final Value op, final Environment env, final Encoding enc) {
-        final BitSet value = op.asBitSet();
-        value.flip(0, op.getValue().length * 8);
-        return OptionalValue.of(ConstantFactory.createFromBitSet(value, op.getValue().length, enc));
+    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
+        final BitSet bits = value.asBitSet();
+        bits.flip(0, value.getValue().length * 8);
+        return OptionalValue.of(ConstantFactory.createFromBitSet(bits, value.getValue().length, enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
@@ -16,27 +16,23 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
-import java.util.BitSet;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.BinaryValueExpression;
-import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.OptionalValue;
-import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.*;
+
+import java.util.BitSet;
 
 public class Or extends BinaryValueExpression {
 
-    public Or(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public Or(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        final BitSet lbs = lv.asBitSet();
-        lbs.or(rv.asBitSet());
-        final int minSize = Math.max(lv.getValue().length, rv.getValue().length);
+    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+        final BitSet lbs = left.asBitSet();
+        lbs.or(right.asBitSet());
+        final int minSize = Math.max(left.getValue().length, right.getValue().length);
         return OptionalValue.of(ConstantFactory.createFromBitSet(lbs, minSize, enc));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
@@ -16,26 +16,22 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
-import java.util.BitSet;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.BinaryValueExpression;
-import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.OptionalValue;
-import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.*;
+
+import java.util.BitSet;
 
 public class ShiftLeft extends BinaryValueExpression {
 
-    public ShiftLeft(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public ShiftLeft(final ValueExpression operand, final ValueExpression positions) {
+        super(operand, positions);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        final BitSet lbs = lv.asBitSet();
-        final int shiftLeft = rv.asNumeric().intValue();
+    public OptionalValue eval(final Value operand, final Value positions, final Environment env, final Encoding enc) {
+        final BitSet lbs = operand.asBitSet();
+        final int shiftLeft = positions.asNumeric().intValue();
         final int bitCount = lbs.length() + shiftLeft;
         final BitSet out = new BitSet(bitCount);
         for (int i = lbs.nextSetBit(0); i >= 0; i = lbs.nextSetBit(i+1)) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
@@ -16,27 +16,23 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
-import java.util.BitSet;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.BinaryValueExpression;
-import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.OptionalValue;
-import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.*;
+
+import java.util.BitSet;
 
 public class ShiftRight extends BinaryValueExpression {
 
-    public ShiftRight(final ValueExpression lop, final ValueExpression rop) {
-        super(lop, rop);
+    public ShiftRight(final ValueExpression operand, final ValueExpression positions) {
+        super(operand, positions);
     }
 
     @Override
-    public OptionalValue eval(final Value lv, final Value rv, final Environment env, final Encoding enc) {
-        final BitSet lbs = lv.asBitSet();
-        final int shift = rv.asNumeric().intValue();
-        return OptionalValue.of(ConstantFactory.createFromBitSet(lbs.get(shift, Math.max(shift, lbs.length())), lv.getValue().length, enc));
+    public OptionalValue eval(final Value operand, final Value positions, final Environment env, final Encoding enc) {
+        final BitSet lbs = operand.asBitSet();
+        final int shift = positions.asNumeric().intValue();
+        return OptionalValue.of(ConstantFactory.createFromBitSet(lbs.get(shift, Math.max(shift, lbs.length())), operand.getValue().length, enc));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -37,7 +37,7 @@ public class Count implements ValueExpression {
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList ovl = this.operand.eval(env, enc);
+        final OptionalValueList ovl = operand.eval(env, enc);
         return OptionalValueList.create(OptionalValue.of(num(ovl.size)));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -29,15 +29,15 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 public class Count implements ValueExpression {
 
-    public final ValueExpression op;
+    public final ValueExpression operand;
 
-    public Count(final ValueExpression op) {
-        this.op = checkNotNull(op, "op");
+    public Count(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList ovl = this.op.eval(env, enc);
+        final OptionalValueList ovl = this.operand.eval(env, enc);
         return OptionalValueList.create(OptionalValue.of(num(ovl.size)));
     }
 
@@ -47,7 +47,7 @@ public class Count implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + op + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -26,15 +26,15 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 public class First implements ValueExpression {
 
-    private final ValueExpression _op;
+    public final ValueExpression operand;
 
-    public First(final ValueExpression op) {
-        _op = checkNotNull(op, "op");
+    public First(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList list = _op.eval(env, enc);
+        final OptionalValueList list = operand.eval(env, enc);
         return list.isEmpty() ? list : OptionalValueList.create(getFirst(list));
     }
 
@@ -44,7 +44,7 @@ public class First implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -25,21 +25,21 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 public class Last implements ValueExpression {
 
-    private final ValueExpression _op;
+    public final ValueExpression operand;
 
-    public Last(final ValueExpression op) {
-        _op = checkNotNull(op, "op");
+    public Last(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList list = _op.eval(env, enc);
+        final OptionalValueList list = operand.eval(env, enc);
         return list.isEmpty() ? list : OptionalValueList.create(list.head);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
@@ -27,13 +27,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Len extends UnaryValueExpression {
 
-    public Len(final ValueExpression op) {
-        super(op);
+    public Len(final ValueExpression operand) {
+        super(operand);
     }
 
     @Override
-    public OptionalValue eval(final Value v, final Environment env, final Encoding enc) {
-        return OptionalValue.of(num(v.getValue().length));
+    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
+        return OptionalValue.of(num(value.getValue().length));
     }
 
     private static Value num(final long length) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/NameRef.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/NameRef.java
@@ -26,20 +26,20 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 public class NameRef implements ValueExpression {
 
-    private final String _name;
+    public final String name;
 
     public NameRef(final String name) {
-        _name = checkNotNull(name, "name");
+        this.name = checkNotNull(name, "name");
     }
 
     @Override
     public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return OptionalValueList.create(ByName.getAllValues(env.order, _name));
+        return OptionalValueList.create(ByName.getAllValues(env.order, name));
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _name + ")";
+        return getClass().getSimpleName() + "(" + name + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -23,12 +23,12 @@ import io.parsingdata.metal.expression.value.*;
 
 public class Offset extends UnaryValueExpression {
 
-    public Offset(final ValueExpression op) { super(op); }
+    public Offset(final ValueExpression operand) { super(operand); }
 
     @Override
-    public OptionalValue eval(final Value op, final Environment env, final Encoding enc) {
-        if (op instanceof ParseValue) {
-            return OptionalValue.of(ConstantFactory.createFromNumeric(((ParseValue)op).getOffset(), op.getEncoding()));
+    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
+        if (value instanceof ParseValue) {
+            return OptionalValue.of(ConstantFactory.createFromNumeric(((ParseValue) value).getOffset(), value.enc));
         }
         return OptionalValue.empty();
     }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/TokenRef.java
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 public class TokenRef implements ValueExpression {
 
-    private final Token definition;
+    public final Token definition;
 
     public TokenRef(final Token definition) {
         this.definition = checkNotNull(definition, "definition");

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -27,12 +27,16 @@ import static io.parsingdata.metal.Util.checkContainsNoNulls;
 
 public class Cho extends Token {
 
-    public final Token[] tokens;
+    private final Token[] tokens;
 
     public Cho(final Encoding enc, final Token... tokens) {
         super(enc);
         this.tokens = checkContainsNoNulls(tokens, "tokens");
         if (tokens.length < 2) { throw new IllegalArgumentException("At least two Tokens are required."); }
+    }
+
+    public Token[] tokens() {
+        return tokens.clone();
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -38,14 +38,14 @@ public class Cho extends Token {
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
         final ParseResult res = iterate(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc, 0);
-        if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
+        if (res.succeeded) { return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset)); }
         return new ParseResult(false, env);
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final int index) throws IOException {
         if (index >= tokens.length) { return new ParseResult(false, env); }
         final ParseResult res = tokens[index].parse(scope, env, enc);
-        if (res.succeeded()) { return res; }
+        if (res.succeeded) { return res; }
         return iterate(scope, env, enc, index + 1);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -27,11 +27,11 @@ import static io.parsingdata.metal.Util.checkContainsNoNulls;
 
 public class Cho extends Token {
 
-    private final Token[] _tokens;
+    public final Token[] tokens;
 
     public Cho(final Encoding enc, final Token... tokens) {
         super(enc);
-        _tokens = checkContainsNoNulls(tokens, "tokens");
+        this.tokens = checkContainsNoNulls(tokens, "tokens");
         if (tokens.length < 2) { throw new IllegalArgumentException("At least two Tokens are required."); }
     }
 
@@ -43,15 +43,15 @@ public class Cho extends Token {
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final int index) throws IOException {
-        if (index >= _tokens.length) { return new ParseResult(false, env); }
-        final ParseResult res = _tokens[index].parse(scope, env, enc);
+        if (index >= tokens.length) { return new ParseResult(false, env); }
+        final ParseResult res = tokens[index].parse(scope, env, enc);
         if (res.succeeded()) { return res; }
         return iterate(scope, env, enc, index + 1);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + Util.tokensToString(_tokens) + ")";
+        return getClass().getSimpleName() + "(" + Util.tokensToString(tokens) + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -33,13 +33,13 @@ public class Def extends Token {
 
     public final String name;
     public final ValueExpression size;
-    public final Expression pred;
+    public final Expression predicate;
 
-    public Def(final String name, final ValueExpression size, final Expression pred, final Encoding enc) {
+    public Def(final String name, final ValueExpression size, final Expression predicate, final Encoding enc) {
         super(enc);
         this.name = checkNotNull(name, "name");
         this.size = checkNotNull(size, "size");
-        this.pred = pred == null ? new True() : pred;
+        this.predicate = predicate == null ? new True() : predicate;
     }
 
     @Override
@@ -58,12 +58,12 @@ public class Def extends Token {
             return new ParseResult(false, env);
         }
         final Environment newEnv = new Environment(env.order.add(new ParseValue(scope, name, this, env.offset, data, enc)), env.input, env.offset + dataSize);
-        return pred.eval(newEnv, enc) ? new ParseResult(true, newEnv) : new ParseResult(false, env);
+        return predicate.eval(newEnv, enc) ? new ParseResult(true, newEnv) : new ParseResult(false, env);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(\"" + name + "\"," + size + "," + pred + ",)";
+        return getClass().getSimpleName() + "(\"" + name + "\"," + size + "," + predicate + ",)";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -16,10 +16,6 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.data.ParseResult;
@@ -29,22 +25,26 @@ import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.True;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class Def extends Token {
 
-    private final String _name;
-    private final ValueExpression _size;
-    private final Expression _pred;
+    public final String name;
+    public final ValueExpression size;
+    public final Expression pred;
 
     public Def(final String name, final ValueExpression size, final Expression pred, final Encoding enc) {
         super(enc);
-        _name = checkNotNull(name, "name");
-        _size = checkNotNull(size, "size");
-        _pred = pred == null ? new True() : pred;
+        this.name = checkNotNull(name, "name");
+        this.size = checkNotNull(size, "size");
+        this.pred = pred == null ? new True() : pred;
     }
 
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList sizes = _size.eval(env, enc);
+        final OptionalValueList sizes = size.eval(env, enc);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
             return new ParseResult(false, env);
         }
@@ -57,13 +57,13 @@ public class Def extends Token {
         if (env.input.read(env.offset, data) != data.length) {
             return new ParseResult(false, env);
         }
-        final Environment newEnv = new Environment(env.order.add(new ParseValue(scope, _name, this, env.offset, data, enc)), env.input, env.offset + dataSize);
-        return _pred.eval(newEnv, enc) ? new ParseResult(true, newEnv) : new ParseResult(false, env);
+        final Environment newEnv = new Environment(env.order.add(new ParseValue(scope, name, this, env.offset, data, enc)), env.input, env.offset + dataSize);
+        return pred.eval(newEnv, enc) ? new ParseResult(true, newEnv) : new ParseResult(false, env);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(\"" + _name + "\"," + _size + "," + _pred + ",)";
+        return getClass().getSimpleName() + "(\"" + name + "\"," + size + "," + pred + ",)";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Nod.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Nod.java
@@ -16,28 +16,28 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class Nod extends Token {
 
-    private final ValueExpression _size;
+    public final ValueExpression size;
 
     public Nod(final ValueExpression size, final Encoding enc) {
         super(enc);
-        _size = checkNotNull(size, "size");
+        this.size = checkNotNull(size, "size");
     }
 
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList sizes = _size.eval(env, enc);
+        final OptionalValueList sizes = size.eval(env, enc);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
             return new ParseResult(false, env);
         }
@@ -50,7 +50,7 @@ public class Nod extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _size + ")";
+        return getClass().getSimpleName() + "(" + size + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Opt.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Opt.java
@@ -16,33 +16,33 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class Opt extends Token {
 
-    private final Token _op;
+    public final Token token;
 
-    public Opt(final Token op, final Encoding enc) {
+    public Opt(final Token token, final Encoding enc) {
         super(enc);
-        _op = checkNotNull(op, "op");
+        this.token = checkNotNull(token, "token");
     }
 
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = _op.parse(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
+        final ParseResult res = token.parse(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
         if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
         return new ParseResult(true, env);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ")";
+        return getClass().getSimpleName() + "(" + token + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Opt.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Opt.java
@@ -36,7 +36,7 @@ public class Opt extends Token {
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
         final ParseResult res = token.parse(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
-        if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
+        if (res.succeeded) { return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset)); }
         return new ParseResult(true, env);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -16,38 +16,38 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Shorthand.expTrue;
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Shorthand.expTrue;
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class Pre extends Token {
 
-    private final Token _op;
-    private final Expression _pred;
+    public final Token token;
+    public final Expression pred;
 
-    public Pre(final Token op, final Expression pred, final Encoding enc) {
+    public Pre(final Token token, final Expression pred, final Encoding enc) {
         super(enc);
-        _op = checkNotNull(op, "op");
-        _pred = pred == null ? expTrue() : pred;
+        this.token = checkNotNull(token, "token");
+        this.pred = pred == null ? expTrue() : pred;
     }
 
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        if (!_pred.eval(env, enc)) { return new ParseResult(true, env); }
-        final ParseResult res = _op.parse(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
+        if (!pred.eval(env, enc)) { return new ParseResult(true, env); }
+        final ParseResult res = token.parse(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
         if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
         return new ParseResult(false, env);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ", " + _pred + ")";
+        return getClass().getSimpleName() + "(" + token + ", " + pred + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -41,7 +41,7 @@ public class Pre extends Token {
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
         if (!predicate.eval(env, enc)) { return new ParseResult(true, env); }
         final ParseResult res = token.parse(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
-        if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
+        if (res.succeeded) { return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset)); }
         return new ParseResult(false, env);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -29,17 +29,17 @@ import static io.parsingdata.metal.Util.checkNotNull;
 public class Pre extends Token {
 
     public final Token token;
-    public final Expression pred;
+    public final Expression predicate;
 
-    public Pre(final Token token, final Expression pred, final Encoding enc) {
+    public Pre(final Token token, final Expression predicate, final Encoding enc) {
         super(enc);
         this.token = checkNotNull(token, "token");
-        this.pred = pred == null ? expTrue() : pred;
+        this.predicate = predicate == null ? expTrue() : predicate;
     }
 
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        if (!pred.eval(env, enc)) { return new ParseResult(true, env); }
+        if (!predicate.eval(env, enc)) { return new ParseResult(true, env); }
         final ParseResult res = token.parse(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
         if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
         return new ParseResult(false, env);
@@ -47,7 +47,7 @@ public class Pre extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + token + ", " + pred + ")";
+        return getClass().getSimpleName() + "(" + token + ", " + predicate + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Rep.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Rep.java
@@ -36,12 +36,12 @@ public class Rep extends Token {
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
         final ParseResult res = iterate(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
-        return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset));
+        return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset));
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc) throws IOException {
         final ParseResult res = token.parse(scope, env, enc);
-        if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc); }
+        if (res.succeeded) { return iterate(scope, res.environment, enc); }
         return new ParseResult(true, env);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Rep.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Rep.java
@@ -16,21 +16,21 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class Rep extends Token {
 
-    private final Token _op;
+    public final Token token;
 
-    public Rep(final Token op, final Encoding enc) {
+    public Rep(final Token token, final Encoding enc) {
         super(enc);
-        _op = checkNotNull(op, "op");
+        this.token = checkNotNull(token, "token");
     }
 
     @Override
@@ -40,14 +40,14 @@ public class Rep extends Token {
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = _op.parse(scope, env, enc);
+        final ParseResult res = token.parse(scope, env, enc);
         if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc); }
         return new ParseResult(true, env);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ")";
+        return getClass().getSimpleName() + "(" + token + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -44,8 +44,8 @@ public class RepN extends Token {
             return new ParseResult(false, env);
         }
         final ParseResult res = iterate(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc, counts.head.get().asNumeric().longValue());
-        if (res.succeeded()) {
-            return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset));
+        if (res.succeeded) {
+            return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset));
         }
         return new ParseResult(false, env);
     }
@@ -53,7 +53,7 @@ public class RepN extends Token {
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final long count) throws IOException {
         if (count <= 0) { return new ParseResult(true, env); }
         final ParseResult res = token.parse(scope, env, enc);
-        if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc, count - 1); }
+        if (res.succeeded) { return iterate(scope, res.environment, enc, count - 1); }
         return new ParseResult(false, env);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -16,30 +16,30 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class RepN extends Token {
 
-    private final Token _op;
-    private final ValueExpression _n;
+    public final Token token;
+    public final ValueExpression n;
 
-    public RepN(final Token op, final ValueExpression n, final Encoding enc) {
+    public RepN(final Token token, final ValueExpression n, final Encoding enc) {
         super(enc);
-        _op = checkNotNull(op, "op");
-        _n = checkNotNull(n, "n");
+        this.token = checkNotNull(token, "token");
+        this.n = checkNotNull(n, "n");
     }
 
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList counts = _n.eval(env, enc);
+        final OptionalValueList counts = n.eval(env, enc);
         if (counts.size != 1 || !counts.head.isPresent()) {
             return new ParseResult(false, env);
         }
@@ -52,14 +52,14 @@ public class RepN extends Token {
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final long count) throws IOException {
         if (count <= 0) { return new ParseResult(true, env); }
-        final ParseResult res = _op.parse(scope, env, enc);
+        final ParseResult res = token.parse(scope, env, enc);
         if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc, count - 1); }
         return new ParseResult(false, env);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + "," + _n + ")";
+        return getClass().getSimpleName() + "(" + token + "," + n + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -27,11 +27,11 @@ import static io.parsingdata.metal.Util.checkContainsNoNulls;
 
 public class Seq extends Token {
 
-    private final Token[] _tokens;
+    public final Token[] tokens;
 
     public Seq(final Encoding enc, final Token... tokens) {
         super(enc);
-        _tokens = checkContainsNoNulls(tokens, "tokens");
+        this.tokens = checkContainsNoNulls(tokens, "tokens");
         if (tokens.length < 2) { throw new IllegalArgumentException("At least two Tokens are required."); }
     }
 
@@ -43,15 +43,15 @@ public class Seq extends Token {
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final int index) throws IOException {
-        if (index >= _tokens.length) { return new ParseResult(true, env); }
-        final ParseResult res = _tokens[index].parse(scope, env, enc);
+        if (index >= tokens.length) { return new ParseResult(true, env); }
+        final ParseResult res = tokens[index].parse(scope, env, enc);
         if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc, index + 1); }
         return res;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + Util.tokensToString(_tokens) + ")";
+        return getClass().getSimpleName() + "(" + Util.tokensToString(tokens) + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -27,12 +27,16 @@ import static io.parsingdata.metal.Util.checkContainsNoNulls;
 
 public class Seq extends Token {
 
-    public final Token[] tokens;
+    private final Token[] tokens;
 
     public Seq(final Encoding enc, final Token... tokens) {
         super(enc);
         this.tokens = checkContainsNoNulls(tokens, "tokens");
         if (tokens.length < 2) { throw new IllegalArgumentException("At least two Tokens are required."); }
+    }
+
+    public Token[] tokens() {
+        return tokens.clone();
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -38,14 +38,14 @@ public class Seq extends Token {
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
         final ParseResult res = iterate(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc, 0);
-        if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
+        if (res.succeeded) { return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset)); }
         return new ParseResult(false, env);
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final int index) throws IOException {
         if (index >= tokens.length) { return new ParseResult(true, env); }
         final ParseResult res = tokens[index].parse(scope, env, enc);
-        if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc, index + 1); }
+        if (res.succeeded) { return iterate(scope, res.environment, enc, index + 1); }
         return res;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Str.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Str.java
@@ -31,14 +31,14 @@ public class Str extends Token {
     public final String scope;
     public final Token token;
     public final StructSink sink;
-    public final Expression pred;
+    public final Expression predicate;
 
-    public Str(final String scope, final Token token, final Encoding enc, final StructSink sink, final Expression pred) {
+    public Str(final String scope, final Token token, final Encoding enc, final StructSink sink, final Expression predicate) {
         super(enc);
         this.scope = checkNotNull(scope, "scope");
         this.token = checkNotNull(token, "token");
         this.sink = sink;
-        this.pred = pred == null ? new True() : pred;
+        this.predicate = predicate == null ? new True() : predicate;
     }
 
     @Override
@@ -46,7 +46,7 @@ public class Str extends Token {
         final ParseResult res = token.parse(outerScope + "." + scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
         if (!res.succeeded()) { return new ParseResult(false, env); }
         final ParseResult closedResult = new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset));
-        if (sink != null && pred.eval(closedResult.getEnvironment(), enc)) {
+        if (sink != null && predicate.eval(closedResult.getEnvironment(), enc)) {
             sink.handleStruct(outerScope, closedResult.getEnvironment(), enc, closedResult.getEnvironment().order.get(this).asGraph());
         }
         return closedResult;

--- a/core/src/main/java/io/parsingdata/metal/token/Str.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Str.java
@@ -16,45 +16,45 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.True;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class Str extends Token {
 
     public final String scope;
-    private final Token _op;
-    private final StructSink _sink;
-    private final Expression _pred;
+    public final Token token;
+    public final StructSink sink;
+    public final Expression pred;
 
-    public Str(final String scope, final Token op, final Encoding enc, final StructSink sink, final Expression pred) {
+    public Str(final String scope, final Token token, final Encoding enc, final StructSink sink, final Expression pred) {
         super(enc);
         this.scope = checkNotNull(scope, "scope");
-        _op = checkNotNull(op, "op");
-        _sink = sink;
-        _pred = pred == null ? new True() : pred;
+        this.token = checkNotNull(token, "token");
+        this.sink = sink;
+        this.pred = pred == null ? new True() : pred;
     }
 
     @Override
     protected ParseResult parseImpl(final String outerScope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = _op.parse(outerScope + "." + scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
+        final ParseResult res = token.parse(outerScope + "." + scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
         if (!res.succeeded()) { return new ParseResult(false, env); }
         final ParseResult closedResult = new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset));
-        if (_sink != null && _pred.eval(closedResult.getEnvironment(), enc)) {
-            _sink.handleStruct(outerScope, closedResult.getEnvironment(), enc, closedResult.getEnvironment().order.get(this).asGraph());
+        if (sink != null && pred.eval(closedResult.getEnvironment(), enc)) {
+            sink.handleStruct(outerScope, closedResult.getEnvironment(), enc, closedResult.getEnvironment().order.get(this).asGraph());
         }
         return closedResult;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(\"" + scope + "\"," + _op + (_sink != null ? "," + _sink : "") + ")";
+        return getClass().getSimpleName() + "(\"" + scope + "\"," + token + (sink != null ? "," + sink : "") + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Str.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Str.java
@@ -44,10 +44,10 @@ public class Str extends Token {
     @Override
     protected ParseResult parseImpl(final String outerScope, final Environment env, final Encoding enc) throws IOException {
         final ParseResult res = token.parse(outerScope + "." + scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
-        if (!res.succeeded()) { return new ParseResult(false, env); }
-        final ParseResult closedResult = new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset));
-        if (sink != null && predicate.eval(closedResult.getEnvironment(), enc)) {
-            sink.handleStruct(outerScope, closedResult.getEnvironment(), enc, closedResult.getEnvironment().order.get(this).asGraph());
+        if (!res.succeeded) { return new ParseResult(false, env); }
+        final ParseResult closedResult = new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset));
+        if (sink != null && predicate.eval(closedResult.environment, enc)) {
+            sink.handleStruct(outerScope, closedResult.environment, enc, closedResult.environment.order.get(this).asGraph());
         }
         return closedResult;
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -43,8 +43,8 @@ public class Sub extends Token {
         final OptionalValueList addrs = address.eval(env, enc);
         if (addrs.isEmpty() || addrs.containsEmpty()) { return new ParseResult(false, env); }
         final ParseResult res = iterate(scope, addrs, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
-        if (res.succeeded()) {
-            return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, env.offset));
+        if (res.succeeded) {
+            return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, env.offset));
         }
         return new ParseResult(false, env);
     }
@@ -52,11 +52,11 @@ public class Sub extends Token {
     private ParseResult iterate(final String scope, final OptionalValueList addrs, final Environment env, final Encoding enc) throws IOException {
         final long ref = addrs.head.get().asNumeric().longValue();
         final ParseResult res = parse(scope, ref, env, enc);
-        if (res.succeeded()) {
+        if (res.succeeded) {
             if (addrs.tail.isEmpty()) {
                 return res;
             }
-            return iterate(scope, addrs.tail, res.getEnvironment(), enc);
+            return iterate(scope, addrs.tail, res.environment, enc);
         }
         return new ParseResult(false, env);
     }
@@ -66,7 +66,7 @@ public class Sub extends Token {
             return new ParseResult(true, new Environment(env.order.add(new ParseRef(ref, this)), env.input, env.offset));
         }
         final ParseResult res = token.parse(scope, new Environment(env.order, env.input, ref), enc);
-        if (res.succeeded()) {
+        if (res.succeeded) {
             return res;
         }
         return new ParseResult(false, env);

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -29,18 +29,18 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 public class Sub extends Token {
 
-    private final Token _op;
-    private final ValueExpression _addr;
+    public final Token token;
+    public final ValueExpression address;
 
-    public Sub(final Token op, final ValueExpression addr, final Encoding enc) {
+    public Sub(final Token token, final ValueExpression address, final Encoding enc) {
         super(enc);
-        _op = checkNotNull(op, "op");
-        _addr = checkNotNull(addr, "addr");
+        this.token = checkNotNull(token, "token");
+        this.address = checkNotNull(address, "address");
     }
 
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList addrs = _addr.eval(env, enc);
+        final OptionalValueList addrs = address.eval(env, enc);
         if (addrs.isEmpty() || addrs.containsEmpty()) { return new ParseResult(false, env); }
         final ParseResult res = iterate(scope, addrs, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
         if (res.succeeded()) {
@@ -65,7 +65,7 @@ public class Sub extends Token {
         if (env.order.hasGraphAtRef(ref)) {
             return new ParseResult(true, new Environment(env.order.add(new ParseRef(ref, this)), env.input, env.offset));
         }
-        final ParseResult res = _op.parse(scope, new Environment(env.order, env.input, ref), enc);
+        final ParseResult res = token.parse(scope, new Environment(env.order, env.input, ref), enc);
         if (res.succeeded()) {
             return res;
         }
@@ -74,7 +74,7 @@ public class Sub extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ", " + _addr + ")";
+        return getClass().getSimpleName() + "(" + token + ", " + address + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -16,24 +16,24 @@
 
 package io.parsingdata.metal.token;
 
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
+
+import java.io.IOException;
 
 public abstract class Token {
 
     public final static String DEFAULT_NAME = "W";
 
-    private final Encoding _enc;
+    public final Encoding enc;
 
     protected Token(final Encoding enc) {
-        _enc = enc;
+        this.enc = enc;
     }
 
     public ParseResult parse(final String scope, final Environment env, final Encoding enc) throws IOException {
-        return _enc == null ? parseImpl(scope, env, enc) : parseImpl(scope, env, _enc);
+        return this.enc == null ? parseImpl(scope, env, enc) : parseImpl(scope, env, this.enc);
     }
 
     public ParseResult parse(final Environment env, final Encoding enc) throws IOException {

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -29,12 +29,12 @@ import static io.parsingdata.metal.Util.checkNotNull;
 public class While extends Token {
 
     public final Token token;
-    public final Expression pred;
+    public final Expression predicate;
 
-    public While(final Token token, final Expression pred, final Encoding enc) {
+    public While(final Token token, final Expression predicate, final Encoding enc) {
         super(enc);
         this.token = checkNotNull(token, "token");
-        this.pred = pred == null ? expTrue() : pred;
+        this.predicate = predicate == null ? expTrue() : predicate;
     }
 
     @Override
@@ -45,7 +45,7 @@ public class While extends Token {
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc) throws IOException {
-        if (!pred.eval(env, enc)) { return new ParseResult(true, env); }
+        if (!predicate.eval(env, enc)) { return new ParseResult(true, env); }
         final ParseResult res = token.parse(scope, env, enc);
         if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc); }
         return new ParseResult(false, env);
@@ -53,7 +53,7 @@ public class While extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + token + ", " + pred + ")";
+        return getClass().getSimpleName() + "(" + token + ", " + predicate + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -16,25 +16,25 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.Shorthand.expTrue;
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.io.IOException;
-
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
+import java.io.IOException;
+
+import static io.parsingdata.metal.Shorthand.expTrue;
+import static io.parsingdata.metal.Util.checkNotNull;
+
 public class While extends Token {
 
-    private final Token _op;
-    private final Expression _pred;
+    public final Token token;
+    public final Expression pred;
 
-    public While(final Token op, final Expression pred, final Encoding enc) {
+    public While(final Token token, final Expression pred, final Encoding enc) {
         super(enc);
-        _op = checkNotNull(op, "op");
-        _pred = pred == null ? expTrue() : pred;
+        this.token = checkNotNull(token, "token");
+        this.pred = pred == null ? expTrue() : pred;
     }
 
     @Override
@@ -45,15 +45,15 @@ public class While extends Token {
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc) throws IOException {
-        if (!_pred.eval(env, enc)) { return new ParseResult(true, env); }
-        final ParseResult res = _op.parse(scope, env, enc);
+        if (!pred.eval(env, enc)) { return new ParseResult(true, env); }
+        final ParseResult res = token.parse(scope, env, enc);
         if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc); }
         return new ParseResult(false, env);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _op + ", " + _pred + ")";
+        return getClass().getSimpleName() + "(" + token + ", " + pred + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -40,14 +40,14 @@ public class While extends Token {
     @Override
     protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
         final ParseResult res = iterate(scope, new Environment(env.order.addBranch(this), env.input, env.offset), enc);
-        if (res.succeeded()) { return new ParseResult(true, new Environment(res.getEnvironment().order.closeBranch(), res.getEnvironment().input, res.getEnvironment().offset)); }
+        if (res.succeeded) { return new ParseResult(true, new Environment(res.environment.order.closeBranch(), res.environment.input, res.environment.offset)); }
         return new ParseResult(false, env);
     }
 
     private ParseResult iterate(final String scope, final Environment env, final Encoding enc) throws IOException {
         if (!predicate.eval(env, enc)) { return new ParseResult(true, env); }
         final ParseResult res = token.parse(scope, env, enc);
-        if (res.succeeded()) { return iterate(scope, res.getEnvironment(), enc); }
+        if (res.succeeded) { return iterate(scope, res.environment, enc); }
         return new ParseResult(false, env);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -46,7 +46,7 @@ public class ArgumentsTest {
 
     final private static String VALID_NAME = "name";
     final private static ValueExpression VALID_VE = con(1);
-    final private static Reducer VALID_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression l, final ValueExpression r) { return null; }};
+    final private static Reducer VALID_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return null; }};
     final private static Expression VALID_E = new Expression() { @Override public boolean eval(final Environment env, final Encoding enc) { return false; }};
     final private static Token VALID_T = new Token(null) { @Override protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException { return null; } };
 

--- a/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.Shorthand.neg;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;

--- a/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
@@ -47,22 +47,22 @@ public class BackTrackNameBindTest {
 
     @Test
     public void choiceRefLeft() throws IOException {
-        Assert.assertTrue(_choiceRef.parse(stream(1, 2, 2), enc()).succeeded());
+        Assert.assertTrue(_choiceRef.parse(stream(1, 2, 2), enc()).succeeded);
     }
 
     @Test
     public void choiceRefRight() throws IOException {
-        Assert.assertTrue(_choiceRef.parse(stream(1, 2, 3), enc()).succeeded());
+        Assert.assertTrue(_choiceRef.parse(stream(1, 2, 3), enc()).succeeded);
     }
 
     @Test
     public void choiceRefNone() throws IOException {
-        Assert.assertFalse(_choiceRef.parse(stream(1, 1, 2), enc()).succeeded());
+        Assert.assertFalse(_choiceRef.parse(stream(1, 1, 2), enc()).succeeded);
     }
 
     @Test
     public void repeatRef() throws IOException {
-        Assert.assertTrue(_repeatRef.parse(stream(42, 42, 42, 21, 21, 21), enc()).succeeded());
+        Assert.assertTrue(_repeatRef.parse(stream(42, 42, 42, 21, 21, 21), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
@@ -19,10 +19,10 @@ package io.parsingdata.metal;
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.any;
-import static io.parsingdata.metal.TokenDefinitions.eq;
-import static io.parsingdata.metal.TokenDefinitions.eqRef;
-import static io.parsingdata.metal.TokenDefinitions.notEqRef;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.eq;
+import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
+import static io.parsingdata.metal.util.TokenDefinitions.notEqRef;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 

--- a/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
@@ -57,42 +57,42 @@ public class BackTrackOffsetTest {
 
     @Test
     public void choiceLeft() throws IOException {
-        Assert.assertTrue(_backTrackChoice.parse(stream(1, 2), enc()).succeeded());
+        Assert.assertTrue(_backTrackChoice.parse(stream(1, 2), enc()).succeeded);
     }
 
     @Test
     public void choiceRight() throws IOException {
-        Assert.assertTrue(_backTrackChoice.parse(stream(1, 3), enc()).succeeded());
+        Assert.assertTrue(_backTrackChoice.parse(stream(1, 3), enc()).succeeded);
     }
 
     @Test
     public void choiceNone() throws IOException {
-        Assert.assertFalse(_backTrackChoice.parse(stream(1, 4), enc()).succeeded());
+        Assert.assertFalse(_backTrackChoice.parse(stream(1, 4), enc()).succeeded);
     }
 
     @Test
     public void repeatZero() throws IOException {
-        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 3), enc()).succeeded());
+        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 3), enc()).succeeded);
     }
 
     @Test
     public void repeatOnce() throws IOException {
-        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 3), enc()).succeeded());
+        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 3), enc()).succeeded);
     }
 
     @Test
     public void repeatTwice() throws IOException {
-        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 2, 1, 3), enc()).succeeded());
+        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 2, 1, 3), enc()).succeeded);
     }
 
     @Test
     public void repeatNone() throws IOException {
-        Assert.assertFalse(_backTrackRepeat.parse(stream(1, 4), enc()).succeeded());
+        Assert.assertFalse(_backTrackRepeat.parse(stream(1, 4), enc()).succeeded);
     }
 
     @Test
     public void deepMatch() throws IOException {
-        Assert.assertTrue(_backTrackDeep.parse(stream(1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 84), enc()).succeeded());
+        Assert.assertTrue(_backTrackDeep.parse(stream(1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 84), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
@@ -19,8 +19,8 @@ package io.parsingdata.metal;
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.any;
-import static io.parsingdata.metal.TokenDefinitions.eq;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.eq;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -67,8 +67,8 @@ public class ByteLengthTest {
         final Environment env = new Environment(stream);
         final ParseResult result = STRING.parse(env, ENCODING);
 
-        assertTrue(result.succeeded());
-        final ParseGraph graph = result.getEnvironment().order;
+        assertTrue(result.succeeded);
+        final ParseGraph graph = result.environment.order;
         assertEquals(5, graph.get("length").asNumeric().byteValue());
         assertEquals("Hello", graph.get("text1").asString());
         assertEquals("Metal", graph.get("text2").asString());
@@ -79,7 +79,7 @@ public class ByteLengthTest {
         final ByteStream stream = new InMemoryByteStream(string("Joe"));
         final Environment env = new Environment(stream);
         final ParseResult result = NAME.parse(env, ENCODING);
-        assertFalse(result.succeeded());
+        assertFalse(result.succeeded);
     }
 
     private byte[] string(final String text) {

--- a/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.Shorthand.ltNum;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.self;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -74,8 +74,8 @@ public class CurrentOffsetTest {
         final Token offsetValidation = rep(def("byte", con(1), eqNum(sub(self, sub(currentOffset, con(1))), con(0))));
 
         final ParseResult parse = offsetValidation.parse(env, new Encoding(Sign.UNSIGNED));
-        assertTrue(parse.succeeded());
-        assertEquals(256, parse.getEnvironment().offset);
+        assertTrue(parse.succeeded);
+        assertEquals(256, parse.environment.offset);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
@@ -49,10 +49,10 @@ public class DefSizeTest {
         });
         final ParseResult result = FORMAT.parse(new Environment(stream), new Encoding());
 
-        Assert.assertTrue(result.succeeded());
+        Assert.assertTrue(result.succeeded);
         Assert.assertArrayEquals(
             new byte[]{0x04, 0x08},
-            result.getEnvironment().order.get("data").getValue()
+            result.environment.order.get("data").getValue()
         );
     }
 
@@ -64,8 +64,8 @@ public class DefSizeTest {
         });
         final ParseResult result = FORMAT.parse(new Environment(stream), new Encoding());
 
-        Assert.assertFalse(result.succeeded());
+        Assert.assertFalse(result.succeeded);
         // The top-level Token (Seq) has failed, so no values are recorded in the ParseGraph.
-        Assert.assertEquals(ParseGraph.EMPTY, result.getEnvironment().order);
+        Assert.assertEquals(ParseGraph.EMPTY, result.environment.order);
     }
 }

--- a/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
@@ -36,10 +36,10 @@ public class DefinitionTest {
 	public void singleDef() throws IOException {
 		final Token singleDef = def("a", con(1));
 		final ParseResult res = singleDef.parse(stream(1), enc());
-		Assert.assertTrue(res.succeeded());
-		Assert.assertTrue(res.getEnvironment().order.getDefinition() == ParseGraph.NONE);
-		Assert.assertTrue(res.getEnvironment().order.head.getDefinition() == singleDef);
-		Assert.assertTrue(res.getEnvironment().order.tail.getDefinition() == ParseGraph.NONE);
+		Assert.assertTrue(res.succeeded);
+		Assert.assertTrue(res.environment.order.getDefinition() == ParseGraph.NONE);
+		Assert.assertTrue(res.environment.order.head.getDefinition() == singleDef);
+		Assert.assertTrue(res.environment.order.tail.getDefinition() == ParseGraph.NONE);
 	}
 
 	@Test
@@ -48,14 +48,14 @@ public class DefinitionTest {
 		Token defB = def("b", con(1));
 		final Token smallSeq = seq(defA, defB);
 		final ParseResult res = smallSeq.parse(stream(1, 2), enc());
-		Assert.assertTrue(res.succeeded());
-		Assert.assertTrue(res.getEnvironment().order.getDefinition() == ParseGraph.NONE);
-		Assert.assertTrue(res.getEnvironment().order.head.getDefinition() == smallSeq);
-		Assert.assertTrue(res.getEnvironment().order.head.asGraph().head.getDefinition() == defB);
-		Assert.assertTrue(res.getEnvironment().order.head.asGraph().tail.getDefinition() == smallSeq);
-		Assert.assertTrue(res.getEnvironment().order.head.asGraph().tail.head.getDefinition() == defA);
-		Assert.assertTrue(res.getEnvironment().order.head.asGraph().tail.tail.getDefinition() == smallSeq);
-		Assert.assertTrue(res.getEnvironment().order.tail.getDefinition() == ParseGraph.NONE);
+		Assert.assertTrue(res.succeeded);
+		Assert.assertTrue(res.environment.order.getDefinition() == ParseGraph.NONE);
+		Assert.assertTrue(res.environment.order.head.getDefinition() == smallSeq);
+		Assert.assertTrue(res.environment.order.head.asGraph().head.getDefinition() == defB);
+		Assert.assertTrue(res.environment.order.head.asGraph().tail.getDefinition() == smallSeq);
+		Assert.assertTrue(res.environment.order.head.asGraph().tail.head.getDefinition() == defA);
+		Assert.assertTrue(res.environment.order.head.asGraph().tail.tail.getDefinition() == smallSeq);
+		Assert.assertTrue(res.environment.order.tail.getDefinition() == ParseGraph.NONE);
 	}
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
@@ -37,13 +37,13 @@ public class EndiannessTest {
     @Test
     public void andAcrossByteBoundaryLE() throws IOException {
         final Token t = def("x", con(2), eq(and(self, con(0x03, 0xff)), con(0x01, 0x1b)));
-        Assert.assertTrue(t.parse(stream(0x1b, 0x81), le()).succeeded());
+        Assert.assertTrue(t.parse(stream(0x1b, 0x81), le()).succeeded);
     }
 
     @Test
     public void constructIntermediateConstantLE() throws IOException {
         final Token t = def("x", con(2), eq(and(shr(con(0x82, 0x1b), con(1)), con(0x03, 0xff)), con(0x01, 0x0d)));
-        Assert.assertTrue(t.parse(stream(0x00, 0x00), le()).succeeded());
+        Assert.assertTrue(t.parse(stream(0x00, 0x00), le()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -48,7 +48,7 @@ public class ErrorsTest {
     public void noValueForSize() throws IOException {
         thrown = ExpectedException.none();
         final Token t = def("a", div(con(10), con(0)));
-        assertFalse(t.parse(stream(1), enc()).succeeded());
+        assertFalse(t.parse(stream(1), enc()).succeeded);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class ErrorsTest {
                 repn(dummy, ref("b"))
             );
         ParseResult parseResult = multiRepN.parse(stream(2, 2, 2, 2), enc());
-        assertFalse(parseResult.succeeded());
+        assertFalse(parseResult.succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/IterateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/IterateTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.Shorthand.gtNum;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;

--- a/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
@@ -26,7 +26,7 @@ import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.or;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ParseGraphTest.java
@@ -19,7 +19,7 @@ package io.parsingdata.metal;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.sub;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
@@ -40,17 +40,17 @@ public class ReadUntilTest {
 
     @Test
     public void readUntilConstant() throws IOException {
-        Assert.assertTrue(_readUntil.parse(stream(1, 2, 3, 4, 42), enc()).succeeded());
+        Assert.assertTrue(_readUntil.parse(stream(1, 2, 3, 4, 42), enc()).succeeded);
     }
 
     @Test
     public void readUntilNoSkipping() throws IOException {
-        Assert.assertTrue(_readUntil.parse(stream(42), enc()).succeeded());
+        Assert.assertTrue(_readUntil.parse(stream(42), enc()).succeeded);
     }
 
     @Test
     public void readUntilErrorNoTerminator() throws IOException {
-        Assert.assertFalse(_readUntil.parse(stream(1, 2, 3, 4), enc()).succeeded());
+        Assert.assertFalse(_readUntil.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
@@ -18,8 +18,8 @@ package io.parsingdata.metal;
 
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.eq;
-import static io.parsingdata.metal.TokenDefinitions.notEq;
+import static io.parsingdata.metal.util.TokenDefinitions.eq;
+import static io.parsingdata.metal.util.TokenDefinitions.notEq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/ReducersTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReducersTest.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -28,8 +28,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.TokenDefinitions.any;
-import static io.parsingdata.metal.TokenDefinitions.eqRef;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -48,12 +48,12 @@ public class ShorthandsTest {
 
     @Test
     public void sequenceMultiMatch() throws IOException {
-        Assert.assertTrue(multiSequence.parse(stream(1, 2, 3), enc()).succeeded());
+        Assert.assertTrue(multiSequence.parse(stream(1, 2, 3), enc()).succeeded);
     }
 
     @Test
     public void sequenceMultiNoMatch() throws IOException {
-        Assert.assertFalse(multiSequence.parse(stream(1, 2, 2), enc()).succeeded());
+        Assert.assertFalse(multiSequence.parse(stream(1, 2, 2), enc()).succeeded);
     }
 
     @Test
@@ -73,13 +73,13 @@ public class ShorthandsTest {
 
     private void runChoice(final int data, final String matched) throws IOException {
         final ParseResult res = multiChoice.parse(stream(data), enc());
-        Assert.assertTrue(res.succeeded());
-        Assert.assertTrue(res.getEnvironment().order.current().getName().equals(matched));
+        Assert.assertTrue(res.succeeded);
+        Assert.assertTrue(res.environment.order.current().getName().equals(matched));
     }
 
     @Test
     public void choiceMultiNoMatch() throws IOException {
-        Assert.assertFalse(multiChoice.parse(stream(0), enc()).succeeded());
+        Assert.assertFalse(multiChoice.parse(stream(0), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SimpleTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SimpleTest.java
@@ -41,25 +41,25 @@ public class SimpleTest {
     @Test
     public void correct() throws IOException {
         final Token t = buildSimpleToken("r1", 1, 1);
-        Assert.assertTrue(t.parse(stream(1, 2, 3, 4), enc()).succeeded());
+        Assert.assertTrue(t.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void sizeError() throws IOException {
         final Token t = buildSimpleToken("r1", 2, 1);
-        Assert.assertFalse(t.parse(stream(1, 2, 3, 4), enc()).succeeded());
+        Assert.assertFalse(t.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void predicateError() throws IOException {
         final Token t = buildSimpleToken("r1", 1, 2);
-        Assert.assertFalse(t.parse(stream(1, 2, 3, 4), enc()).succeeded());
+        Assert.assertFalse(t.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void sourceError() throws IOException {
         final Token t = buildSimpleToken("r1", 1, 1);
-        Assert.assertFalse(t.parse(stream(2, 2, 2, 2), enc()).succeeded());
+        Assert.assertFalse(t.parse(stream(2, 2, 2, 2), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/StructSinksTest.java
+++ b/core/src/test/java/io/parsingdata/metal/StructSinksTest.java
@@ -22,7 +22,7 @@ import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.str;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -52,9 +52,9 @@ public class SubStructTableTest {
                              * ref3:            +---------------------^^--^^
                              */
         final ParseResult res = table.parse(env, enc());
-        assertTrue(res.succeeded());
-        assertEquals(4, res.getEnvironment().offset);
-        final ParseGraph order = res.getEnvironment().order;
+        assertTrue(res.succeeded);
+        assertEquals(4, res.environment.offset);
+        final ParseGraph order = res.environment.order;
         checkStruct(order.head.asGraph().head.asGraph().head.asGraph());
         checkStruct(order.head.asGraph().head.asGraph().tail.head.asGraph());
         checkStruct(order.head.asGraph().head.asGraph().tail.tail.head.asGraph());
@@ -72,9 +72,9 @@ public class SubStructTableTest {
                              * ref4:               ++---------------------^^--^^
                              */
         final ParseResult res = table.parse(env, enc());
-        assertTrue(res.succeeded());
-        assertEquals(5, res.getEnvironment().offset);
-        final ParseGraph order = res.getEnvironment().order;
+        assertTrue(res.succeeded);
+        assertEquals(5, res.environment.offset);
+        final ParseGraph order = res.environment.order;
         checkStruct(order.head.asGraph().head.asGraph().head.asGraph());
         assertTrue(order.head.asGraph().head.asGraph().tail.head.isRef());
         checkStruct(order.head.asGraph().head.asGraph().tail.head.asRef().resolve(order));

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -61,8 +61,8 @@ public class SubStructTest {
                              * ref 3:                   +----------------*
                              */
         final ParseResult res = token.parse(env, enc());
-        Assert.assertTrue(res.succeeded());
-        final ParseGraph out = res.getEnvironment().order;
+        Assert.assertTrue(res.succeeded);
+        final ParseGraph out = res.environment.order;
         Assert.assertEquals(0, out.getRefs().size); // No cycles
 
         final ParseGraph first = out.head.asGraph();
@@ -80,8 +80,8 @@ public class SubStructTest {
         final Token token = new LinkedList(enc());
         final Environment env = stream(0, 0, 1);
         final ParseResult res = token.parse(env, enc());
-        Assert.assertTrue(res.succeeded());
-        final ParseGraph out = res.getEnvironment().order;
+        Assert.assertTrue(res.succeeded);
+        final ParseGraph out = res.environment.order;
         Assert.assertEquals(1, out.getRefs().size);
 
         final ParseGraph first = out.head.asGraph();
@@ -96,8 +96,8 @@ public class SubStructTest {
         final Token token = new LinkedList(enc());
         final Environment env = stream(0, 4, 1, 21, 0, 0, 1);
         final ParseResult res = token.parse(env, enc());
-        Assert.assertTrue(res.succeeded());
-        final ParseGraph out = res.getEnvironment().order;
+        Assert.assertTrue(res.succeeded);
+        final ParseGraph out = res.environment.order;
         Assert.assertEquals(1, out.getRefs().size);
 
         final ParseGraph first = out.head.asGraph();

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 @RunWith(JUnit4.class)
 public class ToStringTest {

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -69,14 +69,14 @@ public class TreeTest {
 
     @Test
     public void checkRegularTree() {
-        Assert.assertTrue(_regular.succeeded());
-        checkStruct(_regular.getEnvironment().order.reverse(), 0);
+        Assert.assertTrue(_regular.succeeded);
+        checkStruct(_regular.environment.order.reverse(), 0);
     }
 
     @Test
     public void checkCyclicTree() {
-        Assert.assertTrue(_cyclic.succeeded());
-        checkStruct(_cyclic.getEnvironment().order.reverse(), 0);
+        Assert.assertTrue(_cyclic.succeeded);
+        checkStruct(_cyclic.environment.order.reverse(), 0);
     }
 
     private void checkStruct(final ParseGraph graph, final long offset) {
@@ -123,8 +123,8 @@ public class TreeTest {
 
     @Test
     public void checkRegularTreeFlat() {
-        Assert.assertTrue(_regular.succeeded());
-        final ParseValueList nrs = ByName.getAllValues(_regular.getEnvironment().order, "nr");
+        Assert.assertTrue(_regular.succeeded);
+        final ParseValueList nrs = ByName.getAllValues(_regular.environment.order, "nr");
         for (int i = 0; i < 7; i++) {
             Assert.assertTrue(contains(nrs, i));
         }

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -22,7 +22,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -44,12 +44,12 @@ public class ValueExpressionSemanticsTest {
 
     @Test
     public void Cat() throws IOException {
-        Assert.assertTrue(cat.parse(stream(1, 2, 1, 2), enc()).succeeded());
+        Assert.assertTrue(cat.parse(stream(1, 2, 1, 2), enc()).succeeded);
     }
 
     @Test
     public void CatNoMatch() throws IOException {
-        Assert.assertFalse(cat.parse(stream(1, 2, 12, 12), enc()).succeeded());
+        Assert.assertFalse(cat.parse(stream(1, 2, 12, 12), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -222,7 +222,7 @@ public class ByTokenTest {
 
     private ParseGraph parseResultGraph(final Environment env, final Token def) {
         try {
-            return def.parse(env, enc()).getEnvironment().order;
+            return def.parse(env, enc()).environment.order;
         }
         catch (final IOException e) {
             throw new AssertionError("Parsing failed", e);

--- a/core/src/test/java/io/parsingdata/metal/expression/value/BinaryValueExpressionListSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/BinaryValueExpressionListSemanticsTest.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.*;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -44,7 +44,7 @@ public class ElvisExpressionTest {
     @Test
     public void elvisLeft() throws IOException { // the building
         final ParseResult result = choice.parse(stream(1), enc());
-        final OptionalValueList eval = elvisExpression.eval(result.getEnvironment(), enc());
+        final OptionalValueList eval = elvisExpression.eval(result.environment, enc());
 
         assertNotNull(eval);
         assertEquals(1, eval.size);
@@ -54,7 +54,7 @@ public class ElvisExpressionTest {
     @Test
     public void elvisRight() throws IOException {
         final ParseResult result = choice.parse(stream(2), enc());
-        final OptionalValueList eval = elvisExpression.eval(result.getEnvironment(), enc());
+        final OptionalValueList eval = elvisExpression.eval(result.environment, enc());
 
         assertNotNull(eval);
         assertEquals(1, eval.size);
@@ -64,7 +64,7 @@ public class ElvisExpressionTest {
     @Test
     public void elvisNone() throws IOException {
         final ParseResult result = choice.parse(stream(3), enc());
-        final OptionalValueList eval = elvisExpression.eval(result.getEnvironment(), enc());
+        final OptionalValueList eval = elvisExpression.eval(result.environment, enc());
 
         assertNotNull(eval);
         assertTrue(eval.isEmpty());
@@ -73,9 +73,9 @@ public class ElvisExpressionTest {
     @Test
     public void elvisList() throws IOException {
         final ParseResult result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
-        assertTrue(result.succeeded());
+        assertTrue(result.succeeded);
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
-        final OptionalValueList eval = elvis.eval(result.getEnvironment(), enc());
+        final OptionalValueList eval = elvis.eval(result.environment, enc());
         assertEquals(2, eval.size);
         assertEquals(2, eval.head.get().asNumeric().intValue());
         assertEquals(1, eval.tail.head.get().asNumeric().intValue());
@@ -84,9 +84,9 @@ public class ElvisExpressionTest {
     @Test
     public void elvisListWithEmpty() throws IOException {
         final ParseResult result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
-        assertTrue(result.succeeded());
+        assertTrue(result.succeeded);
         final ValueExpression elvis = elvis(ref("c"), ref("b"));
-        final OptionalValueList eval = elvis.eval(result.getEnvironment(), enc());
+        final OptionalValueList eval = elvis.eval(result.environment, enc());
         assertEquals(2, eval.size);
         assertEquals(4, eval.head.get().asNumeric().intValue());
         assertEquals(3, eval.tail.head.get().asNumeric().intValue());
@@ -95,9 +95,9 @@ public class ElvisExpressionTest {
     @Test
     public void elvisListDifferentLengths() throws IOException {
         final ParseResult result = seq(any("a"), any("a"), any("b"), any("b"), any("b")).parse(stream(1, 2, 3, 4, 5), enc());
-        assertTrue(result.succeeded());
+        assertTrue(result.succeeded);
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
-        final OptionalValueList eval = elvis.eval(result.getEnvironment(), enc());
+        final OptionalValueList eval = elvis.eval(result.environment, enc());
         assertEquals(3, eval.size);
         assertEquals(2, eval.head.get().asNumeric().intValue());
         assertEquals(1, eval.tail.head.get().asNumeric().intValue());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -44,14 +44,14 @@ public class FoldEdgeCaseTest {
 
     private final static Reducer ADD_REDUCER = new Reducer() {
         @Override
-        public ValueExpression reduce(final ValueExpression l, final ValueExpression r) {
-            return add(l, r);
+        public ValueExpression reduce(final ValueExpression left, final ValueExpression right) {
+            return add(left, right);
         }
     };
 
     private static final Reducer MULTIPLE_VALUE_REDUCER = new Reducer() {
         @Override
-        public ValueExpression reduce(final ValueExpression l, final ValueExpression r) {
+        public ValueExpression reduce(final ValueExpression left, final ValueExpression right) {
             return ref("value");
         }
     };

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -73,7 +73,7 @@ public class FoldEdgeCaseTest {
                 )
             ).parse(stream(1, 2, 1, 2, 3), enc());
 
-        assertFalse(parseResult.succeeded());
+        assertFalse(parseResult.succeeded);
     }
 
     @Test
@@ -84,7 +84,7 @@ public class FoldEdgeCaseTest {
                 def("folded", 1, eq(foldRight(ref("toFold"), ADD_REDUCER)))
             ).parse(stream(1), enc());
 
-        assertFalse(parseResult.succeeded());
+        assertFalse(parseResult.succeeded);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/NodTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/NodTest.java
@@ -46,22 +46,22 @@ public class NodTest {
     @Test
     public void nodSkipsData() throws IOException {
         final ParseResult parseResult = NOD.parse(stream(1, 1, 1, 1), enc());
-        assertTrue(parseResult.succeeded());
-        assertThat(parseResult.getEnvironment().offset, is(4L));
+        assertTrue(parseResult.succeeded);
+        assertThat(parseResult.environment.offset, is(4L));
     }
 
     @Test
     public void nodWithRefSize() throws IOException {
         final ParseResult parseResult = FOUND_REF.parse(stream(1, 1), enc());
         // 1 byte size, 1 byte nod:
-        assertTrue(parseResult.succeeded());
-        assertThat(parseResult.getEnvironment().offset, is(2L));
+        assertTrue(parseResult.succeeded);
+        assertThat(parseResult.environment.offset, is(2L));
     }
 
     @Test
     public void nodWithoutSize() throws IOException {
         final ParseResult parseResult = NOD_REF_SIZE.parse(stream(), enc());
-        assertFalse(parseResult.succeeded());
+        assertFalse(parseResult.succeeded);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class NodTest {
             seq(def("size", con(1)),
                 def("size", con(1)),
                 NOD_REF_SIZE).parse(stream(2, 2, 0, 0), enc());
-        assertFalse(parseResult.succeeded());
+        assertFalse(parseResult.succeeded);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class NodTest {
         final ParseResult parseResult =
             seq(def("size", con(1)),
                 NOD_REF_SIZE).parse(stream(-1), signed());
-        assertFalse(parseResult.succeeded());
+        assertFalse(parseResult.succeeded);
     }
 
     @Test
@@ -89,8 +89,8 @@ public class NodTest {
                 nod(con(0)),
                 def("two", 1, eq(con(2)))
             ).parse(stream(1, 2), enc());
-        assertTrue(parseResult.succeeded());
-        assertThat(parseResult.getEnvironment().offset, is(2L));
+        assertTrue(parseResult.succeeded);
+        assertThat(parseResult.environment.offset, is(2L));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/PreTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PreTest.java
@@ -38,7 +38,7 @@ public class PreTest {
         final ParseResult result = SEQUENCE.parse(stream(1, 1), enc());
 
         // precondition is true, token is parsed
-        assertThat(result.getEnvironment().offset, is(2L));
+        assertThat(result.environment.offset, is(2L));
     }
 
     @Test
@@ -46,7 +46,7 @@ public class PreTest {
         final ParseResult result = SEQUENCE.parse(stream(0, 1), enc());
 
         // precondition is false, token is not parsed
-        assertThat(result.getEnvironment().offset, is(1L));
+        assertThat(result.environment.offset, is(1L));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class PreTest {
         final ParseResult result = SEQUENCE.parse(stream(1, 2), enc());
 
         // precondition is true, but token can't be parsed
-        assertFalse(result.succeeded());
+        assertFalse(result.succeeded);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class PreTest {
         final ParseResult result = noPrecondition.parse(stream(0), enc());
 
         // precondition null, always parse
-        assertThat(result.getEnvironment().offset, is(1L));
+        assertThat(result.environment.offset, is(1L));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -44,7 +44,7 @@ public class WhileTest {
         // the while stops because the second 'value' is >= 1
         final ParseResult result = WHILE.parse(stream(0, 9, 1, 10, 2, 11), enc());
 
-        assertThat(result.getEnvironment().offset, is(4L));
+        assertThat(result.environment.offset, is(4L));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class WhileTest {
         final ParseResult result = WHILE.parse(stream(0, 9, 0, 8), enc());
 
         // parsing fails because the nested token couldn't be parsed ('value2' <= 9)
-        assertFalse(result.succeeded());
+        assertFalse(result.succeeded);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class WhileTest {
         final ParseResult result = trueWhile.parse(stream(0), enc());
 
         // parsing fails because the nested def fails at the end of the stream
-        assertFalse(result.succeeded());
+        assertFalse(result.succeeded);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -57,7 +57,7 @@ public class WhileTest {
 
     @Test
     public void whileWithoutExpression() throws IOException {
-        // passing null as predicate make this a while(true):
+        // passing null as pred make this a while(true):
         final Token trueWhile = new While(def("value", 1), null, enc());
         final ParseResult result = trueWhile.parse(stream(0), enc());
 

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -57,7 +57,7 @@ public class WhileTest {
 
     @Test
     public void whileWithoutExpression() throws IOException {
-        // passing null as pred make this a while(true):
+        // passing null as predicate make this a while(true):
         final Token trueWhile = new While(def("value", 1), null, enc());
         final ParseResult result = trueWhile.parse(stream(0), enc());
 

--- a/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
@@ -46,7 +46,7 @@ public class ParameterizedParse {
 
     @Test
     public void test() throws IOException {
-        Assert.assertEquals(_result, _token.parse(_env, _enc).succeeded());
+        Assert.assertEquals(_result, _token.parse(_env, _enc).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
+++ b/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package io.parsingdata.metal;
+package io.parsingdata.metal.util;
 
-import static io.parsingdata.metal.Shorthand.con;
-import static io.parsingdata.metal.Shorthand.def;
-import static io.parsingdata.metal.Shorthand.expTrue;
-import static io.parsingdata.metal.Shorthand.not;
-import static io.parsingdata.metal.Shorthand.ref;
+import io.parsingdata.metal.Shorthand;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
+
+import static io.parsingdata.metal.Shorthand.*;
 
 public class TokenDefinitions {
 
@@ -37,7 +35,7 @@ public class TokenDefinitions {
     }
 
     public static Token eq(final String name, final int value) {
-        return def(name, con(1), Shorthand.eq(con(value)));
+        return Shorthand.def(name, con(1), Shorthand.eq(con(value)));
     }
 
     public static Token notEq(final String name, final int value) {

--- a/formats/src/test/java/io/parsingdata/metal/FormatTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/FormatTest.java
@@ -42,22 +42,22 @@ public class FormatTest {
 
     @Test
     public void parsePNG() throws IOException, URISyntaxException {
-        Assert.assertTrue(PNG.FORMAT.parse(stream(toURI(PNGFILE)), enc()).succeeded());
+        Assert.assertTrue(PNG.FORMAT.parse(stream(toURI(PNGFILE)), enc()).succeeded);
     }
 
     @Test
     public void parseZIP() throws IOException, URISyntaxException {
-        Assert.assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE1)), enc()).succeeded());
+        Assert.assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE1)), enc()).succeeded);
     }
 
     @Test
     public void parseZIP2() throws IOException, URISyntaxException {
-        Assert.assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE2)), enc()).succeeded());
+        Assert.assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE2)), enc()).succeeded);
     }
 
     @Test
     public void parseJPEG() throws IOException, URISyntaxException {
-        Assert.assertTrue(JPEG.FORMAT.parse(stream(toURI(JPEGFILE)), enc()).succeeded());
+        Assert.assertTrue(JPEG.FORMAT.parse(stream(toURI(JPEGFILE)), enc()).succeeded);
     }
 
     private URI toURI(final String resource) throws URISyntaxException {


### PR DESCRIPTION
Resolves #58: Many immutable public fields in `Token` and `Expression` implementations are now public. The argument names in `Shorthand` and public constructors have been improved. Public field names also have better names. `ParseResult` no longer has getters (so `result.succeeded()` and `result.getEnvironment()` become `result.succeeded` and `result.environment` respectively).