### PR TITLE
Shorthand.con() should support byte array

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -100,6 +100,8 @@ public final class Shorthand {
     public static ValueExpression con(final Value value) { return new Const(value); }
     public static ValueExpression con(final Encoding encoding, final int... values) { return new Const(new Value(toByteArray(values), encoding)); }
     public static ValueExpression con(final int... values) { return con(new Encoding(), values); }
+    public static ValueExpression con(final byte[] value) { return con(value, new Encoding()); }
+    public static ValueExpression con(final byte[] value, final Encoding encoding) { return con(ConstantFactory.createFromBytes(value, encoding)); }
     public static final ValueExpression self = new Self();
     public static ValueExpression len(final ValueExpression operand) { return new Len(operand); }
     public static ValueExpression ref(final String name) { return new NameRef(name); }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
@@ -16,18 +16,22 @@
 
 package io.parsingdata.metal.expression.value;
 
-import io.parsingdata.metal.encoding.ByteOrder;
-import io.parsingdata.metal.encoding.Encoding;
-
 import java.math.BigInteger;
 import java.util.BitSet;
+
+import io.parsingdata.metal.encoding.ByteOrder;
+import io.parsingdata.metal.encoding.Encoding;
 
 public final class ConstantFactory {
 
     private ConstantFactory() {}
 
+    public static Value createFromBytes(final byte[] value, final Encoding enc) {
+        return new Value(value, enc);
+    }
+
     public static Value createFromNumeric(final BigInteger value, final Encoding enc) {
-        return new Value(compact(value.toByteArray(), enc.isSigned()), setToBE(enc));
+        return createFromBytes(compact(value.toByteArray(), enc.isSigned()), setToBE(enc));
     }
 
     public static Value createFromNumeric(final long value, final Encoding enc) {
@@ -49,7 +53,7 @@ public final class ConstantFactory {
         return new Encoding(enc.getSign(), enc.getCharset(), ByteOrder.BIG_ENDIAN);
     }
 
-    private static byte[] compact(final byte[] data, boolean signed) {
+    private static byte[] compact(final byte[] data, final boolean signed) {
         if (signed) { return data; }
         if (data.length < 2) { return data; }
         // strip leading zero bytes

--- a/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
@@ -59,7 +59,9 @@ public class ConstantValueTest extends ParameterizedParse {
             { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(0x81, 0x23))), stream(0x81, 0x23), enc(), true },
             { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(new byte[]{(byte) 0x81, (byte) 0x23}))), stream(0x81, 0x23), enc(), true },
             { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(new byte[]{(byte) 0x81, (byte) 0x23}, enc()))), stream(0x81, 0x23), le(), true },
