### PR TITLE
#80: ParseValues from Def with explicit encoding do not have a name

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -16,13 +16,13 @@
 
 package io.parsingdata.metal.token;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.encoding.Encoding;
+import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.io.IOException;
 
-import static io.parsingdata.metal.Util.checkNotNull;
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.encoding.Encoding;
 
 public abstract class Token {
 
@@ -37,7 +37,7 @@ public abstract class Token {
     }
 
     public ParseResult parse(final String scope, final Environment env, final Encoding enc) throws IOException {
-        return this.enc == null ? parseImpl(makeScope(scope), env, enc) : parseImpl(scope, env, this.enc);
+        return parseImpl(makeScope(scope), env, this.enc != null ? this.enc : enc);
     }
 
     public ParseResult parse(final Environment env, final Encoding enc) throws IOException {

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.token;
+
+import static org.junit.Assert.assertEquals;
+
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class DefTest {
+
+    @Test
+    public void testScopeWithoutEncoding() throws IOException {
+        assertEquals(1, def("a", 1).parse("scope", stream(1), enc()).environment.order.get("scope.a").asNumeric().intValue());
+    }
+
+    @Test
+    public void testScopeWithEncoding() throws IOException {
+        assertEquals(1, def("a", 1, signed()).parse("scope", stream(1), enc()).environment.order.get("scope.a").asNumeric().intValue());
+    }
+}


### PR DESCRIPTION
Resolves #80 