### PR TITLE
Make gpg-plugin user friendly, only run on profile 'release'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,23 @@
     <source-plugin.version>2.2.1</source-plugin.version>
   </properties>
 
+  <profiles>
+    <profile>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.skip>true</gpg.skip>
+      </properties>
+    </profile>
+    <profile>
+      <id>release</id>
+      <properties>
+        <gpg.skip>false</gpg.skip>
+      </properties>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
`mvn clean verify -P release` calls gpg, disabled by default.

Note that the gpg.skip can also be moved to the `<properties>` section so the `activeByDefault` profile can be removed, but I think this way it is more clear