### PR TITLE
Idea: bit support in Metal

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -28,6 +28,8 @@ import io.parsingdata.metal.expression.value.bitwise.ShiftLeft;
 import io.parsingdata.metal.expression.value.bitwise.ShiftRight;
 import io.parsingdata.metal.expression.value.reference.*;
 import io.parsingdata.metal.token.*;
+import io.parsingdata.metal.token.bits.Bit;
+import io.parsingdata.metal.token.bits.Bits;
 
 public final class Shorthand {
 
@@ -81,6 +83,8 @@ public final class Shorthand {
     public static Token opt(final Token token) { return opt(token, null); }
     public static Token nod(final String name, final ValueExpression size) { return new Nod(name, size, null); }
     public static Token nod(final ValueExpression size) { return nod("", size); }
+    public static Token bits(final String name, final ValueExpression size, Bit... bits) { return new Bits(name, size, bits); }
+    public static Bit bit(final String name, final ValueExpression size, final Expression predicate) { return new Bit(name, size, predicate, null); }
 
     public static BinaryValueExpression add(final ValueExpression left, final ValueExpression right) { return new Add(left, right); }
     public static BinaryValueExpression div(final ValueExpression left, final ValueExpression right) { return new Div(left, right); }

--- a/core/src/main/java/io/parsingdata/metal/token/bits/Bit.java
+++ b/core/src/main/java/io/parsingdata/metal/token/bits/Bit.java
@@ -1,0 +1,54 @@
+package io.parsingdata.metal.token.bits;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.data.ParseResult.failure;
+import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.OptionalValueList;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.Expression;
+import io.parsingdata.metal.expression.True;
+import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.token.Token;
+
+public class Bit extends Token {
+
+    public final ValueExpression size;
+    public final Expression predicate;
+
+    public Bit(final String name, final ValueExpression size, final Expression predicate, final Encoding enc) {
+        super(name, enc);
+        this.size = checkNotNull(size, "size");
+        this.predicate = predicate == null ? new True() : predicate;
+    }
+
+    @Override
+    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
+        final OptionalValueList sizes = size.eval(env, enc);
+        if (sizes.size != 1 || !sizes.head.isPresent()) {
+            return failure(env);
+        }
+        // TODO: Handle value expression results as BigInteger (#16)
+        final int dataSize = sizes.head.get().asNumeric().intValue();
+        if (dataSize < 0) {
+            return failure(env);
+        }
+        final byte[] data = new byte[dataSize];
+        if (env.input.read(env.offset, data) != data.length) {
+            return failure(env);
+        }
+        final Environment newEnv = env.add(new ParseValue(scope, this, env.offset, data, enc)).seek(env.offset + dataSize);
+        return predicate.eval(newEnv, enc) ? success(newEnv) : failure(env);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + makeNameFragment() + size + "," + predicate + ")";
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/token/bits/Bits.java
+++ b/core/src/main/java/io/parsingdata/metal/token/bits/Bits.java
@@ -38,8 +38,12 @@ public class Bits extends Token {
         if (env.input.read(env.offset, data) != data.length) {
             return new ParseResult(false, env);
         }
-        final Environment newEnv = env;
+        Environment newEnv = env;
         final BitSet all = BitSet.valueOf(data);
+
+        for (int i = 0; i <= all.length(); i++) {
+            System.out.println((60 - i) + ": " + all.get(i));
+        }
 
         for (int offset = 0, bit = 0; bit < _bits.length; bit++) {
             final OptionalValueList bitSizes = _bits[bit].size.eval(env, enc);
@@ -49,10 +53,17 @@ public class Bits extends Token {
             final int bitSize = bitSizes.head.get().asNumeric().intValue();
 
             final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-            final long val = convert(all.get(all.length() - bitSize - offset, all.length() - offset));
+
+
+            final int start = all.length() - bitSize - offset + 1;
+            final int end = all.length() - offset + 1;
+            System.out.println("start: " + (60 - start) + " end: " + (60 - end));
+
+            final BitSet part = all.get(Math.max(0, start), end);
+            final long val = convert(part);
             buffer.putLong(val);
             System.out.println(val);
-            add(_bits[bit].name, newEnv, enc, buffer.array());
+            newEnv = add(_bits[bit].name, newEnv, enc, buffer.array());
             offset += bitSize;
         }
         return new ParseResult(true, newEnv);

--- a/core/src/main/java/io/parsingdata/metal/token/bits/Bits.java
+++ b/core/src/main/java/io/parsingdata/metal/token/bits/Bits.java
@@ -1,0 +1,72 @@
+package io.parsingdata.metal.token.bits;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.BitSet;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.OptionalValueList;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.token.Token;
+
+public class Bits extends Token {
+
+    private final ValueExpression _size;
+    private final Bit[] _bits;
+
+    public Bits(final String name, final ValueExpression size, final Bit[] bits) {
+        super(name, null); // TODO enc
+        _size = size;
+        _bits = bits;
+    }
+
+    @Override
+    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
+        final OptionalValueList sizes = _size.eval(env, enc);
+        if (sizes.size != 1 || !sizes.head.isPresent()) {
+            return new ParseResult(false, env);
+        }
+        // TODO: Handle value expression results as BigInteger (#16)
+        final int dataSize = sizes.head.get().asNumeric().intValue();
+        if (dataSize < 0) {
+            return new ParseResult(false, env);
+        }
+        final byte[] data = new byte[dataSize];
+        if (env.input.read(env.offset, data) != data.length) {
+            return new ParseResult(false, env);
+        }
+        final Environment newEnv = env;
+        final BitSet all = BitSet.valueOf(data);
+
+        for (int offset = 0, bit = 0; bit < _bits.length; bit++) {
+            final OptionalValueList bitSizes = _bits[bit].size.eval(env, enc);
+            if (bitSizes.size != 1 || !bitSizes.head.isPresent()) {
+                return new ParseResult(false, env);
+            }
+            final int bitSize = bitSizes.head.get().asNumeric().intValue();
+
+            final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+            final long val = convert(all.get(all.length() - bitSize - offset, all.length() - offset));
+            buffer.putLong(val);
+            System.out.println(val);
+            add(_bits[bit].name, newEnv, enc, buffer.array());
+            offset += bitSize;
+        }
+        return new ParseResult(true, newEnv);
+    }
+
+    public static long convert(final BitSet bits) {
+        long value = 0L;
+        for (int i = 0; i < bits.length(); ++i) {
+            value += bits.get(i) ? (1L << i) : 0L;
+        }
+        return value;
+    }
+
+    private Environment add(final String name, final Environment env, final Encoding enc, final byte[] value) {
+        return env.add(new ParseValue(name, this, env.offset, value, enc));
+    }
+}

--- a/core/src/test/java/io/parsingdata/metal/token/BitsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/BitsTest.java
@@ -38,6 +38,6 @@ public class BitsTest {
         final ParseGraph graph = result.environment.order;
 
         assertEquals(6, ByName.getValue(graph, "State"));
-        assertEquals(0x400000, ByName.getValue(graph, "Offset"));
+        assertEquals(4, ByName.getValue(graph, "Offset"));
     }
 }

--- a/core/src/test/java/io/parsingdata/metal/token/BitsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/BitsTest.java
@@ -8,7 +8,7 @@ import static io.parsingdata.metal.Shorthand.bits;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.eqNum;
 import static io.parsingdata.metal.Shorthand.expTrue;
-import static io.parsingdata.metal.util.EncodingFactory.le;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -33,11 +33,11 @@ public class BitsTest {
             bit("Reserved", con(17), eqNum(con(0))),
             bit("Offset", con(44), expTrue()));
 
-        final ParseResult result = bits.parse(env, le());
+        final ParseResult result = bits.parse(env, enc());
         assertTrue(result.succeeded);
         final ParseGraph graph = result.environment.order;
 
-        assertEquals(6, ByName.getValue(graph, "State"));
-        assertEquals(4, ByName.getValue(graph, "Offset"));
+        assertEquals(6, ByName.getValue(graph, "State").asNumeric().longValue());
+        assertEquals(4, ByName.getValue(graph, "Offset").asNumeric().intValue());
     }
 }

--- a/core/src/test/java/io/parsingdata/metal/token/BitsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/BitsTest.java
@@ -1,0 +1,43 @@
+package io.parsingdata.metal.token;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.bit;
+import static io.parsingdata.metal.Shorthand.bits;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.eqNum;
+import static io.parsingdata.metal.Shorthand.expTrue;
+import static io.parsingdata.metal.util.EncodingFactory.le;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.data.selection.ByName;
+import io.parsingdata.metal.util.InMemoryByteStream;
+
+public class BitsTest {
+
+    @Test
+    public void testBits() throws IOException {
+        final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES).putLong(0x400006);
+        final Environment env = new Environment(new InMemoryByteStream(buffer.array()));
+
+        final Token bits = bits("entry", con(8),
+            bit("State", con(3), expTrue()),
+            bit("Reserved", con(17), eqNum(con(0))),
+            bit("Offset", con(44), expTrue()));
+
+        final ParseResult result = bits.parse(env, le());
+        assertTrue(result.succeeded);
+        final ParseGraph graph = result.environment.order;
+
+        assertEquals(6, ByName.getValue(graph, "State"));
+        assertEquals(0x400000, ByName.getValue(graph, "Offset"));
+    }
+}


### PR DESCRIPTION
Working code, but intended as an idea for future implementation.

``` java
final Token bits = bits("entry", con(8), // read 8 bytes
    bit("State", con(3), expTrue()), // read 3 bits
    bit("Reserved", con(17), eqNum(con(0))), // read 17 bits, with predicate
    bit("Offset", con(44), expTrue())); // read 44 bits
```
