### PR TITLE
Use junit-quickcheck to test ConstantFactory's long and BigInteger conversion code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ script: mvn clean verify -Dgpg.skip
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 
 before_install:
     - pip install --user codecov

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.parsingdata</groupId>
     <artifactId>metal-parent</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>metal-core</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>

--- a/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 public class Encoding {
 
-    private static final Sign DEFAULT_SIGNED = Sign.UNSIGNED;
+    private static final Sign DEFAULT_SIGN = Sign.UNSIGNED;
     private static final Charset DEFAULT_CHARSET = StandardCharsets.US_ASCII;
     private static final ByteOrder DEFAULT_BYTE_ORDER = ByteOrder.BIG_ENDIAN;
 
@@ -30,7 +30,7 @@ public class Encoding {
     private final ByteOrder _byteOrder;
 
     public Encoding() {
-        this(DEFAULT_SIGNED, DEFAULT_CHARSET, DEFAULT_BYTE_ORDER);
+        this(DEFAULT_SIGN, DEFAULT_CHARSET, DEFAULT_BYTE_ORDER);
     }
 
     public Encoding(final Sign signed) {
@@ -38,11 +38,11 @@ public class Encoding {
     }
 
     public Encoding(final Charset charset) {
-        this(DEFAULT_SIGNED, charset, DEFAULT_BYTE_ORDER);
+        this(DEFAULT_SIGN, charset, DEFAULT_BYTE_ORDER);
     }
 
     public Encoding(final ByteOrder byteOrder) {
-        this(DEFAULT_SIGNED, DEFAULT_CHARSET, byteOrder);
+        this(DEFAULT_SIGN, DEFAULT_CHARSET, byteOrder);
     }
 
     public Encoding(final Sign sign, final Charset charset, final ByteOrder byteOrder) {

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryTest.java
@@ -17,32 +17,32 @@ public class ConstantFactoryTest {
 
     public static final BigInteger TWOS_DIFF = BigInteger.valueOf(2).add(BigInteger.valueOf(Long.MAX_VALUE)).add(BigInteger.valueOf(Long.MAX_VALUE));
 
-    @Property(trials = 1000000)
-    public void longConstant(final long input) {
+    @Test public void longConstant0() { checkLongConstant(0L); }
+    @Property public void longConstant8(@InRange(min = "-128", max = "127") final long input) { checkLongConstant(input); }
+    @Property public void longConstant16(@InRange(min = "-32768", max = "32767") final long input) { checkLongConstant(input); }
+    @Property public void longConstant24(@InRange(min = "-8388608", max = "8388607") final long input) { checkLongConstant(input); }
+    @Property public void longConstant32(@InRange(min = "-2147483648", max = "2147483647") final long input) { checkLongConstant(input); }
+    @Property public void longConstant40(@InRange(min = "-549755813888", max = "549755813887") final long input) { checkLongConstant(input); }
+    @Property public void longConstant48(@InRange(min = "-140737488355328", max = "140737488355327") final long input) { checkLongConstant(input); }
+    @Property public void longConstant56(@InRange(min = "-36028797018963968", max = "36028797018963967") final long input) { checkLongConstant(input); }
+    @Property public void longConstant64(@InRange(min = "-9223372036854775808", max = "9223372036854775807") final long input) { checkLongConstant(input); }
+
+    private void checkLongConstant(final long input) {
         assertEquals(input, ConstantFactory.createFromNumeric(input, signed()).asNumeric().longValue());
         if (input >= 0) {
-            //System.out.println("pos");
             assertEquals(input, ConstantFactory.createFromNumeric(input, enc()).asNumeric().longValue());
         } else {
             assertEquals(0, calculateUnsignedValue(input).compareTo(ConstantFactory.createFromNumeric(input, enc()).asNumeric()));
         }
     }
 
-    @Test
-    public void wo() {
-        final long input = -39337942513L;
-        assertEquals(0, calculateUnsignedValue(input).compareTo(ConstantFactory.createFromNumeric(input, enc()).asNumeric()));
-    }
-
     private BigInteger calculateUnsignedValue(final long input) {
         for (int i = 8; i < 64; i+=8) {
             final long maxValue = BigInteger.valueOf(2).pow(i-1).longValue();
             if ((maxValue + input) >= 0) {
-                System.out.print(i/8);
-                return BigInteger.valueOf(input).add(BigInteger.valueOf(maxValue)).add(BigInteger.valueOf(maxValue));
+                return BigInteger.valueOf(input).add(BigInteger.valueOf(2*maxValue));
             }
         }
-        //System.out.print(8);
         return BigInteger.valueOf(input).add(TWOS_DIFF);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryTest.java
@@ -1,0 +1,55 @@
+package io.parsingdata.metal.expression.value;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.math.BigInteger;
+
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnitQuickcheck.class)
+public class ConstantFactoryTest {
+
+    public static final BigInteger TWOS_DIFF = BigInteger.valueOf(2).add(BigInteger.valueOf(Long.MAX_VALUE)).add(BigInteger.valueOf(Long.MAX_VALUE));
+
+    @Property(trials = 1000000)
+    public void longConstant(final long input) {
+        assertEquals(input, ConstantFactory.createFromNumeric(input, signed()).asNumeric().longValue());
+        if (input >= 0) {
+            //System.out.println("pos");
+            assertEquals(input, ConstantFactory.createFromNumeric(input, enc()).asNumeric().longValue());
+        } else {
+            assertEquals(0, calculateUnsignedValue(input).compareTo(ConstantFactory.createFromNumeric(input, enc()).asNumeric()));
+        }
+    }
+
+    @Test
+    public void wo() {
+        final long input = -39337942513L;
+        assertEquals(0, calculateUnsignedValue(input).compareTo(ConstantFactory.createFromNumeric(input, enc()).asNumeric()));
+    }
+
+    private BigInteger calculateUnsignedValue(final long input) {
+        for (int i = 8; i < 64; i+=8) {
+            final long maxValue = BigInteger.valueOf(2).pow(i-1).longValue();
+            if ((maxValue + input) >= 0) {
+                System.out.print(i/8);
+                return BigInteger.valueOf(input).add(BigInteger.valueOf(maxValue)).add(BigInteger.valueOf(maxValue));
+            }
+        }
+        //System.out.print(8);
+        return BigInteger.valueOf(input).add(TWOS_DIFF);
+    }
+
+    @Property
+    public void bigIntegerConstant(@InRange(min = "-1000000000000000000", max = "1000000000000000000") final BigInteger input) {
+        assertEquals(0, input.compareTo(ConstantFactory.createFromNumeric(input, signed()).asNumeric()));
+        assertEquals(0, new BigInteger(1, input.toByteArray()).compareTo(ConstantFactory.createFromNumeric(input, enc()).asNumeric()));
+    }
+
+}

--- a/formats/pom.xml
+++ b/formats/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.parsingdata</groupId>
     <artifactId>metal-parent</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>metal-formats</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>io.parsingdata</groupId>
   <artifactId>metal-parent</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
-  <version>4.0.1</version>
+  <version>4.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>http://parsingdata.io/</url>
   <description>A Java library for parsing binary data formats, using declarative descriptions.</description>
@@ -54,7 +54,8 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
 
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
+    <junit-quickcheck.version>0.7-alpha-2</junit-quickcheck.version>
 
     <jacoco-plugin.version>0.7.5.201505241946</jacoco-plugin.version>
     <reports-plugin.version>2.8</reports-plugin.version>
@@ -72,6 +73,18 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.pholser</groupId>
+      <artifactId>junit-quickcheck-core</artifactId>
+      <version>${junit-quickcheck.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.pholser</groupId>
+      <artifactId>junit-quickcheck-generators</artifactId>
+      <version>${junit-quickcheck.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This will resolve #83.

I hesitated due to loss of JDK7 testing on Travis. But we'll lose that quickly anyway as we move toward Java8 with Metal itself. So seems a reasonable step.