-            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(new byte[]{(byte) 0x81, (byte) 0x23}, le()))), stream(0x81, 0x23), le(), true },
+            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eqNum(con(new byte[]{(byte) 0x81, (byte) 0x23}, enc()))), stream(0x81, 0x23), le(), false },
+            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eqNum(con(new byte[]{(byte) 0x81, (byte) 0x23}, enc()))), stream(0x23, 0x81), le(), true },
+            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eqNum(con(new byte[]{(byte) 0x81, (byte) 0x23}, le()))), stream(0x81, 0x23), le(), true },
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
@@ -21,6 +21,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.eqNum;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
@@ -37,34 +38,37 @@ import io.parsingdata.metal.util.ParameterizedParse;
 
 public class ConstantValueTest extends ParameterizedParse {
 
-	@Parameters(name="{0} ({4})")
+    @Parameters(name="{0} ({4})")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-        	{ "1 byte, Eq(0), Signed", single(1, eq(con(0))), stream(0), signed(), true },
-        	{ "1 byte, Eq(0), Unsigned", single(1, eq(con(0))), stream(0), enc(), true },
-        	{ "1 byte, Eq(-1), Signed", single(1, eq(con(-1))), stream(-1), signed(), true },
-        	{ "1 byte, Eq(-1), Unsigned", single(1, eq(con(-1))), stream(-1), enc(), true },
-        	{ "1 byte, EqNum(-1, Signed), Signed", single(1, eqNum(con(-1, signed()))), stream(-1), signed(), true },
-        	{ "1 byte, EqNum(-1), Unsigned", single(1, eqNum(con(-1))), stream(-1), enc(), true },
-        	{ "1 byte, Eq(0xff), Signed", single(1, eq(con(0xff))), stream(0xff), signed(), true },
-        	{ "1 byte, Eq(0xff), Unsigned", single(1, eq(con(0xff))), stream(0xff), enc(), true },
-        	{ "2 bytes, Eq(0x0123), Signed", single(2, eq(con(0x0123))), stream(0x01, 0x23), signed(), true },
-        	{ "2 bytes, Eq(0x0123), Unsigned", single(2, eq(con(0x0123))), stream(0x01, 0x23), enc(), true },
-        	{ "2 bytes, Eq(0x8123), Signed", single(2, eq(con(0x8123))), stream(0x81, 0x23), signed(), true },
-        	{ "2 bytes, Eq(0x8123), Unsigned", single(2, eq(con(0x8123))), stream(0x81, 0x23), enc(), true },
-        	{ "2 bytes, Eq(0x01, 0x23), Signed", single(2, eq(con(0x01, 0x23))), stream(0x01, 0x23), signed(), true },
-        	{ "2 bytes, Eq(0x01, 0x23), Unsigned", single(2, eq(con(0x01, 0x23))), stream(0x01, 0x23), enc(), true },
-        	{ "2 bytes, Eq(0x81, 0x23), Signed", single(2, eq(con(0x81, 0x23))), stream(0x81, 0x23), signed(), true },
-        	{ "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(0x81, 0x23))), stream(0x81, 0x23), enc(), true },
+            { "1 byte, Eq(0), Signed", single(1, eq(con(0))), stream(0), signed(), true },
+            { "1 byte, Eq(0), Unsigned", single(1, eq(con(0))), stream(0), enc(), true },
+            { "1 byte, Eq(-1), Signed", single(1, eq(con(-1))), stream(-1), signed(), true },
+            { "1 byte, Eq(-1), Unsigned", single(1, eq(con(-1))), stream(-1), enc(), true },
+            { "1 byte, EqNum(-1, Signed), Signed", single(1, eqNum(con(-1, signed()))), stream(-1), signed(), true },
+            { "1 byte, EqNum(-1), Unsigned", single(1, eqNum(con(-1))), stream(-1), enc(), true },
+            { "1 byte, Eq(0xff), Signed", single(1, eq(con(0xff))), stream(0xff), signed(), true },
+            { "1 byte, Eq(0xff), Unsigned", single(1, eq(con(0xff))), stream(0xff), enc(), true },
+            { "2 bytes, Eq(0x0123), Signed", single(2, eq(con(0x0123))), stream(0x01, 0x23), signed(), true },
+            { "2 bytes, Eq(0x0123), Unsigned", single(2, eq(con(0x0123))), stream(0x01, 0x23), enc(), true },
+            { "2 bytes, Eq(0x8123), Signed", single(2, eq(con(0x8123))), stream(0x81, 0x23), signed(), true },
+            { "2 bytes, Eq(0x8123), Unsigned", single(2, eq(con(0x8123))), stream(0x81, 0x23), enc(), true },
+            { "2 bytes, Eq(0x01, 0x23), Signed", single(2, eq(con(0x01, 0x23))), stream(0x01, 0x23), signed(), true },
+            { "2 bytes, Eq(0x01, 0x23), Unsigned", single(2, eq(con(0x01, 0x23))), stream(0x01, 0x23), enc(), true },
+            { "2 bytes, Eq(0x81, 0x23), Signed", single(2, eq(con(0x81, 0x23))), stream(0x81, 0x23), signed(), true },
+            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(0x81, 0x23))), stream(0x81, 0x23), enc(), true },
+            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(new byte[]{(byte) 0x81, (byte) 0x23}))), stream(0x81, 0x23), enc(), true },
+            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(new byte[]{(byte) 0x81, (byte) 0x23}, enc()))), stream(0x81, 0x23), le(), true },
+            { "2 bytes, Eq(0x81, 0x23), Unsigned", single(2, eq(con(new byte[]{(byte) 0x81, (byte) 0x23}, le()))), stream(0x81, 0x23), le(), true },
         });
     }
-    
+
     public ConstantValueTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
         super(token, env, enc, result);
     }
-    
-    private static Token single(int size, Expression predicate) {
-    	return def("conValue", con(size), predicate);
+
+    private static Token single(final int size, final Expression predicate) {
+        return def("conValue", con(size), predicate);
     }
 
 }


### PR DESCRIPTION
Fixes issue #94 