### PR TITLE
Completed tasks for 5.0.0 release around testing, naming, style and conventions.

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -181,11 +181,11 @@ public final class Shorthand {
     public final static Reducer SUB_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return sub(left, right); } };
 
     public static byte[] toByteArray(final int... bytes) {
-        final byte[] out = new byte[bytes.length];
+        final byte[] outBytes = new byte[bytes.length];
         for (int i = 0; i < bytes.length; i++) {
-            out[i] = (byte) bytes[i];
+            outBytes[i] = (byte) bytes[i];
         }
-        return out;
+        return outBytes;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -179,6 +179,7 @@ public final class Shorthand {
     public final static Reducer MUL_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return mul(left, right); } };
     public final static Reducer CAT_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return cat(left, right); } };
     public final static Reducer SUB_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return sub(left, right); } };
+    public final static Reducer DIV_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return div(left, right); } };
 
     public static byte[] toByteArray(final int... bytes) {
         final byte[] outBytes = new byte[bytes.length];

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -29,23 +29,23 @@ public final class Util {
         return argument;
     }
 
-    public static <T>T[] checkContainsNoNulls(final T[] argument, final String name) {
-        checkNotNull(argument, name);
-        for (final T arg : argument) {
-            if (arg == null) { throw new IllegalArgumentException("Value in array " + name + " may not be null."); }
+    public static <T>T[] checkContainsNoNulls(final T[] arguments, final String name) {
+        checkNotNull(arguments, name);
+        for (final T argument : arguments) {
+            if (argument == null) { throw new IllegalArgumentException("Value in array " + name + " may not be null."); }
         }
-        return argument;
+        return arguments;
     }
 
     public static String tokensToString(final Token[] tokens) {
         checkNotNull(tokens, "tokens");
         if (tokens.length == 0) { return ""; }
-        final StringBuilder out = new StringBuilder();
+        final StringBuilder outString = new StringBuilder();
         for (int i = 0; i < tokens.length - 1; i++) {
-            out.append(tokens[i].toString());
-            out.append(", ");
+            outString.append(tokens[i].toString());
+            outString.append(", ");
         }
-        return out.append(tokens[tokens.length - 1]).toString();
+        return outString.append(tokens[tokens.length - 1]).toString();
     }
 
     public static String bytesToHexString(final byte[] bytes) {

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -22,7 +22,7 @@ public final class Util {
 
     private Util() {}
 
-    final private static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+    final private static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray(); // Private because array contents is mutable.
 
     public static <T>T checkNotNull(final T argument, final String name) {
         if (argument == null) { throw new IllegalArgumentException("Argument " + name + " may not be null."); }

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
@@ -20,6 +20,6 @@ import java.io.IOException;
 
 public interface ByteStream {
 
-    int read(final long offset, final byte[] data) throws IOException;
+    int read(long offset, byte[] data) throws IOException;
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/Environment.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Environment.java
@@ -67,8 +67,8 @@ public class Environment {
         return new Environment(order, input, newOffset, callbacks);
     }
 
-    public Environment add(final ParseRef parseRef) {
-        return new Environment(order.add(parseRef), input, offset, callbacks);
+    public Environment add(final ParseReference parseReference) {
+        return new Environment(order.add(parseReference), input, offset, callbacks);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/OptionalValueList.java
+++ b/core/src/main/java/io/parsingdata/metal/data/OptionalValueList.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal.data;
 
-import io.parsingdata.metal.expression.value.OptionalValue;
-
 import static io.parsingdata.metal.Util.checkNotNull;
+
+import io.parsingdata.metal.expression.value.OptionalValue;
 
 public class OptionalValueList {
 
@@ -46,7 +46,7 @@ public class OptionalValueList {
 
     public static OptionalValueList create(final ParseValueList list) {
         checkNotNull(list, "list");
-        if (list.isEmpty()) return OptionalValueList.EMPTY;
+        if (list.isEmpty()) { return OptionalValueList.EMPTY; }
         return create(list.tail).add(OptionalValue.of(list.head));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -32,8 +32,8 @@ public class ParseGraph implements ParseItem {
     public final long size;
 
     public static final Token NONE = new Token("NONE", null) {
-        @Override protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException { throw new IllegalStateException("This placeholder may not be invoked."); }
-        @Override public String toString() { return "None"; };
+        @Override protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException { throw new IllegalStateException("This placeholder may not be invoked."); }
+        @Override public String toString() { return "None"; }
     };
 
     public static final ParseGraph EMPTY = new ParseGraph(NONE);
@@ -64,7 +64,7 @@ public class ParseGraph implements ParseItem {
         return new ParseGraph(head, this, definition);
     }
 
-    public ParseGraph add(final ParseRef ref) {
+    public ParseGraph add(final ParseReference ref) {
         if (branched) { return new ParseGraph(head.asGraph().add(ref), tail, definition, true); }
         return new ParseGraph(ref, this, definition);
     }
@@ -93,18 +93,18 @@ public class ParseGraph implements ParseItem {
         if (isEmpty()) { return null; }
         if (head.isValue()) { return head.asValue(); }
         if (head.isGraph()) {
-            final ParseValue val = head.asGraph().current();
-            if (val != null) { return val; }
+            final ParseValue value = head.asGraph().current();
+            if (value != null) { return value; }
         }
         return tail.current(); // Ignore current if it's a reference (or an empty graph)
     }
 
     @Override public boolean isValue() { return false; }
     @Override public boolean isGraph() { return true; }
-    @Override public boolean isRef() { return false; }
+    @Override public boolean isReference() { return false; }
     @Override public ParseValue asValue() { throw new UnsupportedOperationException("Cannot convert ParseGraph to ParseValue."); }
     @Override public ParseGraph asGraph() { return this; }
-    @Override public ParseRef asRef() { throw new UnsupportedOperationException("Cannot convert ParseGraph to ParseRef."); }
+    @Override public ParseReference asReference() { throw new UnsupportedOperationException("Cannot convert ParseGraph to ParseReference."); }
     @Override public Token getDefinition() { return definition; }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -64,9 +64,9 @@ public class ParseGraph implements ParseItem {
         return new ParseGraph(head, this, definition);
     }
 
-    public ParseGraph add(final ParseReference ref) {
-        if (branched) { return new ParseGraph(head.asGraph().add(ref), tail, definition, true); }
-        return new ParseGraph(ref, this, definition);
+    public ParseGraph add(final ParseReference parseReference) {
+        if (branched) { return new ParseGraph(head.asGraph().add(parseReference), tail, definition, true); }
+        return new ParseGraph(parseReference, this, definition);
     }
 
     ParseGraph addBranch(final Token definition) {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseItem.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseItem.java
@@ -22,9 +22,9 @@ public interface ParseItem {
 
     boolean isValue();
     boolean isGraph();
-    boolean isRef();
+    boolean isReference();
     ParseValue asValue();
-    ParseRef asRef();
+    ParseReference asReference();
     ParseGraph asGraph();
     Token getDefinition();
 

--- a/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
@@ -22,12 +22,12 @@ import static io.parsingdata.metal.data.selection.ByToken.getAllRoots;
 
 import io.parsingdata.metal.token.Token;
 
-public class ParseRef implements ParseItem {
+public class ParseReference implements ParseItem {
 
     public final long location;
     public final Token definition;
 
-    public ParseRef(final long location, final Token definition) {
+    public ParseReference(final long location, final Token definition) {
         this.location = location;
         this.definition = checkNotNull(definition, "definition");
     }
@@ -38,10 +38,10 @@ public class ParseRef implements ParseItem {
 
     @Override public boolean isValue() { return false; }
     @Override public boolean isGraph() { return false; }
-    @Override public boolean isRef() { return true; }
-    @Override public ParseValue asValue() { throw new UnsupportedOperationException("Cannot convert ParseRef to ParseValue."); }
-    @Override public ParseGraph asGraph() { throw new UnsupportedOperationException("Cannot convert ParseRef to ParseGraph."); }
-    @Override public ParseRef asRef() { return this; }
+    @Override public boolean isReference() { return true; }
+    @Override public ParseValue asValue() { throw new UnsupportedOperationException("Cannot convert ParseReference to ParseValue."); }
+    @Override public ParseGraph asGraph() { throw new UnsupportedOperationException("Cannot convert ParseReference to ParseGraph."); }
+    @Override public ParseReference asReference() { return this; }
     @Override public Token getDefinition() { return definition; }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
@@ -16,11 +16,11 @@
 
 package io.parsingdata.metal.data;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.token.Token;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public class ParseValue extends Value implements ParseItem {
 
@@ -28,8 +28,8 @@ public class ParseValue extends Value implements ParseItem {
     public Token definition;
     public final long offset;
 
-    public ParseValue(final String name, final Token definition, final long offset, final byte[] data, final Encoding enc) {
-        super(data, enc);
+    public ParseValue(final String name, final Token definition, final long offset, final byte[] data, final Encoding encoding) {
+        super(data, encoding);
         this.name = checkNotNull(name, "name");
         this.definition = checkNotNull(definition, "definition");
         this.offset = offset;
@@ -45,10 +45,10 @@ public class ParseValue extends Value implements ParseItem {
 
     @Override public boolean isValue() { return true; }
     @Override public boolean isGraph() { return false; }
-    @Override public boolean isRef() { return false; }
+    @Override public boolean isReference() { return false; }
     @Override public ParseValue asValue() { return this; }
     @Override public ParseGraph asGraph() { throw new UnsupportedOperationException("Cannot convert ParseValue to ParseGraph."); }
-    @Override public ParseRef asRef() { throw new UnsupportedOperationException("Cannot convert ParseValue to ParseRef."); }
+    @Override public ParseReference asReference() { throw new UnsupportedOperationException("Cannot convert ParseValue to ParseReference."); }
     @Override public Token getDefinition() { return definition; }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ParseValueList.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseValueList.java
@@ -64,16 +64,16 @@ public class ParseValueList {
 
     public ParseValueList getAll(final String name) {
         if (isEmpty()) { return this; }
-        final ParseValueList t = tail.getAll(name);
-        if (head.matches(name)) { return t.add(head); }
-        else { return t; }
+        final ParseValueList tailList = tail.getAll(name);
+        if (head.matches(name)) { return tailList.add(head); }
+        else { return tailList; }
     }
 
     public ParseValueList getValuesSincePrefix(final ParseValue prefix) {
         if (isEmpty()) { return this; }
         if (head == prefix) { return EMPTY; }
-        final ParseValueList t = tail.getValuesSincePrefix(prefix);
-        return t.add(head);
+        final ParseValueList tailList = tail.getValuesSincePrefix(prefix);
+        return tailList.add(head);
     }
 
     public boolean isEmpty() {

--- a/core/src/main/java/io/parsingdata/metal/data/callback/Callback.java
+++ b/core/src/main/java/io/parsingdata/metal/data/callback/Callback.java
@@ -21,6 +21,6 @@ import io.parsingdata.metal.token.Token;
 
 public interface Callback {
 
-    void handle(final Token token, final ParseResult result);
+    void handle(Token token, ParseResult result);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
@@ -16,12 +16,12 @@
 
 package io.parsingdata.metal.data.selection;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.ParseValueList;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public final class ByName {
 
@@ -39,8 +39,8 @@ public final class ByName {
         final ParseItem head = graph.head;
         if (head.isValue() && head.asValue().matches(name)) { return head.asValue(); }
         if (head.isGraph()) {
-            final ParseValue val = getValue(head.asGraph(), name);
-            if (val != null) { return val; }
+            final ParseValue value = getValue(head.asGraph(), name);
+            if (value != null) { return value; }
         }
         return getValue(graph.tail, name);
     }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
@@ -29,24 +29,24 @@ public final class ByOffset {
 
     private ByOffset() {}
 
-    public static boolean hasRootAtOffset(final ParseGraph graph, final Token definition, final long ref) {
-        return findItemAtOffset(getAllRoots(graph, definition), ref) != null;
+    public static boolean hasRootAtOffset(final ParseGraph graph, final Token definition, final long offset) {
+        return findItemAtOffset(getAllRoots(graph, definition), offset) != null;
     }
 
-    public static ParseItem findItemAtOffset(final ParseItemList items, final long ref) {
+    public static ParseItem findItemAtOffset(final ParseItemList items, final long offset) {
         checkNotNull(items, "items");
         if (items.isEmpty()) { return null; }
         final ParseItem head = items.head;
-        if (head.isValue() && head.asValue().getOffset() == ref) {
+        if (head.isValue() && head.asValue().getOffset() == offset) {
             return head;
         }
         if (head.isGraph()) {
-            final ParseValue val = getLowestOffsetValue(head.asGraph(), null);
-            if (val != null && val.getOffset() == ref) {
+            final ParseValue value = getLowestOffsetValue(head.asGraph(), null);
+            if (value != null && value.getOffset() == offset) {
                 return head;
             }
         }
-        return findItemAtOffset(items.tail, ref);
+        return findItemAtOffset(items.tail, offset);
     }
 
     private static ParseValue getLowestOffsetValue(final ParseGraph graph, final ParseValue lowest) {

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
@@ -54,7 +54,7 @@ public final class ByToken {
         final ParseItemList results = graph.definition == definition ? tailResults.add(graph) : tailResults;
         final ParseItem head = graph.head;
         if (head.isValue() && head.asValue().definition == definition) { return results.add(head); }
-        if (head.isRef() && head.asRef().definition == definition) { return results.add(head); }
+        if (head.isReference() && head.asReference().definition == definition) { return results.add(head); }
         if (head.isGraph()) { return results.add(getAllRecursive(head.asGraph(), definition)); }
         return results;
     }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByType.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByType.java
@@ -26,16 +26,16 @@ public final class ByType {
 
     private ByType() {}
 
-    public static ParseItemList getRefs(final ParseGraph graph) {
+    public static ParseItemList getReferences(final ParseGraph graph) {
         checkNotNull(graph, "graph");
-        return getRefs(graph, graph);
+        return getReferences(graph, graph);
     }
 
-    private static ParseItemList getRefs(final ParseGraph graph, final ParseGraph root) {
+    private static ParseItemList getReferences(final ParseGraph graph, final ParseGraph root) {
         if (graph.isEmpty()) { return ParseItemList.EMPTY; }
         final ParseItem head = graph.head;
-        if (head.isRef() && head.asRef().resolve(root) == null) { throw new IllegalStateException("A ref must point to an existing graph."); }
-        return getRefs(graph.tail, root).add(head.isGraph() ? getRefs(head.asGraph(), root) : (head.isRef() ? ParseItemList.EMPTY.add(head.asRef().resolve(root)) : ParseItemList.EMPTY));
+        if (head.isReference() && head.asReference().resolve(root) == null) { throw new IllegalStateException("A ref must point to an existing graph."); }
+        return getReferences(graph.tail, root).add(head.isGraph() ? getReferences(head.asGraph(), root) : (head.isReference() ? ParseItemList.EMPTY.add(head.asReference().resolve(root)) : ParseItemList.EMPTY));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/encoding/ByteOrder.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/ByteOrder.java
@@ -18,14 +18,14 @@ package io.parsingdata.metal.encoding;
 
 public enum ByteOrder {
 
-    BIG_ENDIAN { public byte[] apply(final byte[] b) { return b.clone(); } },
-    LITTLE_ENDIAN { public byte[] apply(final byte[] b) {
-        final byte[] o = b.clone();
-        for (int i = 0; i < b.length; i++) {
-            o[i] = b[(b.length-1)-i];
+    BIG_ENDIAN { public byte[] apply(final byte[] bytes) { return bytes.clone(); } },
+    LITTLE_ENDIAN { public byte[] apply(final byte[] bytes) {
+        final byte[] output = bytes.clone();
+        for (int i = 0; i < bytes.length; i++) {
+            output[i] = bytes[(bytes.length-1)-i];
         }
-        return o;
+        return output;
     } };
 
-    public abstract byte[] apply(final byte[] b);
+    public abstract byte[] apply(final byte[] bytes);
 }

--- a/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
@@ -51,10 +51,6 @@ public class Encoding {
         this.byteOrder = byteOrder;
     }
 
-    public boolean isSigned() {
-        return sign == Sign.SIGNED;
-    }
-
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + sign + "," + charset + "," + byteOrder + ")";

--- a/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
@@ -21,13 +21,13 @@ import java.nio.charset.StandardCharsets;
 
 public class Encoding {
 
-    private static final Sign DEFAULT_SIGNED = Sign.UNSIGNED;
-    private static final Charset DEFAULT_CHARSET = StandardCharsets.US_ASCII;
-    private static final ByteOrder DEFAULT_BYTE_ORDER = ByteOrder.BIG_ENDIAN;
+    public static final Sign DEFAULT_SIGNED = Sign.UNSIGNED;
+    public static final Charset DEFAULT_CHARSET = StandardCharsets.US_ASCII;
+    public static final ByteOrder DEFAULT_BYTE_ORDER = ByteOrder.BIG_ENDIAN;
 
-    private final Sign sign;
-    private final Charset charset;
-    private final ByteOrder byteOrder;
+    public final Sign sign;
+    public final Charset charset;
+    public final ByteOrder byteOrder;
 
     public Encoding() {
         this(DEFAULT_SIGNED, DEFAULT_CHARSET, DEFAULT_BYTE_ORDER);
@@ -51,20 +51,8 @@ public class Encoding {
         this.byteOrder = byteOrder;
     }
 
-    public Sign getSign() {
-        return sign;
-    }
-
     public boolean isSigned() {
         return sign == Sign.SIGNED;
-    }
-
-    public Charset getCharset() {
-        return charset;
-    }
-
-    public ByteOrder getByteOrder() {
-        return byteOrder;
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
@@ -25,9 +25,9 @@ public class Encoding {
     private static final Charset DEFAULT_CHARSET = StandardCharsets.US_ASCII;
     private static final ByteOrder DEFAULT_BYTE_ORDER = ByteOrder.BIG_ENDIAN;
 
-    private final Sign _sign;
-    private final Charset _charset;
-    private final ByteOrder _byteOrder;
+    private final Sign sign;
+    private final Charset charset;
+    private final ByteOrder byteOrder;
 
     public Encoding() {
         this(DEFAULT_SIGNED, DEFAULT_CHARSET, DEFAULT_BYTE_ORDER);
@@ -46,29 +46,29 @@ public class Encoding {
     }
 
     public Encoding(final Sign sign, final Charset charset, final ByteOrder byteOrder) {
-        _sign = sign;
-        _charset = charset;
-        _byteOrder = byteOrder;
+        this.sign = sign;
+        this.charset = charset;
+        this.byteOrder = byteOrder;
     }
 
     public Sign getSign() {
-        return _sign;
+        return sign;
     }
 
     public boolean isSigned() {
-        return _sign == Sign.SIGNED;
+        return sign == Sign.SIGNED;
     }
 
     public Charset getCharset() {
-        return _charset;
+        return charset;
     }
 
     public ByteOrder getByteOrder() {
-        return _byteOrder;
+        return byteOrder;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _sign + "," + _charset + "," + _byteOrder + ")";
+        return getClass().getSimpleName() + "(" + sign + "," + charset + "," + byteOrder + ")";
     }
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/Expression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/Expression.java
@@ -21,6 +21,6 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public interface Expression {
 
-    boolean eval(final Environment env, final Encoding enc);
+    boolean eval(Environment env, Encoding enc);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/Expression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/Expression.java
@@ -21,6 +21,6 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public interface Expression {
 
-    boolean eval(Environment env, Encoding enc);
+    boolean eval(Environment environment, Encoding encoding);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/True.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/True.java
@@ -22,7 +22,7 @@ import io.parsingdata.metal.encoding.Encoding;
 public class True implements Expression {
 
     @Override
-    public boolean eval(final Environment env, final Encoding enc) {
+    public boolean eval(final Environment environment, final Encoding encoding) {
         return true;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.comparison;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
@@ -23,8 +25,6 @@ import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.value.OptionalValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public abstract class ComparisonExpression implements Expression {
 
@@ -37,12 +37,12 @@ public abstract class ComparisonExpression implements Expression {
     }
 
     @Override
-    public boolean eval(final Environment env, final Encoding enc) {
-        final OptionalValueList ovl = value == null ? OptionalValueList.create(OptionalValue.of(env.order.current())) : value.eval(env, enc);
-        if (ovl.isEmpty()) { return false; }
-        final OptionalValueList opl = predicate.eval(env, enc);
-        if (ovl.size != opl.size) { return false; }
-        return compare(ovl, opl);
+    public boolean eval(final Environment environment, final Encoding encoding) {
+        final OptionalValueList values = value == null ? OptionalValueList.create(OptionalValue.of(environment.order.current())) : value.eval(environment, encoding);
+        if (values.isEmpty()) { return false; }
+        final OptionalValueList predicates = predicate.eval(environment, encoding);
+        if (values.size != predicates.size) { return false; }
+        return compare(values, predicates);
     }
 
     private boolean compare(final OptionalValueList currents, final OptionalValueList predicates) {

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
@@ -27,11 +27,11 @@ public class Eq extends ComparisonExpression {
 
     @Override
     public boolean compare(final Value left, final Value right) {
-        final byte[] l = left.getValue();
-        final byte[] r = right.getValue();
-        if (l.length != r.length) { return false; }
-        for (int i = 0; i < l.length; i++) {
-            if (l[i] != r[i]) { return false; }
+        final byte[] leftBytes = left.getValue();
+        final byte[] rightBytes = right.getValue();
+        if (leftBytes.length != rightBytes.length) { return false; }
+        for (int i = 0; i < leftBytes.length; i++) {
+            if (leftBytes[i] != rightBytes[i]) { return false; }
         }
         return true;
     }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/And.java
@@ -27,8 +27,8 @@ public class And extends BinaryLogicalExpression {
     }
 
     @Override
-    public boolean eval(final Environment env, final Encoding enc) {
-        return left.eval(env, enc) && right.eval(env, enc);
+    public boolean eval(final Environment environment, final Encoding encoding) {
+        return left.eval(environment, encoding) && right.eval(environment, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/Not.java
@@ -27,8 +27,8 @@ public class Not extends UnaryLogicalExpression {
     }
 
     @Override
-    public boolean eval(final Environment env, final Encoding enc) {
-        return !operand.eval(env, enc);
+    public boolean eval(final Environment environment, final Encoding encoding) {
+        return !operand.eval(environment, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/Or.java
@@ -27,8 +27,8 @@ public class Or extends BinaryLogicalExpression {
     }
 
     @Override
-    public boolean eval(final Environment env, final Encoding enc) {
-        return left.eval(env, enc) || right.eval(env, enc);
+    public boolean eval(final Environment environment, final Encoding encoding) {
+        return left.eval(environment, encoding) || right.eval(environment, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -16,11 +16,11 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 /**
  * Base class for ValueExpressions with two operands.
@@ -43,14 +43,14 @@ public abstract class BinaryValueExpression implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return evalLists(left.eval(env, enc), right.eval(env, enc), env, enc);
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return evalLists(left.eval(environment, encoding), right.eval(environment, encoding), environment, encoding);
     }
 
-    private OptionalValueList evalLists(final OptionalValueList lvl, final OptionalValueList rvl, final Environment env, final Encoding enc) {
-        if (lvl.isEmpty()) { return makeListWithEmpty(rvl.size); }
-        if (rvl.isEmpty()) { return makeListWithEmpty(lvl.size); }
-        return evalLists(lvl.tail, rvl.tail, env, enc).add(eval(lvl.head, rvl.head, env, enc));
+    private OptionalValueList evalLists(final OptionalValueList leftValues, final OptionalValueList rightValues, final Environment environment, final Encoding encoding) {
+        if (leftValues.isEmpty()) { return makeListWithEmpty(rightValues.size); }
+        if (rightValues.isEmpty()) { return makeListWithEmpty(leftValues.size); }
+        return evalLists(leftValues.tail, rightValues.tail, environment, encoding).add(eval(leftValues.head, rightValues.head, environment, encoding));
     }
 
     private OptionalValueList makeListWithEmpty(final long size) {
@@ -58,12 +58,12 @@ public abstract class BinaryValueExpression implements ValueExpression {
         return makeListWithEmpty(size - 1).add(OptionalValue.empty());
     }
 
-    private OptionalValue eval(final OptionalValue left, final OptionalValue right, final Environment env, final Encoding enc) {
+    private OptionalValue eval(final OptionalValue left, final OptionalValue right, final Environment environment, final Encoding encoding) {
         if (!left.isPresent() || !right.isPresent()) { return OptionalValue.empty(); }
-        return eval(left.get(), right.get(), env, enc);
+        return eval(left.get(), right.get(), environment, encoding);
     }
 
-    public abstract OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc);
+    public abstract OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding);
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -26,13 +26,13 @@ public class Cat extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
-        final byte[] lb = left.getValue();
-        final byte[] rb = right.getValue();
-        final byte[] res = new byte[lb.length + rb.length];
-        System.arraycopy(lb, 0, res, 0, lb.length);
-        System.arraycopy(rb, 0, res, lb.length, rb.length);
-        return OptionalValue.of(new Value(res, enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
+        final byte[] leftBytes = left.getValue();
+        final byte[] rightBytes = right.getValue();
+        final byte[] concatenatedBytes = new byte[leftBytes.length + rightBytes.length];
+        System.arraycopy(leftBytes, 0, concatenatedBytes, 0, leftBytes.length);
+        System.arraycopy(rightBytes, 0, concatenatedBytes, leftBytes.length, rightBytes.length);
+        return OptionalValue.of(new Value(concatenatedBytes, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -29,7 +29,7 @@ public class Const implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
         return OptionalValueList.create(OptionalValue.of(value));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
@@ -39,7 +39,7 @@ public final class ConstantFactory {
     }
 
     public static Value createFromString(final String value, final Encoding encoding) {
-        return new Value(value.getBytes(encoding.getCharset()), encoding);
+        return new Value(value.getBytes(encoding.charset), encoding);
     }
 
     public static Value createFromBitSet(final BitSet value, final int minSize, final Encoding encoding) {
@@ -50,7 +50,7 @@ public final class ConstantFactory {
     }
 
     private static Encoding setToBigEndian(final Encoding encoding) {
-        return new Encoding(encoding.getSign(), encoding.getCharset(), ByteOrder.BIG_ENDIAN);
+        return new Encoding(encoding.sign, encoding.charset, ByteOrder.BIG_ENDIAN);
     }
 
     private static byte[] compact(final byte[] data, final boolean signed) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
@@ -26,42 +26,42 @@ public final class ConstantFactory {
 
     private ConstantFactory() {}
 
-    public static Value createFromBytes(final byte[] value, final Encoding enc) {
-        return new Value(value, enc);
+    public static Value createFromBytes(final byte[] value, final Encoding encoding) {
+        return new Value(value, encoding);
     }
 
-    public static Value createFromNumeric(final BigInteger value, final Encoding enc) {
-        return createFromBytes(compact(value.toByteArray(), enc.isSigned()), setToBE(enc));
+    public static Value createFromNumeric(final BigInteger value, final Encoding encoding) {
+        return createFromBytes(compact(value.toByteArray(), encoding.isSigned()), setToBigEndian(encoding));
     }
 
-    public static Value createFromNumeric(final long value, final Encoding enc) {
-        return createFromNumeric(BigInteger.valueOf(value), enc);
+    public static Value createFromNumeric(final long value, final Encoding encoding) {
+        return createFromNumeric(BigInteger.valueOf(value), encoding);
     }
 
-    public static Value createFromString(final String value, final Encoding enc) {
-        return new Value(value.getBytes(enc.getCharset()), enc);
+    public static Value createFromString(final String value, final Encoding encoding) {
+        return new Value(value.getBytes(encoding.getCharset()), encoding);
     }
 
-    public static Value createFromBitSet(final BitSet value, final int minSize, final Encoding enc) {
+    public static Value createFromBitSet(final BitSet value, final int minSize, final Encoding encoding) {
         final byte[] bytes = ByteOrder.LITTLE_ENDIAN.apply(value.toByteArray());
-        final byte[] out = new byte[Math.max(minSize, bytes.length)];
-        System.arraycopy(bytes, 0, out, out.length - bytes.length, bytes.length);
-        return new Value(out, setToBE(enc));
+        final byte[] outBytes = new byte[Math.max(minSize, bytes.length)];
+        System.arraycopy(bytes, 0, outBytes, outBytes.length - bytes.length, bytes.length);
+        return new Value(outBytes, setToBigEndian(encoding));
     }
 
-    private static Encoding setToBE(final Encoding enc) {
-        return new Encoding(enc.getSign(), enc.getCharset(), ByteOrder.BIG_ENDIAN);
+    private static Encoding setToBigEndian(final Encoding encoding) {
+        return new Encoding(encoding.getSign(), encoding.getCharset(), ByteOrder.BIG_ENDIAN);
     }
 
     private static byte[] compact(final byte[] data, final boolean signed) {
         if (signed) { return data; }
         if (data.length < 2) { return data; }
         // strip leading zero bytes
-        int i = 0;
-        for (; i < data.length && data[i] == 0; i++);
-        final byte[] out = new byte[data.length - i];
-        System.arraycopy(data, i, out, 0, out.length);
-        return out;
+        int zeroCount = 0;
+        for (; zeroCount < data.length && data[zeroCount] == 0; zeroCount++);
+        final byte[] outBytes = new byte[data.length - zeroCount];
+        System.arraycopy(data, zeroCount, outBytes, 0, outBytes.length);
+        return outBytes;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
@@ -56,12 +56,13 @@ public final class ConstantFactory {
     private static byte[] compact(final byte[] data, final boolean signed) {
         if (signed) { return data; }
         if (data.length < 2) { return data; }
-        // strip leading zero bytes
-        int zeroCount = 0;
-        for (; zeroCount < data.length && data[zeroCount] == 0; zeroCount++);
-        final byte[] outBytes = new byte[data.length - zeroCount];
-        System.arraycopy(data, zeroCount, outBytes, 0, outBytes.length);
-        return outBytes;
+        // Strip possible leading zero byte.
+        if (data[0] == 0) {
+            final byte[] outBytes = new byte[data.length - 1];
+            System.arraycopy(data, 1, outBytes, 0, outBytes.length);
+            return outBytes;
+        }
+        return data;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
@@ -21,6 +21,7 @@ import java.util.BitSet;
 
 import io.parsingdata.metal.encoding.ByteOrder;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.encoding.Sign;
 
 public final class ConstantFactory {
 
@@ -31,7 +32,7 @@ public final class ConstantFactory {
     }
 
     public static Value createFromNumeric(final BigInteger value, final Encoding encoding) {
-        return createFromBytes(compact(value.toByteArray(), encoding.isSigned()), setToBigEndian(encoding));
+        return createFromBytes(compact(value.toByteArray(), encoding.sign == Sign.SIGNED), setToBigEndian(encoding));
     }
 
     public static Value createFromNumeric(final long value, final Encoding encoding) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -16,11 +16,11 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 /**
  * Expression for the 'elvis operator': <pre>?:</pre>.
@@ -48,14 +48,14 @@ public class Elvis implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return eval(left.eval(env, enc), right.eval(env, enc));
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return eval(left.eval(environment, encoding), right.eval(environment, encoding));
     }
 
-    private OptionalValueList eval(final OptionalValueList llist, final OptionalValueList rlist) {
-        if (llist.isEmpty()) { return rlist; }
-        if (rlist.isEmpty()) { return llist; }
-        return eval(llist.tail, rlist.tail).add(llist.head.isPresent() ? llist.head : rlist.head);
+    private OptionalValueList eval(final OptionalValueList leftValues, final OptionalValueList rightValues) {
+        if (leftValues.isEmpty()) { return rightValues; }
+        if (rightValues.isEmpty()) { return leftValues; }
+        return eval(leftValues.tail, rightValues.tail).add(leftValues.head.isPresent() ? leftValues.head : rightValues.head);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
@@ -16,12 +16,12 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
-
-import static io.parsingdata.metal.Shorthand.con;
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public class FoldLeft implements ValueExpression {
 
@@ -36,30 +36,30 @@ public class FoldLeft implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList init = initial != null ? initial.eval(env, enc) : OptionalValueList.EMPTY;
-        if (init.size > 1) {
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        final OptionalValueList initial = this.initial != null ? this.initial.eval(environment, encoding) : OptionalValueList.EMPTY;
+        if (initial.size > 1) {
             return OptionalValueList.EMPTY;
         }
-        final OptionalValueList values = this.values.eval(env, enc).reverse();
+        final OptionalValueList values = this.values.eval(environment, encoding).reverse();
         if (values.isEmpty() || values.containsEmpty()) {
-            return init;
+            return initial;
         }
-        if (!init.isEmpty()) {
-            return OptionalValueList.create(fold(env, enc, reducer, init.head, values));
+        if (!initial.isEmpty()) {
+            return OptionalValueList.create(fold(environment, encoding, reducer, initial.head, values));
         }
-        return OptionalValueList.create(fold(env, enc, reducer, values.head, values.tail));
+        return OptionalValueList.create(fold(environment, encoding, reducer, values.head, values.tail));
     }
 
-    private OptionalValue fold(final Environment env, final Encoding enc, final Reducer reducer, final OptionalValue head, final OptionalValueList tail) {
+    private OptionalValue fold(final Environment environment, final Encoding encoding, final Reducer reducer, final OptionalValue head, final OptionalValueList tail) {
         if (!head.isPresent() || tail.isEmpty()) {
             return head;
         }
-        final OptionalValueList reducedValue = reducer.reduce(con(head.get()), con(tail.head.get())).eval(env, enc);
+        final OptionalValueList reducedValue = reducer.reduce(con(head.get()), con(tail.head.get())).eval(environment, encoding);
         if (reducedValue.size != 1) {
             throw new IllegalStateException("Reducer must yield a single value.");
         }
-        return fold(env, enc, reducer, reducedValue.head, tail.tail);
+        return fold(environment, encoding, reducer, reducedValue.head, tail.tail);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
@@ -16,12 +16,12 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
-
-import static io.parsingdata.metal.Shorthand.con;
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public class FoldRight implements ValueExpression {
 
@@ -36,30 +36,30 @@ public class FoldRight implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList init = initial != null ? initial.eval(env, enc) : OptionalValueList.EMPTY;
-        if (init.size > 1) {
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        final OptionalValueList initial = this.initial != null ? this.initial.eval(environment, encoding) : OptionalValueList.EMPTY;
+        if (initial.size > 1) {
             return OptionalValueList.EMPTY;
         }
-        final OptionalValueList values = this.values.eval(env, enc);
+        final OptionalValueList values = this.values.eval(environment, encoding);
         if (values.isEmpty() || values.containsEmpty()) {
-            return init;
+            return initial;
         }
-        if (!init.isEmpty()) {
-            return OptionalValueList.create(fold(env, enc, reducer, init.head, values));
+        if (!initial.isEmpty()) {
+            return OptionalValueList.create(fold(environment, encoding, reducer, initial.head, values));
         }
-        return OptionalValueList.create(fold(env, enc, reducer, values.head, values.tail));
+        return OptionalValueList.create(fold(environment, encoding, reducer, values.head, values.tail));
     }
 
-    private OptionalValue fold(final Environment env, final Encoding enc, final Reducer reducer, final OptionalValue head, final OptionalValueList tail) {
+    private OptionalValue fold(final Environment environment, final Encoding encoding, final Reducer reducer, final OptionalValue head, final OptionalValueList tail) {
         if (!head.isPresent() || tail.isEmpty()) {
             return head;
         }
-        final OptionalValueList reducedValue = reducer.reduce(con(tail.head.get()), con(head.get())).eval(env, enc);
+        final OptionalValueList reducedValue = reducer.reduce(con(tail.head.get()), con(head.get())).eval(environment, encoding);
         if (reducedValue.size != 1) {
             throw new IllegalStateException("Reducer must yield a single value.");
         }
-        return fold(env, enc, reducer, reducedValue.head, tail.tail);
+        return fold(environment, encoding, reducer, reducedValue.head, tail.tail);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/OptionalValue.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/OptionalValue.java
@@ -20,7 +20,7 @@ import java.util.NoSuchElementException;
 
 public class OptionalValue {
 
-    private final Value value;
+    private final Value value; // Private because access is explicitly guarded.
 
     private OptionalValue(final Value value) {
         this.value = value;

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reducer.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reducer.java
@@ -18,6 +18,6 @@ package io.parsingdata.metal.expression.value;
 
 public interface Reducer {
 
-    ValueExpression reduce(final ValueExpression left, final ValueExpression right);
+    ValueExpression reduce(ValueExpression left, ValueExpression right);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -16,11 +16,11 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public abstract class UnaryValueExpression implements ValueExpression {
 
@@ -31,16 +31,16 @@ public abstract class UnaryValueExpression implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return eval(operand.eval(env, enc), env, enc);
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return eval(operand.eval(environment, encoding), environment, encoding);
     }
 
-    private OptionalValueList eval(final OptionalValueList vl, final Environment env, final Encoding enc) {
-        if (vl.isEmpty()) { return vl; }
-        return eval(vl.tail, env, enc).add(vl.head.isPresent() ? eval(vl.head.get(), env, enc) : vl.head);
+    private OptionalValueList eval(final OptionalValueList values, final Environment environment, final Encoding encoding) {
+        if (values.isEmpty()) { return values; }
+        return eval(values.tail, environment, encoding).add(values.head.isPresent() ? eval(values.head.get(), environment, encoding) : values.head);
     }
 
-    public abstract OptionalValue eval(final Value value, final Environment env, final Encoding enc);
+    public abstract OptionalValue eval(final Value value, final Environment environment, final Encoding encoding);
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
@@ -16,23 +16,23 @@
 
 package io.parsingdata.metal.expression.value;
 
-import io.parsingdata.metal.Util;
-import io.parsingdata.metal.encoding.ByteOrder;
-import io.parsingdata.metal.encoding.Encoding;
+import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.math.BigInteger;
 import java.util.BitSet;
 
-import static io.parsingdata.metal.Util.checkNotNull;
+import io.parsingdata.metal.Util;
+import io.parsingdata.metal.encoding.ByteOrder;
+import io.parsingdata.metal.encoding.Encoding;
 
 public class Value {
 
     private final byte[] data; // Private because array content is mutable.
-    public final Encoding enc;
+    public final Encoding encoding;
 
-    public Value(final byte[] data, final Encoding enc) {
+    public Value(final byte[] data, final Encoding encoding) {
         this.data = data.clone();
-        this.enc = checkNotNull(enc, "enc");
+        this.encoding = checkNotNull(encoding, "encoding");
     }
 
     public byte[] getValue() {
@@ -40,20 +40,20 @@ public class Value {
     }
 
     public BigInteger asNumeric() {
-        return enc.isSigned() ? new BigInteger(enc.getByteOrder().apply(data))
-                              : new BigInteger(1, enc.getByteOrder().apply(data));
+        return encoding.isSigned() ? new BigInteger(encoding.getByteOrder().apply(data))
+                                   : new BigInteger(1, encoding.getByteOrder().apply(data));
     }
 
     public String asString() {
-        return new String(data, enc.getCharset());
+        return new String(data, encoding.getCharset());
     }
 
     public BitSet asBitSet() {
-        return BitSet.valueOf(enc.getByteOrder() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN.apply(data) : data);
+        return BitSet.valueOf(encoding.getByteOrder() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN.apply(data) : data);
     }
 
-    public OptionalValue operation(final ValueOperation op) {
-        return op.execute(this);
+    public OptionalValue operation(final ValueOperation operation) {
+        return operation.execute(this);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
@@ -27,7 +27,7 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public class Value {
 
-    private final byte[] data; // Private because array content is mutable.
+    private final byte[] data; // Private because array contents is mutable.
     public final Encoding encoding;
 
     public Value(final byte[] data, final Encoding encoding) {
@@ -40,16 +40,16 @@ public class Value {
     }
 
     public BigInteger asNumeric() {
-        return encoding.isSigned() ? new BigInteger(encoding.getByteOrder().apply(data))
-                                   : new BigInteger(1, encoding.getByteOrder().apply(data));
+        return encoding.isSigned() ? new BigInteger(encoding.byteOrder.apply(data))
+                                   : new BigInteger(1, encoding.byteOrder.apply(data));
     }
 
     public String asString() {
-        return new String(data, encoding.getCharset());
+        return new String(data, encoding.charset);
     }
 
     public BitSet asBitSet() {
-        return BitSet.valueOf(encoding.getByteOrder() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN.apply(data) : data);
+        return BitSet.valueOf(encoding.byteOrder == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN.apply(data) : data);
     }
 
     public OptionalValue operation(final ValueOperation operation) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
@@ -24,6 +24,7 @@ import java.util.BitSet;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.encoding.ByteOrder;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.encoding.Sign;
 
 public class Value {
 
@@ -40,8 +41,8 @@ public class Value {
     }
 
     public BigInteger asNumeric() {
-        return encoding.isSigned() ? new BigInteger(encoding.byteOrder.apply(data))
-                                   : new BigInteger(1, encoding.byteOrder.apply(data));
+        return encoding.sign == Sign.SIGNED ? new BigInteger(encoding.byteOrder.apply(data))
+                                            : new BigInteger(1, encoding.byteOrder.apply(data));
     }
 
     public String asString() {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
@@ -22,6 +22,6 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public interface ValueExpression {
 
-    OptionalValueList eval(final Environment env, final Encoding enc);
+    OptionalValueList eval(Environment env, Encoding enc);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
@@ -22,6 +22,6 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public interface ValueExpression {
 
-    OptionalValueList eval(Environment env, Encoding enc);
+    OptionalValueList eval(Environment environment, Encoding encoding);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ValueOperation.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ValueOperation.java
@@ -18,6 +18,6 @@ package io.parsingdata.metal.expression.value;
 
 public interface ValueOperation {
 
-    OptionalValue execute(final Value value);
+    OptionalValue execute(Value value);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
@@ -31,8 +31,8 @@ public class Add extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().add(right.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().add(right.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
@@ -16,11 +16,15 @@
 
 package io.parsingdata.metal.expression.value.arithmetic;
 
+import java.math.BigInteger;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
-import java.math.BigInteger;
+import io.parsingdata.metal.expression.value.BinaryValueExpression;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Div extends BinaryValueExpression {
 
@@ -29,9 +33,9 @@ public class Div extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
         if (right.asNumeric().equals(BigInteger.ZERO)) { return OptionalValue.empty(); }
-        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().divide(right.asNumeric()), enc));
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().divide(right.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
@@ -16,11 +16,15 @@
 
 package io.parsingdata.metal.expression.value.arithmetic;
 
+import java.math.BigInteger;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
-import java.math.BigInteger;
+import io.parsingdata.metal.expression.value.BinaryValueExpression;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Mod extends BinaryValueExpression {
 
@@ -29,9 +33,9 @@ public class Mod extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
         if (right.asNumeric().compareTo(BigInteger.ZERO) < 0) { return OptionalValue.empty(); }
-        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().mod(right.asNumeric()), enc));
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().mod(right.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
@@ -31,8 +31,8 @@ public class Mul extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().multiply(right.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().multiply(right.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
@@ -31,8 +31,8 @@ public class Neg extends UnaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(value.asNumeric().negate(), enc));
+    public OptionalValue eval(final Value value, final Environment environment, final Encoding encoding) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(value.asNumeric().negate(), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
@@ -31,8 +31,8 @@ public class Sub extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
-        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().subtract(right.asNumeric()), enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
+        return OptionalValue.of(ConstantFactory.createFromNumeric(left.asNumeric().subtract(right.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
@@ -16,11 +16,15 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
+import java.util.BitSet;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
-import java.util.BitSet;
+import io.parsingdata.metal.expression.value.BinaryValueExpression;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class And extends BinaryValueExpression {
 
@@ -29,10 +33,10 @@ public class And extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
-        final BitSet lbs = left.asBitSet();
-        lbs.and(right.asBitSet());
-        return OptionalValue.of(ConstantFactory.createFromBitSet(lbs, left.getValue().length, enc));
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
+        final BitSet leftBits = left.asBitSet();
+        leftBits.and(right.asBitSet());
+        return OptionalValue.of(ConstantFactory.createFromBitSet(leftBits, left.getValue().length, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
@@ -16,11 +16,15 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
+import java.util.BitSet;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
-import java.util.BitSet;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Not extends UnaryValueExpression {
 
@@ -29,10 +33,10 @@ public class Not extends UnaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
+    public OptionalValue eval(final Value value, final Environment environment, final Encoding encoding) {
         final BitSet bits = value.asBitSet();
         bits.flip(0, value.getValue().length * 8);
-        return OptionalValue.of(ConstantFactory.createFromBitSet(bits, value.getValue().length, enc));
+        return OptionalValue.of(ConstantFactory.createFromBitSet(bits, value.getValue().length, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
@@ -16,11 +16,15 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
+import java.util.BitSet;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
-import java.util.BitSet;
+import io.parsingdata.metal.expression.value.BinaryValueExpression;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class Or extends BinaryValueExpression {
 
@@ -29,11 +33,11 @@ public class Or extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value left, final Value right, final Environment env, final Encoding enc) {
-        final BitSet lbs = left.asBitSet();
-        lbs.or(right.asBitSet());
+    public OptionalValue eval(final Value left, final Value right, final Environment environment, final Encoding encoding) {
+        final BitSet leftBits = left.asBitSet();
+        leftBits.or(right.asBitSet());
         final int minSize = Math.max(left.getValue().length, right.getValue().length);
-        return OptionalValue.of(ConstantFactory.createFromBitSet(lbs, minSize, enc));
+        return OptionalValue.of(ConstantFactory.createFromBitSet(leftBits, minSize, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
@@ -16,11 +16,15 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
+import java.util.BitSet;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
-import java.util.BitSet;
+import io.parsingdata.metal.expression.value.BinaryValueExpression;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class ShiftLeft extends BinaryValueExpression {
 
@@ -29,16 +33,16 @@ public class ShiftLeft extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value operand, final Value positions, final Environment env, final Encoding enc) {
-        final BitSet lbs = operand.asBitSet();
+    public OptionalValue eval(final Value operand, final Value positions, final Environment environment, final Encoding encoding) {
+        final BitSet leftBits = operand.asBitSet();
         final int shiftLeft = positions.asNumeric().intValue();
-        final int bitCount = lbs.length() + shiftLeft;
+        final int bitCount = leftBits.length() + shiftLeft;
         final BitSet out = new BitSet(bitCount);
-        for (int i = lbs.nextSetBit(0); i >= 0; i = lbs.nextSetBit(i+1)) {
+        for (int i = leftBits.nextSetBit(0); i >= 0; i = leftBits.nextSetBit(i+1)) {
             out.set(i + shiftLeft);
         }
         final int minSize = (bitCount + 7) / 8;
-        return OptionalValue.of(ConstantFactory.createFromBitSet(out, minSize, enc));
+        return OptionalValue.of(ConstantFactory.createFromBitSet(out, minSize, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
@@ -16,11 +16,15 @@
 
 package io.parsingdata.metal.expression.value.bitwise;
 
+import java.util.BitSet;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
-import java.util.BitSet;
+import io.parsingdata.metal.expression.value.BinaryValueExpression;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class ShiftRight extends BinaryValueExpression {
 
@@ -29,10 +33,10 @@ public class ShiftRight extends BinaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value operand, final Value positions, final Environment env, final Encoding enc) {
-        final BitSet lbs = operand.asBitSet();
+    public OptionalValue eval(final Value operand, final Value positions, final Environment environment, final Encoding encoding) {
+        final BitSet leftBits = operand.asBitSet();
         final int shift = positions.asNumeric().intValue();
-        return OptionalValue.of(ConstantFactory.createFromBitSet(lbs.get(shift, Math.max(shift, lbs.length())), operand.getValue().length, enc));
+        return OptionalValue.of(ConstantFactory.createFromBitSet(leftBits.get(shift, Math.max(shift, leftBits.length())), operand.getValue().length, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
@@ -24,8 +26,6 @@ import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.OptionalValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public class Count implements ValueExpression {
 
@@ -36,12 +36,12 @@ public class Count implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList ovl = operand.eval(env, enc);
-        return OptionalValueList.create(OptionalValue.of(num(ovl.size)));
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        final OptionalValueList values = operand.eval(environment, encoding);
+        return OptionalValueList.create(OptionalValue.of(fromNumeric(values.size)));
     }
 
-    private static Value num(final long length) {
+    private static Value fromNumeric(final long length) {
         return ConstantFactory.createFromNumeric(length, new Encoding(Sign.SIGNED));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
@@ -30,8 +30,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 public class CurrentOffset implements ValueExpression {
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return OptionalValueList.create(OptionalValue.of(ConstantFactory.createFromNumeric(env.offset, new Encoding(Sign.SIGNED))));
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return OptionalValueList.create(OptionalValue.of(ConstantFactory.createFromNumeric(environment.offset, new Encoding(Sign.SIGNED))));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -16,13 +16,13 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.OptionalValue;
 import io.parsingdata.metal.expression.value.ValueExpression;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public class First implements ValueExpression {
 
@@ -33,13 +33,13 @@ public class First implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList list = operand.eval(env, enc);
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        final OptionalValueList list = operand.eval(environment, encoding);
         return list.isEmpty() ? list : OptionalValueList.create(getFirst(list));
     }
 
-    private OptionalValue getFirst(final OptionalValueList list) {
-        return list.tail.isEmpty() ? list.head : getFirst(list.tail);
+    private OptionalValue getFirst(final OptionalValueList values) {
+        return values.tail.isEmpty() ? values.head : getFirst(values.tail);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -16,12 +16,12 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
-
-import static io.parsingdata.metal.Util.checkNotNull;
 
 public class Last implements ValueExpression {
 
@@ -32,8 +32,8 @@ public class Last implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        final OptionalValueList list = operand.eval(env, enc);
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        final OptionalValueList list = operand.eval(environment, encoding);
         return list.isEmpty() ? list : OptionalValueList.create(list.head);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
@@ -32,11 +32,11 @@ public class Len extends UnaryValueExpression {
     }
 
     @Override
-    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
-        return OptionalValue.of(num(value.getValue().length));
+    public OptionalValue eval(final Value value, final Environment environment, final Encoding encoding) {
+        return OptionalValue.of(fromNumeric(value.getValue().length));
     }
 
-    private static Value num(final long length) {
+    private static Value fromNumeric(final long length) {
         return ConstantFactory.createFromNumeric(length, new Encoding(Sign.SIGNED));
     }
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/NameRef.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/NameRef.java
@@ -16,14 +16,13 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.OptionalValueList;
-import io.parsingdata.metal.data.selection.ByName;
-import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.ValueExpression;
-
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.OptionalValueList;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.ValueExpression;
 
 public class NameRef implements ValueExpression {
 
@@ -34,8 +33,8 @@ public class NameRef implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return OptionalValueList.create(getAllValues(env.order, name));
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return OptionalValueList.create(getAllValues(environment.order, name));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -16,9 +16,10 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
-import static io.parsingdata.metal.Util.checkNotNull;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
+
+import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.math.BigInteger;
 
@@ -55,8 +56,8 @@ public class Nth implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return eval(values.eval(env, enc), indices.eval(env, enc));
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return eval(values.eval(environment, encoding), indices.eval(environment, encoding));
     }
 
     private OptionalValueList eval(final OptionalValueList values, final OptionalValueList indices) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -47,8 +47,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Nth implements ValueExpression {
 
-    private final ValueExpression values;
-    private final ValueExpression indices;
+    public final ValueExpression values;
+    public final ValueExpression indices;
 
     public Nth(final ValueExpression values, final ValueExpression indices) {
         this.values = checkNotNull(values, "values");

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -26,9 +26,9 @@ public class Offset extends UnaryValueExpression {
     public Offset(final ValueExpression operand) { super(operand); }
 
     @Override
-    public OptionalValue eval(final Value value, final Environment env, final Encoding enc) {
+    public OptionalValue eval(final Value value, final Environment environment, final Encoding encoding) {
         if (value instanceof ParseValue) {
-            return OptionalValue.of(ConstantFactory.createFromNumeric(((ParseValue) value).getOffset(), value.enc));
+            return OptionalValue.of(ConstantFactory.createFromNumeric(((ParseValue) value).getOffset(), value.encoding));
         }
         return OptionalValue.empty();
     }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -25,8 +25,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 public class Self implements ValueExpression {
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return OptionalValueList.create(OptionalValue.of(env.order.current()));
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return OptionalValueList.create(OptionalValue.of(environment.order.current()));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/TokenRef.java
@@ -34,8 +34,8 @@ public class TokenRef implements ValueExpression {
     }
 
     @Override
-    public OptionalValueList eval(final Environment env, final Encoding enc) {
-        return OptionalValueList.create(getAllValues(env.order, definition));
+    public OptionalValueList eval(final Environment environment, final Encoding encoding) {
+        return OptionalValueList.create(getAllValues(environment.order, definition));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -16,23 +16,23 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.Util.checkContainsNoNulls;
+import static io.parsingdata.metal.data.ParseResult.failure;
+import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 
-import java.io.IOException;
-
-import static io.parsingdata.metal.Util.checkContainsNoNulls;
-import static io.parsingdata.metal.data.ParseResult.failure;
-import static io.parsingdata.metal.data.ParseResult.success;
-
 public class Cho extends Token {
 
     private final Token[] tokens;
 
-    public Cho(final String name, final Encoding enc, final Token... tokens) {
-        super(name, enc);
+    public Cho(final String name, final Encoding encoding, final Token... tokens) {
+        super(name, encoding);
         this.tokens = checkContainsNoNulls(tokens, "tokens");
         if (tokens.length < 2) { throw new IllegalArgumentException("At least two Tokens are required."); }
     }
@@ -42,17 +42,17 @@ public class Cho extends Token {
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = iterate(scope, env.addBranch(this), enc, 0);
-        if (res.succeeded) { return success(res.environment.closeBranch()); }
-        return failure(env);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final ParseResult result = iterate(scope, environment.addBranch(this), encoding, 0);
+        if (result.succeeded) { return success(result.environment.closeBranch()); }
+        return failure(environment);
     }
 
-    private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final int index) throws IOException {
-        if (index >= tokens.length) { return failure(env); }
-        final ParseResult res = tokens[index].parse(scope, env, enc);
-        if (res.succeeded) { return res; }
-        return iterate(scope, env, enc, index + 1);
+    private ParseResult iterate(final String scope, final Environment environment, final Encoding encoding, final int index) throws IOException {
+        if (index >= tokens.length) { return failure(environment); }
+        final ParseResult result = tokens[index].parse(scope, environment, encoding);
+        if (result.succeeded) { return result; }
+        return iterate(scope, environment, encoding, index + 1);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -29,7 +29,7 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public class Cho extends Token {
 
-    private final Token[] tokens;
+    private final Token[] tokens; // Private because array contents is mutable.
 
     public Cho(final String name, final Encoding encoding, final Token... tokens) {
         super(name, encoding);

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -16,6 +16,12 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.data.ParseResult.failure;
+import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.data.ParseResult;
@@ -25,40 +31,34 @@ import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.True;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
-import java.io.IOException;
-
-import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.ParseResult.failure;
-import static io.parsingdata.metal.data.ParseResult.success;
-
 public class Def extends Token {
 
     public final ValueExpression size;
     public final Expression predicate;
 
-    public Def(final String name, final ValueExpression size, final Expression predicate, final Encoding enc) {
-        super(name, enc);
+    public Def(final String name, final ValueExpression size, final Expression predicate, final Encoding encoding) {
+        super(name, encoding);
         this.size = checkNotNull(size, "size");
         this.predicate = predicate == null ? new True() : predicate;
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList sizes = size.eval(env, enc);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final OptionalValueList sizes = size.eval(environment, encoding);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
-            return failure(env);
+            return failure(environment);
         }
         // TODO: Handle value expression results as BigInteger (#16)
         final int dataSize = sizes.head.get().asNumeric().intValue();
         if (dataSize < 0) {
-            return failure(env);
+            return failure(environment);
         }
         final byte[] data = new byte[dataSize];
-        if (env.input.read(env.offset, data) != data.length) {
-            return failure(env);
+        if (environment.input.read(environment.offset, data) != data.length) {
+            return failure(environment);
         }
-        final Environment newEnv = env.add(new ParseValue(scope, this, env.offset, data, enc)).seek(env.offset + dataSize);
-        return predicate.eval(newEnv, enc) ? success(newEnv) : failure(env);
+        final Environment newEnvironment = environment.add(new ParseValue(scope, this, environment.offset, data, encoding)).seek(environment.offset + dataSize);
+        return predicate.eval(newEnvironment, encoding) ? success(newEnvironment) : failure(environment);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Nod.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Nod.java
@@ -16,38 +16,38 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.data.ParseResult.failure;
+import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
-import java.io.IOException;
-
-import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.ParseResult.failure;
-import static io.parsingdata.metal.data.ParseResult.success;
-
 public class Nod extends Token {
 
     public final ValueExpression size;
 
-    public Nod(final String name, final ValueExpression size, final Encoding enc) {
-        super(name, enc);
+    public Nod(final String name, final ValueExpression size, final Encoding encoding) {
+        super(name, encoding);
         this.size = checkNotNull(size, "size");
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList sizes = size.eval(env, enc);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final OptionalValueList sizes = size.eval(environment, encoding);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
-            return failure(env);
+            return failure(environment);
         }
         final long skipSize = sizes.head.get().asNumeric().longValue();
         if (skipSize < 0) {
-            return failure(env);
+            return failure(environment);
         }
-        return success(env.seek(env.offset + skipSize));
+        return success(environment.seek(environment.offset + skipSize));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Opt.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Opt.java
@@ -16,29 +16,29 @@
 
 package io.parsingdata.metal.token;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.encoding.Encoding;
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.data.ParseResult.success;
 
 import java.io.IOException;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.ParseResult.success;
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.encoding.Encoding;
 
 public class Opt extends Token {
 
     public final Token token;
 
-    public Opt(final String name, final Token token, final Encoding enc) {
-        super(name, enc);
+    public Opt(final String name, final Token token, final Encoding encoding) {
+        super(name, encoding);
         this.token = checkNotNull(token, "token");
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = token.parse(scope, env.addBranch(this), enc);
-        if (res.succeeded) { return success(res.environment.closeBranch()); }
-        return success(env);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final ParseResult result = token.parse(scope, environment.addBranch(this), encoding);
+        if (result.succeeded) { return success(result.environment.closeBranch()); }
+        return success(environment);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -16,35 +16,35 @@
 
 package io.parsingdata.metal.token;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.Expression;
-
-import java.io.IOException;
-
 import static io.parsingdata.metal.Shorthand.expTrue;
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.ParseResult.failure;
 import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.Expression;
 
 public class Pre extends Token {
 
     public final Token token;
     public final Expression predicate;
 
-    public Pre(final String name, final Token token, final Expression predicate, final Encoding enc) {
-        super(name, enc);
+    public Pre(final String name, final Token token, final Expression predicate, final Encoding encoding) {
+        super(name, encoding);
         this.token = checkNotNull(token, "token");
         this.predicate = predicate == null ? expTrue() : predicate;
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        if (!predicate.eval(env, enc)) { return success(env); }
-        final ParseResult res = token.parse(scope, env.addBranch(this), enc);
-        if (res.succeeded) { return success(res.environment.closeBranch()); }
-        return failure(env);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        if (!predicate.eval(environment, encoding)) { return success(environment); }
+        final ParseResult result = token.parse(scope, environment.addBranch(this), encoding);
+        if (result.succeeded) { return success(result.environment.closeBranch()); }
+        return failure(environment);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Rep.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Rep.java
@@ -16,34 +16,34 @@
 
 package io.parsingdata.metal.token;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.encoding.Encoding;
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.data.ParseResult.success;
 
 import java.io.IOException;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.ParseResult.success;
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.encoding.Encoding;
 
 public class Rep extends Token {
 
     public final Token token;
 
-    public Rep(final String name, final Token token, final Encoding enc) {
-        super(name, enc);
+    public Rep(final String name, final Token token, final Encoding encoding) {
+        super(name, encoding);
         this.token = checkNotNull(token, "token");
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = iterate(scope, env.addBranch(this), enc);
-        return success(res.environment.closeBranch());
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final ParseResult result = iterate(scope, environment.addBranch(this), encoding);
+        return success(result.environment.closeBranch());
     }
 
-    private ParseResult iterate(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = token.parse(scope, env, enc);
-        if (res.succeeded) { return iterate(scope, res.environment, enc); }
-        return success(env);
+    private ParseResult iterate(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final ParseResult result = token.parse(scope, environment, encoding);
+        if (result.succeeded) { return iterate(scope, result.environment, encoding); }
+        return success(environment);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -16,47 +16,47 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.data.ParseResult.failure;
+import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
-import java.io.IOException;
-
-import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.ParseResult.failure;
-import static io.parsingdata.metal.data.ParseResult.success;
-
 public class RepN extends Token {
 
     public final Token token;
     public final ValueExpression n;
 
-    public RepN(final String name, final Token token, final ValueExpression n, final Encoding enc) {
-        super(name, enc);
+    public RepN(final String name, final Token token, final ValueExpression n, final Encoding encoding) {
+        super(name, encoding);
         this.token = checkNotNull(token, "token");
         this.n = checkNotNull(n, "n");
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList counts = n.eval(env, enc);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final OptionalValueList counts = n.eval(environment, encoding);
         if (counts.size != 1 || !counts.head.isPresent()) {
-            return failure(env);
+            return failure(environment);
         }
-        final ParseResult res = iterate(scope, env.addBranch(this), enc, counts.head.get().asNumeric().longValue());
-        if (res.succeeded) {
-            return success(res.environment.closeBranch());
+        final ParseResult result = iterate(scope, environment.addBranch(this), encoding, counts.head.get().asNumeric().longValue());
+        if (result.succeeded) {
+            return success(result.environment.closeBranch());
         }
-        return failure(env);
+        return failure(environment);
     }
 
-    private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final long count) throws IOException {
-        if (count <= 0) { return success(env); }
-        final ParseResult res = token.parse(scope, env, enc);
-        if (res.succeeded) { return iterate(scope, res.environment, enc, count - 1); }
-        return failure(env);
+    private ParseResult iterate(final String scope, final Environment environment, final Encoding encoding, final long count) throws IOException {
+        if (count <= 0) { return success(environment); }
+        final ParseResult result = token.parse(scope, environment, encoding);
+        if (result.succeeded) { return iterate(scope, result.environment, encoding, count - 1); }
+        return failure(environment);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -16,23 +16,23 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.Util.checkContainsNoNulls;
+import static io.parsingdata.metal.data.ParseResult.failure;
+import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 
-import java.io.IOException;
-
-import static io.parsingdata.metal.Util.checkContainsNoNulls;
-import static io.parsingdata.metal.data.ParseResult.failure;
-import static io.parsingdata.metal.data.ParseResult.success;
-
 public class Seq extends Token {
 
     private final Token[] tokens;
 
-    public Seq(final String name, final Encoding enc, final Token... tokens) {
-        super(name, enc);
+    public Seq(final String name, final Encoding encoding, final Token... tokens) {
+        super(name, encoding);
         this.tokens = checkContainsNoNulls(tokens, "tokens");
         if (tokens.length < 2) { throw new IllegalArgumentException("At least two Tokens are required."); }
     }
@@ -42,17 +42,17 @@ public class Seq extends Token {
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = iterate(scope, env.addBranch(this), enc, 0);
-        if (res.succeeded) { return success(res.environment.closeBranch()); }
-        return failure(env);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final ParseResult result = iterate(scope, environment.addBranch(this), encoding, 0);
+        if (result.succeeded) { return success(result.environment.closeBranch()); }
+        return failure(environment);
     }
 
-    private ParseResult iterate(final String scope, final Environment env, final Encoding enc, final int index) throws IOException {
-        if (index >= tokens.length) { return success(env); }
-        final ParseResult res = tokens[index].parse(scope, env, enc);
-        if (res.succeeded) { return iterate(scope, res.environment, enc, index + 1); }
-        return res;
+    private ParseResult iterate(final String scope, final Environment environment, final Encoding encoding, final int index) throws IOException {
+        if (index >= tokens.length) { return success(environment); }
+        final ParseResult result = tokens[index].parse(scope, environment, encoding);
+        if (result.succeeded) { return iterate(scope, result.environment, encoding, index + 1); }
+        return result;
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -29,7 +29,7 @@ import io.parsingdata.metal.encoding.Encoding;
 
 public class Seq extends Token {
 
-    private final Token[] tokens;
+    private final Token[] tokens; // Private because array contents is mutable.
 
     public Seq(final String name, final Encoding encoding, final Token... tokens) {
         super(name, encoding);

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
-import io.parsingdata.metal.data.ParseRef;
+import io.parsingdata.metal.data.ParseReference;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -35,44 +35,44 @@ public class Sub extends Token {
     public final Token token;
     public final ValueExpression address;
 
-    public Sub(final String name, final Token token, final ValueExpression address, final Encoding enc) {
-        super(name, enc);
+    public Sub(final String name, final Token token, final ValueExpression address, final Encoding encoding) {
+        super(name, encoding);
         this.token = checkNotNull(token, "token");
         this.address = checkNotNull(address, "address");
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final OptionalValueList addrs = address.eval(env, enc);
-        if (addrs.isEmpty() || addrs.containsEmpty()) { return failure(env); }
-        final ParseResult res = iterate(scope, addrs, env.addBranch(this), enc);
-        if (res.succeeded) {
-            return success(res.environment.closeBranch().seek(env.offset));
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final OptionalValueList addresses = address.eval(environment, encoding);
+        if (addresses.isEmpty() || addresses.containsEmpty()) { return failure(environment); }
+        final ParseResult result = iterate(scope, addresses, environment.addBranch(this), encoding);
+        if (result.succeeded) {
+            return success(result.environment.closeBranch().seek(environment.offset));
         }
-        return failure(env);
+        return failure(environment);
     }
 
-    private ParseResult iterate(final String scope, final OptionalValueList addrs, final Environment env, final Encoding enc) throws IOException {
-        final long ref = addrs.head.get().asNumeric().longValue();
-        final ParseResult res = parse(scope, ref, env, enc);
-        if (res.succeeded) {
-            if (addrs.tail.isEmpty()) {
-                return res;
+    private ParseResult iterate(final String scope, final OptionalValueList addresses, final Environment environment, final Encoding encoding) throws IOException {
+        final long offset = addresses.head.get().asNumeric().longValue();
+        final ParseResult result = parse(scope, offset, environment, encoding);
+        if (result.succeeded) {
+            if (addresses.tail.isEmpty()) {
+                return result;
             }
-            return iterate(scope, addrs.tail, res.environment, enc);
+            return iterate(scope, addresses.tail, result.environment, encoding);
         }
-        return failure(env);
+        return failure(environment);
     }
 
-    private ParseResult parse(final String scope, final long ref, final Environment env, final Encoding enc) throws IOException {
-        if (hasRootAtOffset(env.order, token.getCanonical(env), ref)) {
-            return success(env.add(new ParseRef(ref, token.getCanonical(env))));
+    private ParseResult parse(final String scope, final long offset, final Environment environment, final Encoding encoding) throws IOException {
+        if (hasRootAtOffset(environment.order, token.getCanonical(environment), offset)) {
+            return success(environment.add(new ParseReference(offset, token.getCanonical(environment))));
         }
-        final ParseResult res = token.parse(scope, env.seek(ref), enc);
-        if (res.succeeded) {
-            return res;
+        final ParseResult result = token.parse(scope, environment.seek(offset), encoding);
+        if (result.succeeded) {
+            return result;
         }
-        return failure(env);
+        return failure(environment);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -30,25 +30,25 @@ public abstract class Token {
     public static final String SEPARATOR = ".";
 
     public final String name;
-    public final Encoding enc;
+    public final Encoding encoding;
 
-    protected Token(final String name, final Encoding enc) {
+    protected Token(final String name, final Encoding encoding) {
         this.name = checkNotNull(name, "name");
-        this.enc = enc;
+        this.encoding = encoding;
     }
 
-    public ParseResult parse(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final Encoding encoding = this.enc != null ? this.enc : enc;
-        final ParseResult result = parseImpl(makeScope(scope), env, encoding);
+    public ParseResult parse(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final Encoding activeEncoding = this.encoding != null ? this.encoding : encoding;
+        final ParseResult result = parseImpl(makeScope(scope), environment, activeEncoding);
         handleCallbacks(result.environment.callbacks, result);
         return result;
     }
 
-    public ParseResult parse(final Environment env, final Encoding enc) throws IOException {
-        return parse("", env, enc);
+    public ParseResult parse(final Environment environment, final Encoding encoding) throws IOException {
+        return parse("", environment, encoding);
     }
 
-    protected abstract ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException;
+    protected abstract ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException;
 
     private String makeScope(final String scope) {
         return scope + (scope.isEmpty() || name.isEmpty() ? "" : SEPARATOR) + name;
@@ -68,7 +68,7 @@ public abstract class Token {
         return true;
     }
 
-    public Token getCanonical(final Environment env) { return this; }
+    public Token getCanonical(final Environment environment) { return this; }
 
     protected String makeNameFragment() {
         return name.isEmpty() ? "" : name + ",";

--- a/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
@@ -30,34 +30,34 @@ public class TokenRef extends Token {
 
     private static final Token LOOKUP_FAILED = new Token("LOOKUP_FAILED", null) {
         @Override
-        protected ParseResult parseImpl(String scope, Environment env, Encoding enc) throws IOException {
-            return failure(env);
+        protected ParseResult parseImpl(String scope, Environment environment, Encoding encoding) throws IOException {
+            return failure(environment);
         }
     };
 
-    public final String refName;
+    public final String referenceName;
 
-    public TokenRef(String name, String refName, Encoding enc) {
-        super(name, enc);
-        this.refName = checkNotNull(refName, "refName");
-        if (refName.isEmpty()) { throw new IllegalArgumentException("Argument refName may not be empty."); }
+    public TokenRef(String name, String referenceName, Encoding encoding) {
+        super(name, encoding);
+        this.referenceName = checkNotNull(referenceName, "referenceName");
+        if (referenceName.isEmpty()) { throw new IllegalArgumentException("Argument referenceName may not be empty."); }
     }
 
     @Override
-    protected ParseResult parseImpl(String scope, Environment env, Encoding enc) throws IOException {
-        return lookup(env.order, refName).parse(scope, env, enc);
+    protected ParseResult parseImpl(String scope, Environment environment, Encoding encoding) throws IOException {
+        return lookup(environment.order, referenceName).parse(scope, environment, encoding);
     }
 
-    private Token lookup(final ParseItem item, final String refName) {
-        if (item.getDefinition().name.equals(refName)) { return item.getDefinition(); }
+    private Token lookup(final ParseItem item, final String referenceName) {
+        if (item.getDefinition().name.equals(referenceName)) { return item.getDefinition(); }
         if (!item.isGraph() || item.asGraph().isEmpty()) { return LOOKUP_FAILED; }
-        final Token headResult = lookup(item.asGraph().head, refName);
+        final Token headResult = lookup(item.asGraph().head, referenceName);
         if (headResult != LOOKUP_FAILED) { return headResult; }
-        return lookup(item.asGraph().tail, refName);
+        return lookup(item.asGraph().tail, referenceName);
     }
 
     @Override
-    public Token getCanonical(Environment env) {
-        return lookup(env.order, refName);
+    public Token getCanonical(Environment environment) {
+        return lookup(environment.order, referenceName);
     }
 }

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -16,41 +16,41 @@
 
 package io.parsingdata.metal.token;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.Expression;
-
-import java.io.IOException;
-
 import static io.parsingdata.metal.Shorthand.expTrue;
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.ParseResult.failure;
 import static io.parsingdata.metal.data.ParseResult.success;
+
+import java.io.IOException;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.Expression;
 
 public class While extends Token {
 
     public final Token token;
     public final Expression predicate;
 
-    public While(final String name, final Token token, final Expression predicate, final Encoding enc) {
-        super(name, enc);
+    public While(final String name, final Token token, final Expression predicate, final Encoding encoding) {
+        super(name, encoding);
         this.token = checkNotNull(token, "token");
         this.predicate = predicate == null ? expTrue() : predicate;
     }
 
     @Override
-    protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-        final ParseResult res = iterate(scope, env.addBranch(this), enc);
-        if (res.succeeded) { return success(res.environment.closeBranch()); }
-        return failure(env);
+    protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        final ParseResult result = iterate(scope, environment.addBranch(this), encoding);
+        if (result.succeeded) { return success(result.environment.closeBranch()); }
+        return failure(environment);
     }
 
-    private ParseResult iterate(final String scope, final Environment env, final Encoding enc) throws IOException {
-        if (!predicate.eval(env, enc)) { return success(env); }
-        final ParseResult res = token.parse(scope, env, enc);
-        if (res.succeeded) { return iterate(scope, res.environment, enc); }
-        return failure(env);
+    private ParseResult iterate(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        if (!predicate.eval(environment, encoding)) { return success(environment); }
+        final ParseResult result = token.parse(scope, environment, encoding);
+        if (result.succeeded) { return iterate(scope, result.environment, encoding); }
+        return failure(environment);
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -70,8 +70,8 @@ public class ArgumentsTest {
     final private static String EMPTY_NAME = "";
     final private static ValueExpression VALID_VE = con(1);
     final private static Reducer VALID_REDUCER = new Reducer() { @Override public ValueExpression reduce(final ValueExpression left, final ValueExpression right) { return null; }};
-    final private static Expression VALID_E = new Expression() { @Override public boolean eval(final Environment env, final Encoding enc) { return false; }};
-    final private static Token VALID_T = new Token("", null) { @Override protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException { return null; } };
+    final private static Expression VALID_E = new Expression() { @Override public boolean eval(final Environment environment, final Encoding encoding) { return false; }};
+    final private static Token VALID_T = new Token("", null) { @Override protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException { return null; } };
 
     private final Class<?> _class;
     private final Object[] _arguments;
@@ -139,8 +139,8 @@ public class ArgumentsTest {
         });
     }
 
-    public ArgumentsTest(final Class<?> theClass, final Object[] arguments) {
-        _class = theClass;
+    public ArgumentsTest(final Class<?> argumentsClass, final Object[] arguments) {
+        _class = argumentsClass;
         _arguments = arguments;
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -16,6 +16,10 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import static io.parsingdata.metal.Shorthand.con;
 
 import java.io.IOException;
@@ -24,7 +28,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -147,15 +150,15 @@ public class ArgumentsTest {
     @Test
     public void runConstructor() throws Throwable {
         final Constructor<?>[] constructors = _class.getConstructors();
-        Assert.assertEquals(1, constructors.length);
+        assertEquals(1, constructors.length);
         try {
             constructors[0].newInstance(_arguments);
-            Assert.fail("Should have thrown an IllegalArgumentException.");
+            fail("Should have thrown an IllegalArgumentException.");
         }
         catch (final InvocationTargetException e) {
-            Assert.assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+            assertEquals(IllegalArgumentException.class, e.getCause().getClass());
             final String message = e.getCause().getMessage();
-            Assert.assertTrue(message.endsWith("may not be null.") || message.endsWith("may not be empty."));
+            assertTrue(message.endsWith("may not be null.") || message.endsWith("may not be empty."));
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
@@ -27,14 +27,16 @@ import static io.parsingdata.metal.Shorthand.neg;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.junit.runners.Parameterized.Parameters;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
@@ -43,8 +45,6 @@ import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
-
-import org.junit.runners.Parameterized.Parameters;
 
 public class ArithmeticValueExpressionSemanticsTest extends ParameterizedParse {
 
@@ -97,8 +97,8 @@ public class ArithmeticValueExpressionSemanticsTest extends ParameterizedParse {
         });
     }
 
-    public ArithmeticValueExpressionSemanticsTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public ArithmeticValueExpressionSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private static Token add = binaryValueExpressionToken(add(ref("a"), ref("b")), 1);
@@ -109,18 +109,18 @@ public class ArithmeticValueExpressionSemanticsTest extends ParameterizedParse {
     private static Token mod = binaryValueExpressionToken(mod(ref("a"), ref("b")), 1);
     private static Token neg = unaryValueExpressionToken(neg(ref("a")));
 
-    private static Token singleToken(final String firstName, final String secondName, final int resultSize, final ValueExpression ve) {
+    private static Token singleToken(final String firstName, final String secondName, final int resultSize, final ValueExpression valueExpression) {
         return seq(any(firstName),
-                   def(secondName, con(resultSize), eqNum(ve)));
+                   def(secondName, con(resultSize), eqNum(valueExpression)));
     }
 
-    private static Token binaryValueExpressionToken(final BinaryValueExpression bve, final int resultSize) {
+    private static Token binaryValueExpressionToken(final BinaryValueExpression binaryValueExpression, final int resultSize) {
         return seq(any("a"),
-                   singleToken("b", "c", resultSize, bve));
+                   singleToken("b", "c", resultSize, binaryValueExpression));
     }
 
-    private static Token unaryValueExpressionToken(final UnaryValueExpression uve) {
-        return singleToken("a", "b", 1, uve);
+    private static Token unaryValueExpressionToken(final UnaryValueExpression unaryValueExpression) {
+        return singleToken("a", "b", 1, unaryValueExpression);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
@@ -16,24 +16,26 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
 import static io.parsingdata.metal.util.TokenDefinitions.notEqRef;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
 
 import java.io.IOException;
 
-import io.parsingdata.metal.token.Token;
-
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import io.parsingdata.metal.token.Token;
 
 @RunWith(JUnit4.class)
 public class BackTrackNameBindTest {
@@ -47,22 +49,22 @@ public class BackTrackNameBindTest {
 
     @Test
     public void choiceRefLeft() throws IOException {
-        Assert.assertTrue(_choiceRef.parse(stream(1, 2, 2), enc()).succeeded);
+        assertTrue(_choiceRef.parse(stream(1, 2, 2), enc()).succeeded);
     }
 
     @Test
     public void choiceRefRight() throws IOException {
-        Assert.assertTrue(_choiceRef.parse(stream(1, 2, 3), enc()).succeeded);
+        assertTrue(_choiceRef.parse(stream(1, 2, 3), enc()).succeeded);
     }
 
     @Test
     public void choiceRefNone() throws IOException {
-        Assert.assertFalse(_choiceRef.parse(stream(1, 1, 2), enc()).succeeded);
+        assertFalse(_choiceRef.parse(stream(1, 1, 2), enc()).succeeded);
     }
 
     @Test
     public void repeatRef() throws IOException {
-        Assert.assertTrue(_repeatRef.parse(stream(42, 42, 42, 21, 21, 21), enc()).succeeded);
+        assertTrue(_repeatRef.parse(stream(42, 42, 42, 21, 21, 21), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
@@ -16,22 +16,24 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
 
 import java.io.IOException;
 
-import io.parsingdata.metal.token.Token;
-
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import io.parsingdata.metal.token.Token;
 
 @RunWith(JUnit4.class)
 public class BackTrackOffsetTest {
@@ -57,42 +59,42 @@ public class BackTrackOffsetTest {
 
     @Test
     public void choiceLeft() throws IOException {
-        Assert.assertTrue(_backTrackChoice.parse(stream(1, 2), enc()).succeeded);
+        assertTrue(_backTrackChoice.parse(stream(1, 2), enc()).succeeded);
     }
 
     @Test
     public void choiceRight() throws IOException {
-        Assert.assertTrue(_backTrackChoice.parse(stream(1, 3), enc()).succeeded);
+        assertTrue(_backTrackChoice.parse(stream(1, 3), enc()).succeeded);
     }
 
     @Test
     public void choiceNone() throws IOException {
-        Assert.assertFalse(_backTrackChoice.parse(stream(1, 4), enc()).succeeded);
+        assertFalse(_backTrackChoice.parse(stream(1, 4), enc()).succeeded);
     }
 
     @Test
     public void repeatZero() throws IOException {
-        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 3), enc()).succeeded);
+        assertTrue(_backTrackRepeat.parse(stream(1, 3), enc()).succeeded);
     }
 
     @Test
     public void repeatOnce() throws IOException {
-        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 3), enc()).succeeded);
+        assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 3), enc()).succeeded);
     }
 
     @Test
     public void repeatTwice() throws IOException {
-        Assert.assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 2, 1, 3), enc()).succeeded);
+        assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 2, 1, 3), enc()).succeeded);
     }
 
     @Test
     public void repeatNone() throws IOException {
-        Assert.assertFalse(_backTrackRepeat.parse(stream(1, 4), enc()).succeeded);
+        assertFalse(_backTrackRepeat.parse(stream(1, 4), enc()).succeeded);
     }
 
     @Test
     public void deepMatch() throws IOException {
-        Assert.assertTrue(_backTrackDeep.parse(stream(1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 84), enc()).succeeded);
+        assertTrue(_backTrackDeep.parse(stream(1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 84), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/BitwiseValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BitwiseValueExpressionSemanticsTest.java
@@ -73,8 +73,8 @@ public class BitwiseValueExpressionSemanticsTest extends ParameterizedParse {
         });
     }
 
-    public BitwiseValueExpressionSemanticsTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public BitwiseValueExpressionSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private static Token simpleNot(final int size) {

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -40,7 +40,6 @@ import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.data.selection.ByName;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.InMemoryByteStream;
@@ -66,8 +65,8 @@ public class ByteLengthTest {
         final byte[] text2 = "Metal".getBytes(UTF_8);
 
         final ByteStream stream = new InMemoryByteStream(concat(text1, text2));
-        final Environment env = new Environment(stream);
-        final ParseResult result = STRING.parse(env, ENCODING);
+        final Environment environment = new Environment(stream);
+        final ParseResult result = STRING.parse(environment, ENCODING);
 
         assertTrue(result.succeeded);
         final ParseGraph graph = result.environment.order;
@@ -79,8 +78,8 @@ public class ByteLengthTest {
     @Test
     public void testLenNull() throws IOException {
         final ByteStream stream = new InMemoryByteStream(string("Joe"));
-        final Environment env = new Environment(stream);
-        final ParseResult result = NAME.parse(env, ENCODING);
+        final Environment environment = new Environment(stream);
+        final ParseResult result = NAME.parse(environment, ENCODING);
         assertFalse(result.succeeded);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
@@ -16,71 +16,84 @@
 
 package io.parsingdata.metal;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.eqNum;
+import static io.parsingdata.metal.Shorthand.eqStr;
+import static io.parsingdata.metal.Shorthand.expTrue;
+import static io.parsingdata.metal.Shorthand.gtNum;
+import static io.parsingdata.metal.Shorthand.ltNum;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.self;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized.Parameters;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.comparison.ComparisonExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
-import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-import java.util.Collection;
-
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class ComparisonExpressionSemanticsTest extends ParameterizedParse {
 
     @Parameters(name="{0} ({4})")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "1 == 1(eqNum)", numCom(1, eqNum(ref("a"))), stream(1, 1), enc(), true },
-            { "2 == 1(eqNum)", numCom(1, eqNum(ref("a"))), stream(1, 2), enc(), false },
-            { "1 > 1", numCom(1, gtNum(ref("a"))), stream(1, 1), enc(), false },
-            { "2 > 1", numCom(1, gtNum(ref("a"))), stream(1, 2), enc(), true },
-            { "1 > 2", numCom(1, gtNum(ref("a"))), stream(2, 1), enc(), false },
-            { "1 < 1", numCom(1, ltNum(ref("a"))), stream(1, 1), enc(), false },
-            { "2 < 1", numCom(1, ltNum(ref("a"))), stream(1, 2), enc(), false },
-            { "1 < 2", numCom(1, ltNum(ref("a"))), stream(2, 1), enc(), true },
-            { "\"abc\" == \"abc\"", strCom(3, eqStr(ref("a"))), stream("abcabc", US_ASCII), new Encoding(US_ASCII), true },
-            { "\"abd\" == \"abc\"", strCom(3, eqStr(ref("a"))), stream("abcabd", US_ASCII), new Encoding(US_ASCII), false },
-            { "1 == 1(eq)", valCom(1, eq(ref("a"))), stream(1, 1), enc(), true },
-            { "2 == 1(eq)", valCom(1, eq(ref("a"))), stream(1, 2), enc(), false },
-            { "1 == 1 with self", valCom(1, eq(self, ref("a"))), stream(1, 1), enc(), true },
-            { "1 == 2 with self", valCom(1, eq(self, ref("a"))), stream(1, 2), enc(), false },
-            { "1, 2 == 1", listCom(eq(ref("a"), ref("b")), expTrue()), stream(1, 2, 1, 2), enc(), false },
-            { "1, 2 == 1, 2", listCom(expTrue(), eq(ref("a"), ref("b"))), stream(1, 2, 1, 2), enc(), true },
-            { "1, 2 == 2, 2", listCom(expTrue(), eq(ref("a"), ref("b"))), stream(1, 2, 2, 2), enc(), false },
-            { "1, 2 == 1, 3", listCom(expTrue(), eq(ref("a"), ref("b"))), stream(1, 2, 1, 3), enc(), false },
-            { "1, 2, 1 != 1/0", valCom(1, eqNum(con(1), div(con(1), con(0)))), stream(1, 2), enc(), false },
-            { "1, 2, 1/0 != 1", valCom(1, eqNum(div(con(1), con(0)), con(1))), stream(1, 2), enc(), false }
+            { "1 == 1(eqNum)", numericCompare(1, eqNum(ref("a"))), stream(1, 1), enc(), true },
+            { "2 == 1(eqNum)", numericCompare(1, eqNum(ref("a"))), stream(1, 2), enc(), false },
+            { "1 > 1", numericCompare(1, gtNum(ref("a"))), stream(1, 1), enc(), false },
+            { "2 > 1", numericCompare(1, gtNum(ref("a"))), stream(1, 2), enc(), true },
+            { "1 > 2", numericCompare(1, gtNum(ref("a"))), stream(2, 1), enc(), false },
+            { "1 < 1", numericCompare(1, ltNum(ref("a"))), stream(1, 1), enc(), false },
+            { "2 < 1", numericCompare(1, ltNum(ref("a"))), stream(1, 2), enc(), false },
+            { "1 < 2", numericCompare(1, ltNum(ref("a"))), stream(2, 1), enc(), true },
+            { "\"abc\" == \"abc\"", stringCompare(3, eqStr(ref("a"))), stream("abcabc", US_ASCII), new Encoding(US_ASCII), true },
+            { "\"abd\" == \"abc\"", stringCompare(3, eqStr(ref("a"))), stream("abcabd", US_ASCII), new Encoding(US_ASCII), false },
+            { "1 == 1(eq)", valueCompare(1, eq(ref("a"))), stream(1, 1), enc(), true },
+            { "2 == 1(eq)", valueCompare(1, eq(ref("a"))), stream(1, 2), enc(), false },
+            { "1 == 1 with self", valueCompare(1, eq(self, ref("a"))), stream(1, 1), enc(), true },
+            { "1 == 2 with self", valueCompare(1, eq(self, ref("a"))), stream(1, 2), enc(), false },
+            { "1, 2 == 1", listCompare(eq(ref("a"), ref("b")), expTrue()), stream(1, 2, 1, 2), enc(), false },
+            { "1, 2 == 1, 2", listCompare(expTrue(), eq(ref("a"), ref("b"))), stream(1, 2, 1, 2), enc(), true },
+            { "1, 2 == 2, 2", listCompare(expTrue(), eq(ref("a"), ref("b"))), stream(1, 2, 2, 2), enc(), false },
+            { "1, 2 == 1, 3", listCompare(expTrue(), eq(ref("a"), ref("b"))), stream(1, 2, 1, 3), enc(), false },
+            { "1, 2, 1 != 1/0", valueCompare(1, eqNum(con(1), div(con(1), con(0)))), stream(1, 2), enc(), false },
+            { "1, 2, 1/0 != 1", valueCompare(1, eqNum(div(con(1), con(0)), con(1))), stream(1, 2), enc(), false }
         });
     }
 
-    public ComparisonExpressionSemanticsTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public ComparisonExpressionSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
-    private static Token numCom(final int size, final ComparisonExpression comparison) {
+    private static Token numericCompare(final int size, final ComparisonExpression comparison) {
         return seq(any("a"),
                    def("b", con(size), comparison));
     }
 
-    private static Token strCom(final int size, final ComparisonExpression comparison) {
+    private static Token stringCompare(final int size, final ComparisonExpression comparison) {
         return seq(def("a", con(size), expTrue()),
                    def("b", con(size), comparison));
     }
 
-    private static Token valCom(final int size, final ComparisonExpression comparison) {
+    private static Token valueCompare(final int size, final ComparisonExpression comparison) {
         return seq(def("a", con(size), expTrue()),
                    def("b", con(size), comparison));
     }
 
-    private static Token listCom(final Expression first, final Expression second) {
+    private static Token listCompare(final Expression first, final Expression second) {
         return seq(any("a"),
                    any("a"),
                    def("b", con(1), first),

--- a/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
@@ -16,19 +16,32 @@
 
 package io.parsingdata.metal;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.token.Token;
-import io.parsingdata.metal.util.ParameterizedParse;
-import org.junit.runners.Parameterized.Parameters;
+import static io.parsingdata.metal.Shorthand.add;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.currentOffset;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.eqNum;
+import static io.parsingdata.metal.Shorthand.last;
+import static io.parsingdata.metal.Shorthand.ltNum;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.Shorthand.pre;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.Shorthand.whl;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import org.junit.runners.Parameterized.Parameters;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.token.Token;
+import io.parsingdata.metal.util.ParameterizedParse;
 
 public class ConditionalTokenTest extends ParameterizedParse {
 
@@ -46,8 +59,8 @@ public class ConditionalTokenTest extends ParameterizedParse {
         });
     }
 
-    public ConditionalTokenTest(final String name, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public ConditionalTokenTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private static final Token preToken = seq(any("a"),

--- a/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
@@ -65,8 +65,8 @@ public class ConstantValueTest extends ParameterizedParse {
         });
     }
 
-    public ConstantValueTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public ConstantValueTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private static Token single(final int size, final Expression predicate) {

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -16,6 +16,22 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.currentOffset;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eqNum;
+import static io.parsingdata.metal.Shorthand.rep;
+import static io.parsingdata.metal.Shorthand.self;
+import static io.parsingdata.metal.Shorthand.sub;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
@@ -25,12 +41,6 @@ import io.parsingdata.metal.encoding.Sign;
 import io.parsingdata.metal.expression.value.reference.CurrentOffset;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.InMemoryByteStream;
-import org.junit.Test;
-
-import java.io.IOException;
-
-import static io.parsingdata.metal.Shorthand.*;
-import static org.junit.Assert.*;
 
 public class CurrentOffsetTest {
 
@@ -41,9 +51,9 @@ public class CurrentOffsetTest {
 
     @Test
     public void currentOffset() {
-        final Environment env = new Environment(NO_BYTES, 42);
+        final Environment environment = new Environment(NO_BYTES, 42);
 
-        final OptionalValueList currentOffset = CURRENT_OFFSET.eval(env, ENCODING);
+        final OptionalValueList currentOffset = CURRENT_OFFSET.eval(environment, ENCODING);
 
         assertNotNull(currentOffset);
         assertEquals(1, currentOffset.size);
@@ -53,9 +63,9 @@ public class CurrentOffsetTest {
     @Test
     public void currentOffsetLarger() {
         // offset would flip signed bit if interpreted as signed integer:
-        final Environment env = new Environment(NO_BYTES, 128);
+        final Environment environment = new Environment(NO_BYTES, 128);
 
-        final OptionalValueList currentOffset = CURRENT_OFFSET.eval(env, ENCODING);
+        final OptionalValueList currentOffset = CURRENT_OFFSET.eval(environment, ENCODING);
 
         assertNotNull(currentOffset);
         assertEquals(1, currentOffset.size);
@@ -68,14 +78,14 @@ public class CurrentOffsetTest {
         for (int i = 0; i < stream.length; i++) {
             stream[i] = (byte) i;
         }
-        final Environment env = new Environment(new InMemoryByteStream(stream));
+        final Environment environment = new Environment(new InMemoryByteStream(stream));
 
         // value - offset + 1 should be 0:
         final Token offsetValidation = rep(def("byte", con(1), eqNum(sub(self, sub(currentOffset, con(1))), con(0))));
 
-        final ParseResult parse = offsetValidation.parse(env, new Encoding(Sign.UNSIGNED));
-        assertTrue(parse.succeeded);
-        assertEquals(256, parse.environment.offset);
+        final ParseResult result = offsetValidation.parse(environment, new Encoding(Sign.UNSIGNED));
+        assertTrue(result.succeeded);
+        assertEquals(256, result.environment.offset);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
@@ -16,7 +16,10 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -30,7 +33,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import io.parsingdata.metal.data.ByteStream;
@@ -56,8 +58,8 @@ public class DefSizeTest {
         });
         final ParseResult result = FORMAT.parse(new Environment(stream), new Encoding());
 
-        Assert.assertTrue(result.succeeded);
-        Assert.assertArrayEquals(
+        assertTrue(result.succeeded);
+        assertArrayEquals(
             new byte[]{0x04, 0x08},
             getValue(result.environment.order, "data").getValue()
         );
@@ -71,9 +73,9 @@ public class DefSizeTest {
         });
         final ParseResult result = FORMAT.parse(new Environment(stream), new Encoding());
 
-        Assert.assertFalse(result.succeeded);
+        assertFalse(result.succeeded);
         // The top-level Token (Seq) has failed, so no values are recorded in the ParseGraph.
-        Assert.assertEquals(ParseGraph.EMPTY, result.environment.order);
+        assertEquals(ParseGraph.EMPTY, result.environment.order);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
@@ -16,17 +16,20 @@
 
 package io.parsingdata.metal;
 
-import io.parsingdata.metal.data.ParseGraph;
-import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.token.Token;
-import org.junit.Assert;
-import org.junit.Test;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.io.IOException;
 
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.token.Token;
 
 public class DefinitionTest {
 	
@@ -35,11 +38,11 @@ public class DefinitionTest {
 	@Test
 	public void singleDef() throws IOException {
 		final Token singleDef = def("a", con(1));
-		final ParseResult res = singleDef.parse(stream(1), enc());
-		Assert.assertTrue(res.succeeded);
-		Assert.assertTrue(res.environment.order.getDefinition() == ParseGraph.NONE);
-		Assert.assertTrue(res.environment.order.head.getDefinition() == singleDef);
-		Assert.assertTrue(res.environment.order.tail.getDefinition() == ParseGraph.NONE);
+		final ParseResult result = singleDef.parse(stream(1), enc());
+		Assert.assertTrue(result.succeeded);
+		Assert.assertTrue(result.environment.order.getDefinition() == ParseGraph.NONE);
+		Assert.assertTrue(result.environment.order.head.getDefinition() == singleDef);
+		Assert.assertTrue(result.environment.order.tail.getDefinition() == ParseGraph.NONE);
 	}
 
 	@Test
@@ -47,15 +50,15 @@ public class DefinitionTest {
 		Token defA = def("a", con(1));
 		Token defB = def("b", con(1));
 		final Token smallSeq = seq(defA, defB);
-		final ParseResult res = smallSeq.parse(stream(1, 2), enc());
-		Assert.assertTrue(res.succeeded);
-		Assert.assertTrue(res.environment.order.getDefinition() == ParseGraph.NONE);
-		Assert.assertTrue(res.environment.order.head.getDefinition() == smallSeq);
-		Assert.assertTrue(res.environment.order.head.asGraph().head.getDefinition() == defB);
-		Assert.assertTrue(res.environment.order.head.asGraph().tail.getDefinition() == smallSeq);
-		Assert.assertTrue(res.environment.order.head.asGraph().tail.head.getDefinition() == defA);
-		Assert.assertTrue(res.environment.order.head.asGraph().tail.tail.getDefinition() == smallSeq);
-		Assert.assertTrue(res.environment.order.tail.getDefinition() == ParseGraph.NONE);
+		final ParseResult result = smallSeq.parse(stream(1, 2), enc());
+		Assert.assertTrue(result.succeeded);
+		Assert.assertTrue(result.environment.order.getDefinition() == ParseGraph.NONE);
+		Assert.assertTrue(result.environment.order.head.getDefinition() == smallSeq);
+		Assert.assertTrue(result.environment.order.head.asGraph().head.getDefinition() == defB);
+		Assert.assertTrue(result.environment.order.head.asGraph().tail.getDefinition() == smallSeq);
+		Assert.assertTrue(result.environment.order.head.asGraph().tail.head.getDefinition() == defA);
+		Assert.assertTrue(result.environment.order.head.asGraph().tail.tail.getDefinition() == smallSeq);
+		Assert.assertTrue(result.environment.order.tail.getDefinition() == ParseGraph.NONE);
 	}
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
@@ -36,14 +36,14 @@ public class EndiannessTest {
 
     @Test
     public void andAcrossByteBoundaryLE() throws IOException {
-        final Token t = def("x", con(2), eq(and(self, con(0x03, 0xff)), con(0x01, 0x1b)));
-        Assert.assertTrue(t.parse(stream(0x1b, 0x81), le()).succeeded);
+        final Token token = def("x", con(2), eq(and(self, con(0x03, 0xff)), con(0x01, 0x1b)));
+        Assert.assertTrue(token.parse(stream(0x1b, 0x81), le()).succeeded);
     }
 
     @Test
     public void constructIntermediateConstantLE() throws IOException {
-        final Token t = def("x", con(2), eq(and(shr(con(0x82, 0x1b), con(1)), con(0x03, 0xff)), con(0x01, 0x0d)));
-        Assert.assertTrue(t.parse(stream(0x00, 0x00), le()).succeeded);
+        final Token token = def("x", con(2), eq(and(shr(con(0x82, 0x1b), con(1)), con(0x03, 0xff)), con(0x01, 0x0d)));
+        Assert.assertTrue(token.parse(stream(0x00, 0x00), le()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.and;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -27,7 +29,6 @@ import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import io.parsingdata.metal.token.Token;
@@ -37,13 +38,13 @@ public class EndiannessTest {
     @Test
     public void andAcrossByteBoundaryLE() throws IOException {
         final Token token = def("x", con(2), eq(and(self, con(0x03, 0xff)), con(0x01, 0x1b)));
-        Assert.assertTrue(token.parse(stream(0x1b, 0x81), le()).succeeded);
+        assertTrue(token.parse(stream(0x1b, 0x81), le()).succeeded);
     }
 
     @Test
     public void constructIntermediateConstantLE() throws IOException {
         final Token token = def("x", con(2), eq(and(shr(con(0x82, 0x1b), con(1)), con(0x03, 0xff)), con(0x01, 0x0d)));
-        Assert.assertTrue(token.parse(stream(0x00, 0x00), le()).succeeded);
+        assertTrue(token.parse(stream(0x00, 0x00), le()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -19,9 +19,11 @@ package io.parsingdata.metal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.neg;
 import static io.parsingdata.metal.Shorthand.offset;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
@@ -50,8 +52,18 @@ public class ErrorsTest {
     @Test
     public void noValueForSize() throws IOException {
         thrown = ExpectedException.none();
-        final Token token = def("a", div(con(10), con(0)));
+        // Basic division by zero.
+        final Token token = def("a", div(con(1), con(0)));
         assertFalse(token.parse(stream(1), enc()).succeeded);
+        // Try to negate division by zero.
+        final Token token2 = def("a", neg(div(con(1), con(0))));
+        assertFalse(token2.parse(stream(1), enc()).succeeded);
+        // Add one to division by zero.
+        final Token token3 = def("a", add(div(con(1), con(0)), con(1)));
+        assertFalse(token3.parse(stream(1), enc()).succeeded);
+        // Add division by zero to one.
+        final Token token4 = def("a", add(con(1), div(con(1), con(0))));
+        assertFalse(token4.parse(stream(1), enc()).succeeded);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -16,23 +16,31 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.repn;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.OptionalValueList;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.token.Token;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.io.IOException;
-
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class ErrorsTest {
 
@@ -42,20 +50,20 @@ public class ErrorsTest {
     @Test
     public void noValueForSize() throws IOException {
         thrown = ExpectedException.none();
-        final Token t = def("a", div(con(10), con(0)));
-        assertFalse(t.parse(stream(1), enc()).succeeded);
+        final Token token = def("a", div(con(10), con(0)));
+        assertFalse(token.parse(stream(1), enc()).succeeded);
     }
 
     @Test
     public void ioError() throws IOException {
         thrown.expect(IOException.class);
-        final Token t = any("a");
+        final Token token = any("a");
         final ByteStream stream = new ByteStream() {
             @Override
             public int read(final long offset, final byte[] data) throws IOException { throw new IOException(); }
         };
-        final Environment env = new Environment(stream);
-        t.parse(env, enc());
+        final Environment environment = new Environment(stream);
+        token.parse(environment, enc());
     }
 
     @Test
@@ -66,8 +74,8 @@ public class ErrorsTest {
                 any("b"),
                 repn(dummy, ref("b"))
             );
-        ParseResult parseResult = multiRepN.parse(stream(2, 2, 2, 2), enc());
-        assertFalse(parseResult.succeeded);
+        ParseResult result = multiRepN.parse(stream(2, 2, 2, 2), enc());
+        assertFalse(result.succeeded);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/IterateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/IterateTest.java
@@ -55,8 +55,8 @@ public class IterateTest extends ParameterizedParse {
         });
     }
 
-    public IterateTest(final String name, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public IterateTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private static final Token repNToken =

--- a/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
@@ -26,20 +26,20 @@ import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.or;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.junit.runners.Parameterized.Parameters;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.logical.LogicalExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
-
-import org.junit.runners.Parameterized.Parameters;
 
 public class LogicalExpressionSemanticsTest extends ParameterizedParse {
 
@@ -59,8 +59,8 @@ public class LogicalExpressionSemanticsTest extends ParameterizedParse {
         });
     }
 
-    public LogicalExpressionSemanticsTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public LogicalExpressionSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private static final Token andEqGt = logicalExp(and(eqNum(ref("a")), gtNum(ref("b"))));

--- a/core/src/test/java/io/parsingdata/metal/ParseValueListTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ParseValueListTest.java
@@ -16,15 +16,19 @@
 
 package io.parsingdata.metal;
 
-import io.parsingdata.metal.data.ParseValue;
-import io.parsingdata.metal.data.ParseValueList;
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import static io.parsingdata.metal.Shorthand.def;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
+import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.data.ParseValueList;
 
 @RunWith(JUnit4.class)
 public class ParseValueListTest {
@@ -56,103 +60,103 @@ public class ParseValueListTest {
     @Test
     public void addList() {
         final ParseValueList l6 = l5.add(l5);
-        Assert.assertEquals(v5, l6.head);
-        Assert.assertEquals(v4, l6.tail.head);
-        Assert.assertEquals(v3, l6.tail.tail.head);
-        Assert.assertEquals(v2, l6.tail.tail.tail.head);
-        Assert.assertEquals(v1, l6.tail.tail.tail.tail.head);
-        Assert.assertEquals(v5, l6.tail.tail.tail.tail.tail.head);
-        Assert.assertEquals(v4, l6.tail.tail.tail.tail.tail.tail.head);
-        Assert.assertEquals(v3, l6.tail.tail.tail.tail.tail.tail.tail.head);
-        Assert.assertEquals(v2, l6.tail.tail.tail.tail.tail.tail.tail.tail.head);
-        Assert.assertEquals(v1, l6.tail.tail.tail.tail.tail.tail.tail.tail.tail.head);
-        Assert.assertTrue(l6.tail.tail.tail.tail.tail.tail.tail.tail.tail.tail.isEmpty());
+        assertEquals(v5, l6.head);
+        assertEquals(v4, l6.tail.head);
+        assertEquals(v3, l6.tail.tail.head);
+        assertEquals(v2, l6.tail.tail.tail.head);
+        assertEquals(v1, l6.tail.tail.tail.tail.head);
+        assertEquals(v5, l6.tail.tail.tail.tail.tail.head);
+        assertEquals(v4, l6.tail.tail.tail.tail.tail.tail.head);
+        assertEquals(v3, l6.tail.tail.tail.tail.tail.tail.tail.head);
+        assertEquals(v2, l6.tail.tail.tail.tail.tail.tail.tail.tail.head);
+        assertEquals(v1, l6.tail.tail.tail.tail.tail.tail.tail.tail.tail.head);
+        assertTrue(l6.tail.tail.tail.tail.tail.tail.tail.tail.tail.tail.isEmpty());
     }
 
     @Test
     public void traverse() {
-        Assert.assertEquals(l5.head, v5);
-        Assert.assertEquals(l5.tail, l4);
-        Assert.assertEquals(l4.head, v4);
-        Assert.assertEquals(l4.tail, l3);
-        Assert.assertEquals(l3.head, v3);
-        Assert.assertEquals(l3.tail, l2);
-        Assert.assertEquals(l2.head, v2);
-        Assert.assertEquals(l2.tail, l1);
-        Assert.assertEquals(l1.head, v1);
-        Assert.assertTrue(l1.tail.isEmpty());
+        assertEquals(l5.head, v5);
+        assertEquals(l5.tail, l4);
+        assertEquals(l4.head, v4);
+        assertEquals(l4.tail, l3);
+        assertEquals(l3.head, v3);
+        assertEquals(l3.tail, l2);
+        assertEquals(l2.head, v2);
+        assertEquals(l2.tail, l1);
+        assertEquals(l1.head, v1);
+        assertTrue(l1.tail.isEmpty());
     }
 
     @Test
     public void getSingleMatch() {
-        Assert.assertEquals(l5.get("b"), v2);
+        assertEquals(l5.get("b"), v2);
     }
 
     @Test
     public void getSingleNoMatch() {
-        Assert.assertNull(l5.get("f"));
+        assertNull(l5.get("f"));
     }
 
     @Test
     public void getMultiMultiMatch() {
         final ParseValueList res = l5.getAll("a");
-        Assert.assertEquals(res.head, v3);
-        Assert.assertEquals(res.tail.head, v1);
-        Assert.assertTrue(res.tail.tail.isEmpty());
+        assertEquals(res.head, v3);
+        assertEquals(res.tail.head, v1);
+        assertTrue(res.tail.tail.isEmpty());
     }
 
     @Test
     public void getMultiSingleMatch() {
         final ParseValueList res = l5.getAll("d");
-        Assert.assertEquals(res.head, v4);
-        Assert.assertTrue(res.tail.isEmpty());
+        assertEquals(res.head, v4);
+        assertTrue(res.tail.isEmpty());
     }
 
     @Test
     public void getMultiNoMatch() {
         final ParseValueList res = l5.getAll("f");
-        Assert.assertTrue(res.isEmpty());
+        assertTrue(res.isEmpty());
     }
 
     @Test
     public void getScopedMatch() {
         final ParseValueList res = l5.getValuesSincePrefix(v3);
-        Assert.assertEquals(res.head, v5);
-        Assert.assertEquals(res.tail.head, v4);
-        Assert.assertTrue(res.tail.tail.isEmpty());
+        assertEquals(res.head, v5);
+        assertEquals(res.tail.head, v4);
+        assertTrue(res.tail.tail.isEmpty());
     }
 
     @Test
     public void getScopedNoMatch() {
         final ParseValueList res = l5.getValuesSincePrefix(v5);
-        Assert.assertTrue(res.isEmpty());
+        assertTrue(res.isEmpty());
     }
 
     @Test
     public void reverse() {
         final ParseValueList rev = l5.reverse();
-        Assert.assertEquals(rev.head, v1);
-        Assert.assertEquals(rev.tail.head, v2);
-        Assert.assertEquals(rev.tail.tail.head, v3);
-        Assert.assertEquals(rev.tail.tail.tail.head, v4);
-        Assert.assertEquals(rev.tail.tail.tail.tail.head, v5);
-        Assert.assertTrue(rev.tail.tail.tail.tail.tail.isEmpty());
+        assertEquals(rev.head, v1);
+        assertEquals(rev.tail.head, v2);
+        assertEquals(rev.tail.tail.head, v3);
+        assertEquals(rev.tail.tail.tail.head, v4);
+        assertEquals(rev.tail.tail.tail.tail.head, v5);
+        assertTrue(rev.tail.tail.tail.tail.tail.isEmpty());
     }
 
     @Test
     public void reverseEmpty() {
-        Assert.assertTrue(ParseValueList.EMPTY.reverse().isEmpty());
+        assertTrue(ParseValueList.EMPTY.reverse().isEmpty());
     }
 
     @Test
     public void size() {
-        Assert.assertEquals(1, l1.size);
-        Assert.assertEquals(5, l5.size);
+        assertEquals(1, l1.size);
+        assertEquals(5, l5.size);
     }
 
     @Test
     public void sizeEmpty() {
-        Assert.assertEquals(0, ParseValueList.EMPTY.size);
+        assertEquals(0, ParseValueList.EMPTY.size);
     }
 
     private ParseValue val(final char c) {

--- a/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
@@ -16,21 +16,23 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.util.TokenDefinitions.eq;
-import static io.parsingdata.metal.util.TokenDefinitions.notEq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.eq;
+import static io.parsingdata.metal.util.TokenDefinitions.notEq;
 
 import java.io.IOException;
 
-import io.parsingdata.metal.token.Token;
-
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import io.parsingdata.metal.token.Token;
 
 @RunWith(JUnit4.class)
 public class ReadUntilTest {
@@ -40,17 +42,17 @@ public class ReadUntilTest {
 
     @Test
     public void readUntilConstant() throws IOException {
-        Assert.assertTrue(_readUntil.parse(stream(1, 2, 3, 4, 42), enc()).succeeded);
+        assertTrue(_readUntil.parse(stream(1, 2, 3, 4, 42), enc()).succeeded);
     }
 
     @Test
     public void readUntilNoSkipping() throws IOException {
-        Assert.assertTrue(_readUntil.parse(stream(42), enc()).succeeded);
+        assertTrue(_readUntil.parse(stream(42), enc()).succeeded);
     }
 
     @Test
     public void readUntilErrorNoTerminator() throws IOException {
-        Assert.assertFalse(_readUntil.parse(stream(1, 2, 3, 4), enc()).succeeded);
+        assertFalse(_readUntil.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ReducersTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReducersTest.java
@@ -16,21 +16,36 @@
 
 package io.parsingdata.metal;
 
+import static io.parsingdata.metal.Shorthand.ADD_REDUCER;
+import static io.parsingdata.metal.Shorthand.CAT_REDUCER;
+import static io.parsingdata.metal.Shorthand.MUL_REDUCER;
+import static io.parsingdata.metal.Shorthand.SUB_REDUCER;
+import static io.parsingdata.metal.Shorthand.add;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.eqNum;
+import static io.parsingdata.metal.Shorthand.fold;
+import static io.parsingdata.metal.Shorthand.foldLeft;
+import static io.parsingdata.metal.Shorthand.foldRight;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.le;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized.Parameters;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
-import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-import java.util.Collection;
-
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EncodingFactory.le;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 public class ReducersTest extends ParameterizedParse {
 
@@ -61,8 +76,8 @@ public class ReducersTest extends ParameterizedParse {
         });
     }
 
-    public ReducersTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public ReducersTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private final static Token reduceAddA = token(1, eq(fold(ref("a"), ADD_REDUCER)));

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -16,22 +16,33 @@
 
 package io.parsingdata.metal;
 
+import static io.parsingdata.metal.Shorthand.ADD_REDUCER;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.first;
+import static io.parsingdata.metal.Shorthand.fold;
+import static io.parsingdata.metal.Shorthand.last;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.repn;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized.Parameters;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
-import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-import java.util.Collection;
-
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
 
@@ -72,8 +83,8 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
         });
     }
 
-    public ReferenceValueExpressionSemanticsTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public ReferenceValueExpressionSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
     private static final Token sequenceMatch2 = seq(any("a"),

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -97,9 +97,9 @@ public class ShorthandsTest {
     }
 
     private void runChoice(final int data, final String matched) throws IOException {
-        final ParseResult res = multiChoice.parse(stream(data), enc());
-        assertTrue(res.succeeded);
-        assertTrue(res.environment.order.current().matches(matched));
+        final ParseResult result = multiChoice.parse(stream(data), enc());
+        assertTrue(result.succeeded);
+        assertTrue(result.environment.order.current().matches(matched));
     }
 
     @Test
@@ -145,16 +145,16 @@ public class ShorthandsTest {
     }
 
     private void checkNameAndValue(final String name, final int value, final Environment env) {
-        OptionalValueList refList = ref(name).eval(env, enc());
-        assertFalse(refList.isEmpty());
-        assertEquals(1, refList.size);
-        assertEquals(value, refList.head.get().asNumeric().intValue());
+        OptionalValueList values = ref(name).eval(env, enc());
+        assertFalse(values.isEmpty());
+        assertEquals(1, values.size);
+        assertEquals(value, values.head.get().asNumeric().intValue());
 
-        while (!refList.isEmpty()) {
-            final Value current = refList.head.get();
+        while (!values.isEmpty()) {
+            final Value current = values.head.get();
             assertThat(current, is(instanceOf(ParseValue.class)));
-            assertEquals(name, ((ParseValue)refList.head.get()).name);
-            refList = refList.tail;
+            assertEquals(name, ((ParseValue)values.head.get()).name);
+            values = values.tail;
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/SimpleTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SimpleTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertFalse;
+
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
@@ -47,19 +49,19 @@ public class SimpleTest {
     @Test
     public void sizeError() throws IOException {
         final Token token = buildSimpleToken("r1", 2, 1);
-        Assert.assertFalse(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
+        assertFalse(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void predicateError() throws IOException {
         final Token token = buildSimpleToken("r1", 1, 2);
-        Assert.assertFalse(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
+        assertFalse(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void sourceError() throws IOException {
         final Token token = buildSimpleToken("r1", 1, 1);
-        Assert.assertFalse(token.parse(stream(2, 2, 2, 2), enc()).succeeded);
+        assertFalse(token.parse(stream(2, 2, 2, 2), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SimpleTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SimpleTest.java
@@ -19,17 +19,17 @@ package io.parsingdata.metal;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.io.IOException;
-
-import io.parsingdata.metal.token.Token;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import io.parsingdata.metal.token.Token;
 
 @RunWith(JUnit4.class)
 public class SimpleTest {
@@ -40,26 +40,26 @@ public class SimpleTest {
 
     @Test
     public void correct() throws IOException {
-        final Token t = buildSimpleToken("r1", 1, 1);
-        Assert.assertTrue(t.parse(stream(1, 2, 3, 4), enc()).succeeded);
+        final Token token = buildSimpleToken("r1", 1, 1);
+        Assert.assertTrue(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void sizeError() throws IOException {
-        final Token t = buildSimpleToken("r1", 2, 1);
-        Assert.assertFalse(t.parse(stream(1, 2, 3, 4), enc()).succeeded);
+        final Token token = buildSimpleToken("r1", 2, 1);
+        Assert.assertFalse(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void predicateError() throws IOException {
-        final Token t = buildSimpleToken("r1", 1, 2);
-        Assert.assertFalse(t.parse(stream(1, 2, 3, 4), enc()).succeeded);
+        final Token token = buildSimpleToken("r1", 1, 2);
+        Assert.assertFalse(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test
     public void sourceError() throws IOException {
-        final Token t = buildSimpleToken("r1", 1, 1);
-        Assert.assertFalse(t.parse(stream(2, 2, 2, 2), enc()).succeeded);
+        final Token token = buildSimpleToken("r1", 1, 1);
+        Assert.assertFalse(token.parse(stream(2, 2, 2, 2), enc()).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SimpleTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SimpleTest.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -26,7 +27,6 @@ import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -43,7 +43,7 @@ public class SimpleTest {
     @Test
     public void correct() throws IOException {
         final Token token = buildSimpleToken("r1", 1, 1);
-        Assert.assertTrue(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
+        assertTrue(token.parse(stream(1, 2, 3, 4), enc()).succeeded);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -51,43 +51,43 @@ public class SubStructTableTest {
 
     @Test
     public void table() throws IOException {
-        final Environment env = stream(3, 6, 4, 9, 42, 84, 42, 84, 0, 42, 84);
-                            /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10
-                             * count:  ^
-                             * pointers:  ^, ^, ^
-                             * ref1:      +----------------^^--^^
-                             * ref2:         +-----^^--^^
-                             * ref3:            +---------------------^^--^^
-                             */
-        final ParseResult res = table.parse(env, enc());
-        assertTrue(res.succeeded);
-        assertEquals(4, res.environment.offset);
-        final ParseGraph order = res.environment.order;
-        checkStruct(order.head.asGraph().head.asGraph().head.asGraph(), 6);
-        checkStruct(order.head.asGraph().head.asGraph().tail.head.asGraph(), 4);
-        checkStruct(order.head.asGraph().head.asGraph().tail.tail.head.asGraph(), 9);
+        final Environment environment = stream(3, 6, 4, 9, 42, 84, 42, 84, 0, 42, 84);
+                                    /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10
+                                     * count:  ^
+                                     * pointers:  ^, ^, ^
+                                     * ref1:      +----------------^^--^^
+                                     * ref2:         +-----^^--^^
+                                     * ref3:            +---------------------^^--^^
+                                     */
+        final ParseResult result = table.parse(environment, enc());
+        assertTrue(result.succeeded);
+        assertEquals(4, result.environment.offset);
+        final ParseGraph graph = result.environment.order;
+        checkStruct(graph.head.asGraph().head.asGraph().head.asGraph(), 6);
+        checkStruct(graph.head.asGraph().head.asGraph().tail.head.asGraph(), 4);
+        checkStruct(graph.head.asGraph().head.asGraph().tail.tail.head.asGraph(), 9);
     }
 
     @Test
     public void tableWithDuplicate() throws IOException {
-        final Environment env = stream(4, 7, 5, 5, 10, 42, 84, 42, 84, 0, 42, 84);
-                            /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10, 11
-                             * count:  ^
-                             * pointers:  ^, ^, ^, ^^
-                             * ref1:      +--------------------^^--^^
-                             * ref2:         +---------^^--^^
-                             * ref3:         +---------^^--^^ duplicate!
-                             * ref4:               ++---------------------^^--^^
-                             */
-        final ParseResult res = table.parse(env, enc());
-        assertTrue(res.succeeded);
-        assertEquals(5, res.environment.offset);
-        final ParseGraph order = res.environment.order;
-        checkStruct(order.head.asGraph().head.asGraph().head.asGraph(), 7);
-        assertTrue(order.head.asGraph().head.asGraph().tail.head.isRef());
-        checkStruct(order.head.asGraph().head.asGraph().tail.head.asRef().resolve(order).asGraph(), 5);
-        checkStruct(order.head.asGraph().head.asGraph().tail.tail.head.asGraph(), 5);
-        checkStruct(order.head.asGraph().head.asGraph().tail.tail.tail.head.asGraph(), 10);
+        final Environment environment = stream(4, 7, 5, 5, 10, 42, 84, 42, 84, 0, 42, 84);
+                                    /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10, 11
+                                     * count:  ^
+                                     * pointers:  ^, ^, ^, ^^
+                                     * ref1:      +--------------------^^--^^
+                                     * ref2:         +---------^^--^^
+                                     * ref3:         +---------^^--^^ duplicate!
+                                     * ref4:               ++---------------------^^--^^
+                                     */
+        final ParseResult result = table.parse(environment, enc());
+        assertTrue(result.succeeded);
+        assertEquals(5, result.environment.offset);
+        final ParseGraph graph = result.environment.order;
+        checkStruct(graph.head.asGraph().head.asGraph().head.asGraph(), 7);
+        assertTrue(graph.head.asGraph().head.asGraph().tail.head.isReference());
+        checkStruct(graph.head.asGraph().head.asGraph().tail.head.asReference().resolve(graph).asGraph(), 5);
+        checkStruct(graph.head.asGraph().head.asGraph().tail.tail.head.asGraph(), 5);
+        checkStruct(graph.head.asGraph().head.asGraph().tail.tail.tail.head.asGraph(), 10);
     }
 
     private void checkStruct(final ParseGraph graph, final int offsetHeader) {

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -26,7 +26,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
-import static io.parsingdata.metal.data.selection.ByType.getRefs;
+import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.seek;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
@@ -42,7 +42,7 @@ import org.junit.Test;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
-import io.parsingdata.metal.data.ParseRef;
+import io.parsingdata.metal.data.ParseReference;
 import io.parsingdata.metal.data.ParseResult;
 import io.parsingdata.metal.token.Token;
 
@@ -58,19 +58,19 @@ public class SubStructTest {
 
     @Test
     public void linkedList() throws IOException {
-        final Environment env = stream(0, 8, 1, 42, 0, 12, 1, 84, 0, 4, 1);
-                            /* offset: 0, 1, 2,  3, 4,  5, 6,  7, 8, 9,10
-                             * struct: -------      --------      -------
-                             * ref 1:     +-----------------------^
-                             * ref 2:               ^----------------+
-                             * ref 3:                   +----------------*
-                             */
-        final ParseResult res = LINKED_LIST.parse(env, enc());
-        Assert.assertTrue(res.succeeded);
-        final ParseGraph out = res.environment.order;
-        Assert.assertEquals(0, getRefs(out).size); // No cycles
+        final Environment environment = stream(0, 8, 1, 42, 0, 12, 1, 84, 0, 4, 1);
+                                    /* offset: 0, 1, 2,  3, 4,  5, 6,  7, 8, 9,10
+                                     * struct: -------      --------      -------
+                                     * ref 1:     +-----------------------^
+                                     * ref 2:               ^----------------+
+                                     * ref 3:                   +----------------*
+                                     */
+        final ParseResult result = LINKED_LIST.parse(environment, enc());
+        Assert.assertTrue(result.succeeded);
+        final ParseGraph graph = result.environment.order;
+        Assert.assertEquals(0, getReferences(graph).size); // No cycles
 
-        final ParseGraph first = out.head.asGraph();
+        final ParseGraph first = graph.head.asGraph();
         checkBranch(first, 0, 8);
 
         final ParseGraph second = first.tail.head.asGraph().head.asGraph().head.asGraph();
@@ -82,25 +82,25 @@ public class SubStructTest {
 
     @Test
     public void linkedListWithSelfReference() throws IOException {
-        final Environment env = stream(0, 0, 1);
-        final ParseResult res = LINKED_LIST.parse(env, enc());
-        Assert.assertTrue(res.succeeded);
-        final ParseGraph out = res.environment.order;
-        Assert.assertEquals(1, getRefs(out).size);
+        final Environment environment = stream(0, 0, 1);
+        final ParseResult result = LINKED_LIST.parse(environment, enc());
+        Assert.assertTrue(result.succeeded);
+        final ParseGraph graph = result.environment.order;
+        Assert.assertEquals(1, getReferences(graph).size);
 
-        final ParseGraph first = out.head.asGraph();
+        final ParseGraph first = graph.head.asGraph();
         checkBranch(first, 0, 0);
 
-        final ParseRef ref = first.tail.head.asGraph().head.asGraph().head.asRef();
-        checkBranch(ref.resolve(out).asGraph(), 0, 0); // Check cycle
+        final ParseReference reference = first.tail.head.asGraph().head.asGraph().head.asReference();
+        checkBranch(reference.resolve(graph).asGraph(), 0, 0); // Check cycle
     }
 
     private ParseGraph startCycle(final int offset) throws IOException {
-        final Environment env = seek(stream(0, 4, 1, 21, 0, 0, 1), offset);
-        final ParseResult res = LINKED_LIST.parse(env, enc());
-        Assert.assertTrue(res.succeeded);
-        Assert.assertEquals(1, getRefs(res.environment.order).size);
-        return res.environment.order;
+        final Environment environment = seek(stream(0, 4, 1, 21, 0, 0, 1), offset);
+        final ParseResult result = LINKED_LIST.parse(environment, enc());
+        Assert.assertTrue(result.succeeded);
+        Assert.assertEquals(1, getReferences(result.environment.order).size);
+        return result.environment.order;
     }
 
     @Test
@@ -113,8 +113,8 @@ public class SubStructTest {
         final ParseGraph second = first.tail.head.asGraph().head.asGraph().head.asGraph();
         checkBranch(second, 4, 0);
 
-        final ParseRef ref = second.tail.head.asGraph().head.asGraph().head.asRef();
-        checkBranch(ref.resolve(graph).asGraph(), 0, 4); // Check cycle
+        final ParseReference reference = second.tail.head.asGraph().head.asGraph().head.asReference();
+        checkBranch(reference.resolve(graph).asGraph(), 0, 4); // Check cycle
     }
 
     @Test
@@ -127,8 +127,8 @@ public class SubStructTest {
         final ParseGraph second = first.tail.head.asGraph().head.asGraph().head.asGraph();
         checkBranch(second, 0, 4);
 
-        final ParseRef ref = second.tail.head.asGraph().head.asGraph().head.asRef();
-        checkBranch(ref.resolve(graph).asGraph(), 4, 0); // Check cycle
+        final ParseReference reference = second.tail.head.asGraph().head.asGraph().head.asReference();
+        checkBranch(reference.resolve(graph).asGraph(), 4, 0); // Check cycle
     }
 
     private void checkBranch(final ParseGraph graph, final int graphOffset, final int nextOffset) {

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.cat;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -36,7 +39,6 @@ import static junit.framework.TestCase.assertFalse;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import io.parsingdata.metal.data.Environment;
@@ -66,9 +68,9 @@ public class SubStructTest {
                                      * ref 3:                   +----------------*
                                      */
         final ParseResult result = LINKED_LIST.parse(environment, enc());
-        Assert.assertTrue(result.succeeded);
+        assertTrue(result.succeeded);
         final ParseGraph graph = result.environment.order;
-        Assert.assertEquals(0, getReferences(graph).size); // No cycles
+        assertEquals(0, getReferences(graph).size); // No cycles
 
         final ParseGraph first = graph.head.asGraph();
         checkBranch(first, 0, 8);
@@ -84,9 +86,9 @@ public class SubStructTest {
     public void linkedListWithSelfReference() throws IOException {
         final Environment environment = stream(0, 0, 1);
         final ParseResult result = LINKED_LIST.parse(environment, enc());
-        Assert.assertTrue(result.succeeded);
+        assertTrue(result.succeeded);
         final ParseGraph graph = result.environment.order;
-        Assert.assertEquals(1, getReferences(graph).size);
+        assertEquals(1, getReferences(graph).size);
 
         final ParseGraph first = graph.head.asGraph();
         checkBranch(first, 0, 0);
@@ -98,8 +100,8 @@ public class SubStructTest {
     private ParseGraph startCycle(final int offset) throws IOException {
         final Environment environment = seek(stream(0, 4, 1, 21, 0, 0, 1), offset);
         final ParseResult result = LINKED_LIST.parse(environment, enc());
-        Assert.assertTrue(result.succeeded);
-        Assert.assertEquals(1, getReferences(result.environment.order).size);
+        assertTrue(result.succeeded);
+        assertEquals(1, getReferences(result.environment.order).size);
         return result.environment.order;
     }
 
@@ -144,9 +146,9 @@ public class SubStructTest {
     }
 
     private void checkValue(final ParseItem item, final int value, final int offset) {
-        Assert.assertTrue(item.isValue());
-        Assert.assertEquals(value, item.asValue().asNumeric().intValue());
-        Assert.assertEquals(offset, item.asValue().getOffset());
+        assertTrue(item.isValue());
+        assertEquals(value, item.asValue().asNumeric().intValue());
+        assertEquals(offset, item.asValue().getOffset());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.and;
@@ -64,7 +65,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -102,7 +102,7 @@ public class ToStringTest {
         final Token t = repn(sub(opt(pre(rep(cho(any(n()), seq(nod(v()), whl(def(n(), con(1), e), e)))), e)), v()), v());
         final String output = t.toString();
         for (int i = 0; i < count; i++) {
-            Assert.assertTrue(output.contains(prefix + i));
+            assertTrue(output.contains(prefix + i));
         }
     }
 
@@ -129,9 +129,9 @@ public class ToStringTest {
 
     private void checkToken(final Token t) {
         final String s1s = t.toString();
-        Assert.assertTrue(s1s.contains("_name_a_"));
-        Assert.assertTrue(s1s.contains("_name_b_"));
-        Assert.assertTrue(s1s.contains("_name_c_"));
+        assertTrue(s1s.contains("_name_a_"));
+        assertTrue(s1s.contains("_name_b_"));
+        assertTrue(s1s.contains("_name_c_"));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -16,6 +16,11 @@
 
 package io.parsingdata.metal;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
 import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.and;
 import static io.parsingdata.metal.Shorthand.cat;
@@ -55,10 +60,6 @@ import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -187,7 +188,7 @@ public class ToStringTest {
 
     private Token makeToken(final String name) {
         return new Token(name, enc()) {
-            @Override protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException { return null; }
+            @Override protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException { return null; }
             @Override public String toString() { return name; }
         };
     }

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -16,6 +16,10 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
@@ -32,7 +36,6 @@ import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -79,13 +82,13 @@ public class TreeTest {
 
     @Test
     public void checkRegularTree() {
-        Assert.assertTrue(regular.succeeded);
+        assertTrue(regular.succeeded);
         checkStructure(Reversal.reverse(regular.environment.order).head.asGraph(), 0);
     }
 
     @Test
     public void checkCyclicTree() {
-        Assert.assertTrue(cyclic.succeeded);
+        assertTrue(cyclic.succeeded);
         checkStructure(Reversal.reverse(cyclic.environment.order).head.asGraph(), 0);
     }
 
@@ -96,7 +99,7 @@ public class TreeTest {
     private void checkStructure(final ParseGraph root, final ParseGraph graph, final long offset) {
         checkHeader(graph, offset);
         final ParseItem left = graph.tail.tail.head;
-        Assert.assertTrue(left.isValue());
+        assertTrue(left.isValue());
         final long leftOffset = left.asValue().asNumeric().longValue();
         if (leftOffset != 0) {
             final ParseItem leftItem = graph.tail.tail.tail.head.asGraph().head;
@@ -104,7 +107,7 @@ public class TreeTest {
         }
 
         final ParseItem right = leftOffset != 0 ? graph.tail.tail.tail.tail.head : graph.tail.tail.tail.head;
-        Assert.assertTrue(right.isValue());
+        assertTrue(right.isValue());
         final long rightOffset = right.asValue().asNumeric().longValue();
         if (rightOffset != 0) {
             final ParseItem rightItem = (leftOffset != 0 ? graph.tail.tail.tail.tail.tail.head : graph.tail.tail.tail.tail.head);
@@ -114,7 +117,7 @@ public class TreeTest {
     }
 
     private void checkBranch(final ParseGraph root, final long offset, final ParseItem item) {
-        Assert.assertFalse(item.isValue());
+        assertFalse(item.isValue());
         if (item.asGraph().head.isGraph()) {
             checkStructure(root, item.asGraph().head.asGraph(), offset);
         } else if (item.asGraph().head.isReference()) {
@@ -124,19 +127,19 @@ public class TreeTest {
 
     private void checkHeader(final ParseGraph graph, final long offset) {
         final ParseItem head = graph.head;
-        Assert.assertTrue(head.isValue());
-        Assert.assertEquals(HEAD, head.asValue().asNumeric().intValue());
-        Assert.assertEquals(offset, head.asValue().getOffset());
+        assertTrue(head.isValue());
+        assertEquals(HEAD, head.asValue().asNumeric().intValue());
+        assertEquals(offset, head.asValue().getOffset());
         final ParseItem nr = graph.tail.head;
-        Assert.assertTrue(nr.isValue());
+        assertTrue(nr.isValue());
     }
 
     @Test
     public void checkRegularTreeFlat() {
-        Assert.assertTrue(regular.succeeded);
+        assertTrue(regular.succeeded);
         final ParseValueList nrs = getAllValues(regular.environment.order, "nr");
         for (int i = 0; i < 7; i++) {
-            Assert.assertTrue(contains(nrs, i));
+            assertTrue(contains(nrs, i));
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -58,42 +58,42 @@ public class TreeTest {
             pre(sub(token("tree"), last(ref("right"))), not(eq(last(ref("right")), con(0))))
         );
 
-    private final ParseResult _regular;
-    private final ParseResult _cyclic;
+    private final ParseResult regular;
+    private final ParseResult cyclic;
 
     public TreeTest() throws IOException {
-        _regular = TREE.parse(stream(HEAD, 0, 6, 10, 8, 8, HEAD, 1, 16, 20, HEAD, 2, 24, 28, 8, 8, HEAD, 3, 0, 0, HEAD, 4, 0, 0, HEAD, 5, 0, 0, HEAD, 6, 0, 0), enc());
-                                  /* *--------+---+        *---------+---+  *---------+---+        *--------*--*  *--------*--*  *--------*--*  *--------*--*
-                                   *          \---|--------/         \---|--|---------|---|--------/              |              |              |
-                                   *              \----------------------|--/         \---|-----------------------|--------------/              |
-                                   *                                     \----------------|-----------------------/                             |
-                                   *                                                      \-----------------------------------------------------/
-                                   */
-        _cyclic = TREE.parse(stream(HEAD, 0, 4, 8, HEAD, 1, 8, 0, HEAD, 2, 4, 0), enc());
-                                 /* *--------+--+  *--------+--*  *--------+--*
-                                  *          \--|--/        \-----/        |
-                                  *             \--|--------------/        |
-                                  *                \-----------------------/
+        regular = TREE.parse(stream(HEAD, 0, 6, 10, 8, 8, HEAD, 1, 16, 20, HEAD, 2, 24, 28, 8, 8, HEAD, 3, 0, 0, HEAD, 4, 0, 0, HEAD, 5, 0, 0, HEAD, 6, 0, 0), enc());
+                                 /* *--------+---+        *---------+---+  *---------+---+        *--------*--*  *--------*--*  *--------*--*  *--------*--*
+                                  *          \---|--------/         \---|--|---------|---|--------/              |              |              |
+                                  *              \----------------------|--/         \---|-----------------------|--------------/              |
+                                  *                                     \----------------|-----------------------/                             |
+                                  *                                                      \-----------------------------------------------------/
                                   */
+        cyclic = TREE.parse(stream(HEAD, 0, 4, 8, HEAD, 1, 8, 0, HEAD, 2, 4, 0), enc());
+                                /* *--------+--+  *--------+--*  *--------+--*
+                                 *          \--|--/        \-----/        |
+                                 *             \--|--------------/        |
+                                 *                \-----------------------/
+                                 */
     }
 
     @Test
     public void checkRegularTree() {
-        Assert.assertTrue(_regular.succeeded);
-        checkStruct(Reversal.reverse(_regular.environment.order).head.asGraph(), 0);
+        Assert.assertTrue(regular.succeeded);
+        checkStructure(Reversal.reverse(regular.environment.order).head.asGraph(), 0);
     }
 
     @Test
     public void checkCyclicTree() {
-        Assert.assertTrue(_cyclic.succeeded);
-        checkStruct(Reversal.reverse(_cyclic.environment.order).head.asGraph(), 0);
+        Assert.assertTrue(cyclic.succeeded);
+        checkStructure(Reversal.reverse(cyclic.environment.order).head.asGraph(), 0);
     }
 
-    private void checkStruct(final ParseGraph graph, final long offset) {
-        checkStruct(graph, graph, offset);
+    private void checkStructure(final ParseGraph graph, final long offset) {
+        checkStructure(graph, graph, offset);
     }
 
-    private void checkStruct(final ParseGraph root, final ParseGraph graph, final long offset) {
+    private void checkStructure(final ParseGraph root, final ParseGraph graph, final long offset) {
         checkHeader(graph, offset);
         final ParseItem left = graph.tail.tail.head;
         Assert.assertTrue(left.isValue());
@@ -116,9 +116,9 @@ public class TreeTest {
     private void checkBranch(final ParseGraph root, final long offset, final ParseItem item) {
         Assert.assertFalse(item.isValue());
         if (item.asGraph().head.isGraph()) {
-            checkStruct(root, item.asGraph().head.asGraph(), offset);
-        } else if (item.asGraph().head.isRef()) {
-            checkHeader(item.asGraph().head.asRef().resolve(root).asGraph(), offset);
+            checkStructure(root, item.asGraph().head.asGraph(), offset);
+        } else if (item.asGraph().head.isReference()) {
+            checkHeader(item.asGraph().head.asReference().resolve(root).asGraph(), offset);
         }
     }
 
@@ -133,8 +133,8 @@ public class TreeTest {
 
     @Test
     public void checkRegularTreeFlat() {
-        Assert.assertTrue(_regular.succeeded);
-        final ParseValueList nrs = getAllValues(_regular.environment.order, "nr");
+        Assert.assertTrue(regular.succeeded);
+        final ParseValueList nrs = getAllValues(regular.environment.order, "nr");
         for (int i = 0; i < 7; i++) {
             Assert.assertTrue(contains(nrs, i));
         }

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.cat;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -28,7 +31,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -50,12 +52,12 @@ public class ValueExpressionSemanticsTest {
 
     @Test
     public void Cat() throws IOException {
-        Assert.assertTrue(cat.parse(stream(1, 2, 1, 2), enc()).succeeded);
+        assertTrue(cat.parse(stream(1, 2, 1, 2), enc()).succeeded);
     }
 
     @Test
     public void CatNoMatch() throws IOException {
-        Assert.assertFalse(cat.parse(stream(1, 2, 12, 12), enc()).succeeded);
+        assertFalse(cat.parse(stream(1, 2, 12, 12), enc()).succeeded);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -22,18 +22,24 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
-
-import io.parsingdata.metal.token.Token;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueOperation;
+import io.parsingdata.metal.token.Token;
 
 @RunWith(JUnit4.class)
 public class ValueExpressionSemanticsTest {
@@ -50,6 +56,22 @@ public class ValueExpressionSemanticsTest {
     @Test
     public void CatNoMatch() throws IOException {
         Assert.assertFalse(cat.parse(stream(1, 2, 12, 12), enc()).succeeded);
+    }
+
+    @Test
+    public void callback() throws IOException {
+        final Environment data = stream(1, 2, 3, 4);
+        def("a", 4, eq(new UnaryValueExpression(ref("a")) {
+            @Override
+            public OptionalValue eval(Value value, Environment environment, Encoding encoding) {
+                return value.operation(new ValueOperation() {
+                    @Override
+                    public OptionalValue execute(Value value) {
+                        return OptionalValue.of(value);
+                    }
+                });
+            }
+        })).parse(data, enc());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -74,12 +74,12 @@ public class ParseGraphTest {
         pgl = makeLongGraph();
     }
 
-    private static ParseValue makeValWithDef(final char n, final Token t, final long o) {
-        return new ParseValue(Character.toString(n), t, o, new byte[] { (byte) n }, enc());
+    private static ParseValue makeValWithDef(final char name, final Token token, final long offset) {
+        return new ParseValue(Character.toString(name), token, offset, new byte[] { (byte) name }, enc());
     }
 
-    private static ParseValue makeVal(final char n, final long o) {
-        return makeValWithDef(n, def(Character.toString(n), o), o);
+    private static ParseValue makeVal(final char name, final long offset) {
+        return makeValWithDef(name, def(Character.toString(name), offset), offset);
     }
 
     private ParseGraph makeSimpleGraph() {
@@ -127,7 +127,7 @@ public class ParseGraphTest {
             .add(a)
             .addBranch(t)
             .add(b)
-            .add(new ParseRef(a.getOffset(), aDef))
+            .add(new ParseReference(a.getOffset(), aDef))
             .closeBranch();
     }
 
@@ -135,8 +135,8 @@ public class ParseGraphTest {
     public void cycle() {
         assertEquals(2, pgc.size);
         assertTrue(pgc.head.isGraph());
-        assertTrue(pgc.head.asGraph().head.isRef());
-        assertEquals(a, pgc.head.asGraph().head.asRef().resolve(pgc));
+        assertTrue(pgc.head.asGraph().head.isReference());
+        assertEquals(a, pgc.head.asGraph().head.asReference().resolve(pgc));
         assertTrue(pgc.head.asGraph().tail.head.isValue());
         assertEquals(b, pgc.head.asGraph().tail.head);
         assertTrue(pgc.tail.head.isValue());
@@ -189,14 +189,14 @@ public class ParseGraphTest {
 
     @Test
     public void testHeadContainsLowestOffsetValue() throws IOException {
-        final Environment stream = stream(0, 0, 0);
+        final Environment environment = stream(0, 0, 0);
         final Token token = seq(
             repn(
                  def("zero", 1),
                  con(2)),
             nod(con(1)));
         // creates a ParseGraph with values in the head, and an empty graph as tail
-        final ParseResult result = token.parse(stream, enc());
+        final ParseResult result = token.parse(environment, enc());
         assertTrue(result.environment.order.head.asGraph().head.asGraph().head.isValue());
     }
 
@@ -259,14 +259,14 @@ public class ParseGraphTest {
     @Test
     public void testAsRef() {
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseGraph to ParseRef.");
-        EMPTY.asRef();
+        thrown.expectMessage("Cannot convert ParseGraph to ParseReference.");
+        EMPTY.asReference();
     }
 
     @Test
     public void testCurrent() {
         assertNull(EMPTY.current());
-        assertNull(EMPTY.add(new ParseRef(0, NONE)).current());
+        assertNull(EMPTY.add(new ParseReference(0, NONE)).current());
         assertNull(EMPTY.addBranch(NONE).current());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -59,13 +59,13 @@ public class ParseReferenceTest {
     }
 
     @Test
-    public void refIsARef() {
+    public void referenceIsAReference() {
         assertTrue(reference.isReference());
         assertThat(reference.asReference(), is(sameInstance(reference)));
     }
 
     @Test
-    public void refIsNotAValue() {
+    public void referenceIsNotAValue() {
         assertFalse(reference.isValue());
 
         thrown.expect(UnsupportedOperationException.class);
@@ -74,7 +74,7 @@ public class ParseReferenceTest {
     }
 
     @Test
-    public void refIsNotAGraph() {
+    public void referenceIsNotAGraph() {
         assertFalse(reference.isGraph());
 
         thrown.expect(UnsupportedOperationException.class);

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -16,66 +16,70 @@
 
 package io.parsingdata.metal.data;
 
-import static io.parsingdata.metal.Shorthand.*;
-import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import io.parsingdata.metal.token.Token;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.sub;
+import static junit.framework.TestCase.assertFalse;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class ParseRefTest {
+import io.parsingdata.metal.token.Token;
+
+public class ParseReferenceTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private Token _definition;
-    private ParseRef _ref;
+    private Token definition;
+    private ParseReference reference;
 
     @Before
     public void setUp() {
-        _definition = sub(def("value", 1), con(0));
-        _ref = new ParseRef(0L, _definition);
+        definition = sub(def("value", 1), con(0));
+        reference = new ParseReference(0L, definition);
     }
 
     @Test
     public void state() {
-        assertThat(_ref.location, is(0L));
-        assertThat(_ref.getDefinition(), is(_definition));
+        assertThat(reference.location, is(0L));
+        assertThat(reference.getDefinition(), is(definition));
     }
 
     @Test
     public void toStringTest() {
-        assertThat(_ref.toString(), is("ref(@0)"));
+        assertThat(reference.toString(), is("ref(@0)"));
     }
 
     @Test
     public void refIsARef() {
-        assertTrue(_ref.isRef());
-        assertThat(_ref.asRef(), is(sameInstance(_ref)));
+        assertTrue(reference.isReference());
+        assertThat(reference.asReference(), is(sameInstance(reference)));
     }
 
     @Test
     public void refIsNotAValue() {
-        assertFalse(_ref.isValue());
+        assertFalse(reference.isValue());
 
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseRef to ParseValue");
-        _ref.asValue();
+        thrown.expectMessage("Cannot convert ParseReference to ParseValue");
+        reference.asValue();
     }
 
     @Test
     public void refIsNotAGraph() {
-        assertFalse(_ref.isGraph());
+        assertFalse(reference.isGraph());
 
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseRef to ParseGraph");
-        _ref.asGraph();
+        thrown.expectMessage("Cannot convert ParseReference to ParseGraph");
+        reference.asGraph();
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -16,76 +16,80 @@
 
 package io.parsingdata.metal.data;
 
-import io.parsingdata.metal.token.Token;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static junit.framework.TestCase.assertFalse;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static io.parsingdata.metal.Shorthand.def;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static junit.framework.TestCase.assertFalse;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import io.parsingdata.metal.token.Token;
 
 public class ParseValueTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private Token _definition;
-    private ParseValue _value;
+    private Token definition;
+    private ParseValue value;
 
     @Before
     public void setUp() {
-        _definition = def("value", 1);
-        _value = new ParseValue("value", _definition, 0, new byte[] { 1 }, enc());
+        definition = def("value", 1);
+        value = new ParseValue("value", definition, 0, new byte[] { 1 }, enc());
     }
 
     @Test
     public void state() {
-        assertThat(_value.name, is("value"));
-        assertThat(_value.getDefinition(), is(_definition));
-        assertThat(_value.getOffset(), is(0L));
-        assertThat(_value.getValue(), is(equalTo(new byte[] { 1 })));
+        assertThat(value.name, is("value"));
+        assertThat(value.getDefinition(), is(definition));
+        assertThat(value.getOffset(), is(0L));
+        assertThat(value.getValue(), is(equalTo(new byte[] { 1 })));
     }
 
     @Test
     public void matching() {
-        assertTrue(_value.matches("value"));
+        assertTrue(value.matches("value"));
 
-        assertFalse(_value.matches("lue"));
-        assertFalse(_value.matches(".value"));
+        assertFalse(value.matches("lue"));
+        assertFalse(value.matches(".value"));
     }
 
     @Test
     public void toStringTest() {
-        assertThat(_value.toString(), is("value(0x01)"));
+        assertThat(value.toString(), is("value(0x01)"));
     }
 
     @Test
     public void valueIsAValue() {
-        assertTrue(_value.isValue());
-        assertThat(_value.asValue(), is(sameInstance(_value)));
+        assertTrue(value.isValue());
+        assertThat(value.asValue(), is(sameInstance(value)));
     }
 
     @Test
     public void valueIsNotARef() {
-        assertFalse(_value.isRef());
+        assertFalse(value.isReference());
 
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseValue to ParseRef");
-        _value.asRef();
+        thrown.expectMessage("Cannot convert ParseValue to ParseReference");
+        value.asReference();
     }
 
     @Test
     public void valueIsNotAGraph() {
-        assertFalse(_value.isGraph());
+        assertFalse(value.isGraph());
 
         thrown.expect(UnsupportedOperationException.class);
         thrown.expectMessage("Cannot convert ParseValue to ParseGraph");
-        _value.asGraph();
+        value.asGraph();
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -70,8 +70,8 @@ public class CallbackTest {
             .add(new TokenCallback(two, callback))
             .add(new TokenCallback(cho, callback))
             .add(new TokenCallback(sequence, callback));
-        final Environment env = new Environment(new InMemoryByteStream(new byte[] { 2, 1 }), callbacks);
-        assertTrue(sequence.parse(env, enc()).succeeded);
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 2, 1 }), callbacks);
+        assertTrue(sequence.parse(environment, enc()).succeeded);
         assertEquals(4, successCount);
         assertEquals(1, failureCount);
     }
@@ -97,15 +97,15 @@ public class CallbackTest {
     @Test
     public void testSimpleCallback() throws IOException {
         final TokenCallbackList callbacks = createCallbackList(SIMPLE_SEQ, 0L);
-        final Environment env = new Environment(new InMemoryByteStream(new byte[] { 1, 2 }), callbacks);
-        assertTrue(SIMPLE_SEQ.parse(env, enc()).succeeded);
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2 }), callbacks);
+        assertTrue(SIMPLE_SEQ.parse(environment, enc()).succeeded);
     }
 
     @Test
     public void testRepSimpleCallback() throws IOException {
         final TokenCallbackList callbacks = createCallbackList(SIMPLE_SEQ, 0L, 2L);
-        final Environment env = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }), callbacks);
-        assertTrue(rep(SIMPLE_SEQ).parse(env, enc()).succeeded);
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }), callbacks);
+        assertTrue(rep(SIMPLE_SEQ).parse(environment, enc()).succeeded);
     }
 
     @Test
@@ -130,8 +130,8 @@ public class CallbackTest {
                     @Override
                     protected void handleFailure(Token token, Environment environment) {}
                 }));
-        final Environment env = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }), callbacks);
-        assertTrue(repeatingSeq.parse(env, enc()).succeeded);
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }), callbacks);
+        assertTrue(repeatingSeq.parse(environment, enc()).succeeded);
     }
 
     @Test
@@ -145,9 +145,9 @@ public class CallbackTest {
             @Override
             protected void handleFailure(Token token, Environment environment) {}
         }));
-        final Environment env = new Environment(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }), callbacks);
-        assertTrue(SubStructTest.LINKED_LIST.parse(env, enc()).succeeded);
-        // The ParseRef does not trigger the callback:
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }), callbacks);
+        assertTrue(SubStructTest.LINKED_LIST.parse(environment, enc()).succeeded);
+        // The ParseReference does not trigger the callback:
         assertEquals(2, linkedListCount);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -75,8 +75,8 @@ public class ByTokenTest {
     private static final Token MUT_REC_1 = seq(DEF1, new Token("", enc()) {
 
         @Override
-        protected ParseResult parseImpl(final String scope, final Environment env, final Encoding enc) throws IOException {
-            return MUT_REC_2.parse(scope, env, enc);
+        protected ParseResult parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+            return MUT_REC_2.parse(scope, environment, encoding);
         }
     });
 
@@ -96,25 +96,25 @@ public class ByTokenTest {
     @Test
     public void findRootToken() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2), SIMPLE_SEQ);
-        final ParseItem parseItem = get(graph, SIMPLE_SEQ);
+        final ParseItem item = get(graph, SIMPLE_SEQ);
 
-        assertThat(parseItem.getDefinition(), is(equalTo(SIMPLE_SEQ)));
+        assertThat(item.getDefinition(), is(equalTo(SIMPLE_SEQ)));
     }
 
     @Test
     public void findNestedToken() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2), SIMPLE_SEQ);
-        final ParseItem parseItem = get(graph, DEF1);
+        final ParseItem item = get(graph, DEF1);
 
-        assertThat(parseItem.getDefinition(), is(equalTo(DEF1)));
+        assertThat(item.getDefinition(), is(equalTo(DEF1)));
     }
 
     @Test
     public void findUnusedToken() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2), SIMPLE_SEQ);
-        final ParseItem parseItem = get(graph, UNUSED_DEF);
+        final ParseItem item = get(graph, UNUSED_DEF);
 
-        assertThat(parseItem, is(nullValue()));
+        assertThat(item, is(nullValue()));
     }
 
     @Test
@@ -128,92 +128,92 @@ public class ByTokenTest {
     @Test
     public void getAllUnusedToken() {
         final ParseGraph graph = parseResultGraph(stream(0), SEQ_REP);
-        final ParseItemList list = getAll(graph, UNUSED_DEF);
+        final ParseItemList items = getAll(graph, UNUSED_DEF);
 
-        assertThat(list.size, is(equalTo(0L)));
+        assertThat(items.size, is(equalTo(0L)));
     }
 
     @Test
     public void getAllNonePresent() {
         final ParseGraph graph = parseResultGraph(stream(0), SEQ_REP);
-        final ParseItemList list = getAll(graph, DEF2);
+        final ParseItemList items = getAll(graph, DEF2);
 
-        assertThat(list.size, is(equalTo(0L)));
+        assertThat(items.size, is(equalTo(0L)));
     }
 
     @Test
     public void getAllSingleDef() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2, 3, 4, 5), SEQ_REP);
-        final ParseItemList list = getAll(graph, DEF1);
+        final ParseItemList items = getAll(graph, DEF1);
 
-        assertThat(list.size, is(equalTo(1L)));
-        assertThat(list.head.getDefinition(), is(equalTo(DEF1)));
+        assertThat(items.size, is(equalTo(1L)));
+        assertThat(items.head.getDefinition(), is(equalTo(DEF1)));
     }
 
     @Test
     public void getAllRepDef() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2, 3, 4, 5), SEQ_REP);
-        final ParseItemList list = getAll(graph, DEF2);
+        final ParseItemList items = getAll(graph, DEF2);
 
-        assertThat(list.size, is(equalTo(5L)));
-        assertThat(list.head.getDefinition(), is(equalTo(DEF2)));
+        assertThat(items.size, is(equalTo(5L)));
+        assertThat(items.head.getDefinition(), is(equalTo(DEF2)));
     }
 
     @Test
     public void getAllRepSeq() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2, 3, 4, 5), rep(SIMPLE_SEQ));
-        final ParseItemList list1 = getAll(graph, DEF1);
-        final ParseItemList list2 = getAll(graph, DEF2);
+        final ParseItemList def1Items = getAll(graph, DEF1);
+        final ParseItemList def2Items = getAll(graph, DEF2);
 
-        assertThat(list1.size, is(equalTo(3L)));
-        assertThat(list2.size, is(equalTo(3L)));
+        assertThat(def1Items.size, is(equalTo(3L)));
+        assertThat(def2Items.size, is(equalTo(3L)));
 
-        assertThat(list1.head.getDefinition(), is(equalTo(DEF1)));
-        assertThat(list2.head.getDefinition(), is(equalTo(DEF2)));
+        assertThat(def1Items.head.getDefinition(), is(equalTo(DEF1)));
+        assertThat(def2Items.head.getDefinition(), is(equalTo(DEF2)));
 
-        assertThat(list1.tail.head.asValue().asNumeric().intValue(), is(equalTo(2)));
-        assertThat(list2.tail.head.asValue().asNumeric().intValue(), is(equalTo(3)));
+        assertThat(def1Items.tail.head.asValue().asNumeric().intValue(), is(equalTo(2)));
+        assertThat(def2Items.tail.head.asValue().asNumeric().intValue(), is(equalTo(3)));
     }
 
     @Test
     public void getAllSub() {
         final ParseGraph graph = parseResultGraph(stream(4, 2, 2, 3, 4, 5), SEQ_SUB);
-        final ParseItemList list = getAll(graph, TWO_BYTES);
+        final ParseItemList items = getAll(graph, TWO_BYTES);
 
-        assertThat(list.size, is(equalTo(2L)));
-        assertThat(list.head.getDefinition(), is(equalTo(TWO_BYTES)));
-        assertThat(list.head.asValue().getValue(), is(equalTo(new byte[]{2, 3})));
+        assertThat(items.size, is(equalTo(2L)));
+        assertThat(items.head.getDefinition(), is(equalTo(TWO_BYTES)));
+        assertThat(items.head.asValue().getValue(), is(equalTo(new byte[]{2, 3})));
     }
 
     @Test
     public void getAllMutualRecursive() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2, 3, 4, 5), MUT_REC_1);
 
-        final ParseItemList repList = getAll(graph, REPN_DEF2);
-        assertThat(repList.size, is(equalTo(4L)));
+        final ParseItemList repItems = getAll(graph, REPN_DEF2);
+        assertThat(repItems.size, is(equalTo(4L)));
 
-        final ParseItemList repRootList = getAllRoots(graph, REPN_DEF2);
-        assertThat(repRootList.size, is(equalTo(2L)));
+        final ParseItemList repRootItems = getAllRoots(graph, REPN_DEF2);
+        assertThat(repRootItems.size, is(equalTo(2L)));
 
-        final ParseItemList recList = getAll(graph, MUT_REC_1);
-        assertThat(recList.size, is(equalTo(4L)));
+        final ParseItemList recursiveItems = getAll(graph, MUT_REC_1);
+        assertThat(recursiveItems.size, is(equalTo(4L)));
 
-        final ParseItemList recRootList = getAllRoots(graph, MUT_REC_1);
-        assertThat(recRootList.size, is(equalTo(2L)));
+        final ParseItemList recursiveRootItems = getAllRoots(graph, MUT_REC_1);
+        assertThat(recursiveRootItems.size, is(equalTo(2L)));
     }
 
     @Test
     public void compareGetAllNameWithGetAllToken() {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2, 3, 4, 5), SEQ_REP);
 
-        ParseValueList valueList = getAllValues(graph, "value2");
-        ParseItemList itemList = getAll(graph, DEF2);
+        ParseValueList values = getAllValues(graph, "value2");
+        ParseItemList items = getAll(graph, DEF2);
 
-        while (valueList.head != null) {
-            assertThat(valueList.head, is(equalTo(itemList.head.asValue())));
+        while (values.head != null) {
+            assertThat(values.head, is(equalTo(items.head.asValue())));
 
-            valueList = valueList.tail;
-            itemList = itemList.tail;
+            values = values.tail;
+            items = items.tail;
         }
     }
 
@@ -234,9 +234,9 @@ public class ByTokenTest {
         final ParseResult result = composition.parse(stream(0), enc());
         assertTrue(result.succeeded);
         final ParseItemList items = getAll(result.environment.order, DEF2);
-        // should return the ParseGraph created by the Sub and the ParseRef that refers to the existing ParseItem
+        // should return the ParseGraph created by the Sub and the ParseReference that refers to the existing ParseItem
         assertEquals(2, items.size);
-        assertTrue(items.head.isRef());
+        assertTrue(items.head.isReference());
         assertTrue(items.tail.head.isValue());
     }
 
@@ -247,10 +247,10 @@ public class ByTokenTest {
         final Token topSeq = seq(any("a"), smallSeq);
         final ParseResult result = topSeq.parse(stream(1, 2, 3), enc());
         assertTrue(result.succeeded);
-        final ParseItemList seqs = getAllRoots(result.environment.order, smallSeq);
-        assertEquals(1, seqs.size);
-        assertEquals(smallSeq, seqs.head.getDefinition());
-        final ParseValue c = seqs.head.asGraph().head.asValue();
+        final ParseItemList seqItems = getAllRoots(result.environment.order, smallSeq);
+        assertEquals(1, seqItems.size);
+        assertEquals(smallSeq, seqItems.head.getDefinition());
+        final ParseValue c = seqItems.head.asGraph().head.asValue();
         assertEquals(3, c.asNumeric().intValue());
         assertEquals(2, c.getOffset());
     }
@@ -260,15 +260,15 @@ public class ByTokenTest {
         final Token topSeq = seq(any("a"), smallSeq, smallSeq);
         final ParseResult result = topSeq.parse(stream(1, 2, 3, 2, 3), enc());
         assertTrue(result.succeeded);
-        final ParseItemList seqs = getAllRoots(result.environment.order, smallSeq);
-        assertEquals(2, seqs.size);
-        assertEquals(smallSeq, seqs.head.getDefinition());
-        assertEquals(smallSeq, seqs.tail.head.getDefinition());
-        final ParseValue c1 = seqs.head.asGraph().head.asValue();
+        final ParseItemList seqItems = getAllRoots(result.environment.order, smallSeq);
+        assertEquals(2, seqItems.size);
+        assertEquals(smallSeq, seqItems.head.getDefinition());
+        assertEquals(smallSeq, seqItems.tail.head.getDefinition());
+        final ParseValue c1 = seqItems.head.asGraph().head.asValue();
         assertEquals(3, c1.asNumeric().intValue());
-        final ParseValue c2 = seqs.tail.head.asGraph().head.asValue();
+        final ParseValue c2 = seqItems.tail.head.asGraph().head.asValue();
         assertEquals(3, c2.asNumeric().intValue());
-        assertNotEquals(seqs.head.asGraph().head, seqs.tail.head.asGraph().head);
+        assertNotEquals(seqItems.head.asGraph().head, seqItems.tail.head.asGraph().head);
     }
 
     private Set<ParseItem> makeSet(final ParseItemList seqs) {
@@ -286,10 +286,10 @@ public class ByTokenTest {
                                                                                            /* 2:       +--------+
                                                                                            /* 3:             +--------+ */
         assertTrue(result.succeeded);
-        final ParseItemList seqs = getAllRoots(result.environment.order, smallSeq);
-        assertEquals(6, seqs.size); // Three regular and three subs.
-        final Set<ParseItem> items = makeSet(seqs);
-        assertEquals(seqs.size, items.size()); // Check that there are no duplicate results.
+        final ParseItemList seqItems = getAllRoots(result.environment.order, smallSeq);
+        assertEquals(6, seqItems.size); // Three regular and three subs.
+        final Set<ParseItem> items = makeSet(seqItems);
+        assertEquals(seqItems.size, items.size()); // Check that there are no duplicate results.
         for (final ParseItem item : items) {
             assertTrue(item.isGraph());
             assertEquals(2, item.asGraph().size);
@@ -307,8 +307,8 @@ public class ByTokenTest {
         }
 
         @Override
-        protected ParseResult parseImpl(String scope, Environment env, Encoding enc) throws IOException {
-            return token.parse(scope, env, enc);
+        protected ParseResult parseImpl(String scope, Environment environment, Encoding encoding) throws IOException {
+            return token.parse(scope, environment, encoding);
         }
     }
 
@@ -317,10 +317,10 @@ public class ByTokenTest {
         final CustomToken customToken = new CustomToken();
         final ParseResult result = customToken.parse(stream(1, 2, 3), enc());
         assertTrue(result.succeeded);
-        final ParseItemList seqs = getAllRoots(result.environment.order, customToken.token);
-        assertEquals(3, seqs.size);
-        final Set<ParseItem> items = makeSet(seqs);
-        assertEquals(seqs.size, items.size()); // Check that there are no duplicate results.
+        final ParseItemList seqItems = getAllRoots(result.environment.order, customToken.token);
+        assertEquals(3, seqItems.size);
+        final Set<ParseItem> items = makeSet(seqItems);
+        assertEquals(seqItems.size, items.size()); // Check that there are no duplicate results.
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -16,14 +16,15 @@
 
 package io.parsingdata.metal.data.selection;
 
-import io.parsingdata.metal.data.ParseRef;
+import static io.parsingdata.metal.data.ParseGraph.EMPTY;
+import static io.parsingdata.metal.data.ParseGraph.NONE;
+import static io.parsingdata.metal.data.selection.ByType.getReferences;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static io.parsingdata.metal.data.ParseGraph.EMPTY;
-import static io.parsingdata.metal.data.ParseGraph.NONE;
-import static io.parsingdata.metal.data.selection.ByType.getRefs;
+import io.parsingdata.metal.data.ParseReference;
 
 public class ByTypeTest {
 
@@ -34,7 +35,7 @@ public class ByTypeTest {
     public void unresolvableRef() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("A ref must point to an existing graph.");
-        getRefs(EMPTY.add(new ParseRef(0, NONE)));
+        getReferences(EMPTY.add(new ParseReference(0, NONE)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/BinaryValueExpressionListSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/BinaryValueExpressionListSemanticsTest.java
@@ -16,20 +16,30 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Shorthand.add;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.first;
+import static io.parsingdata.metal.Shorthand.last;
+import static io.parsingdata.metal.Shorthand.not;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
-import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.Collection;
-
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static io.parsingdata.metal.util.EncodingFactory.*;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 public class BinaryValueExpressionListSemanticsTest extends ParameterizedParse {
 
@@ -53,27 +63,27 @@ public class BinaryValueExpressionListSemanticsTest extends ParameterizedParse {
         });
     }
 
-    public BinaryValueExpressionListSemanticsTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public BinaryValueExpressionListSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
-    private static Token pred2(Expression pred) {
+    private static Token pred2(Expression predicate) {
         return
             seq(any("a"),
                 any("a"),
                 any("b"),
                 any("b"),
-                def("c", con(1), pred));
+                def("c", con(1), predicate));
     }
 
-    private static Token pred3(Expression pred) {
+    private static Token pred3(Expression predicate) {
         return
             seq(any("a"),
                 any("a"),
                 any("a"),
                 any("b"),
                 any("b"),
-                def("c", con(1), pred));
+                def("c", con(1), predicate));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
@@ -16,18 +16,25 @@
 
 package io.parsingdata.metal.expression.value;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.token.Token;
-import io.parsingdata.metal.util.ParameterizedParse;
-import org.junit.runners.Parameterized.Parameters;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.count;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.rep;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static io.parsingdata.metal.Shorthand.*;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import org.junit.runners.Parameterized.Parameters;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.token.Token;
+import io.parsingdata.metal.util.ParameterizedParse;
 
 public class CountTest extends ParameterizedParse {
 
@@ -47,8 +54,8 @@ public class CountTest extends ParameterizedParse {
         });
     }
 
-    public CountTest(final String desc, final Token token, final Environment env, final Encoding enc, final boolean result) {
-        super(token, env, enc, result);
+    public CountTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        super(token, environment, encoding, result);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -16,20 +16,32 @@
 
 package io.parsingdata.metal.expression.value;
 
-import io.parsingdata.metal.data.OptionalValueList;
-import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.token.Token;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-
-import static io.parsingdata.metal.Shorthand.*;
+import static io.parsingdata.metal.Shorthand.cho;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.elvis;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import io.parsingdata.metal.data.OptionalValueList;
+import io.parsingdata.metal.data.ParseResult;
+import io.parsingdata.metal.token.Token;
 
 public class ElvisExpressionTest {
 
@@ -108,6 +120,14 @@ public class ElvisExpressionTest {
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
         final OptionalValueList eval = elvis.eval(stream(0), enc());
         assertEquals(0, eval.size);
+    }
+
+    @Test
+    public void elvisLeftNone() {
+        final ValueExpression elvis = elvis(div(con(1), con(0)), con(1));
+        final OptionalValueList eval = elvis.eval(stream(0), enc());
+        assertEquals(1, eval.size);
+        assertEquals(1, eval.head.get().asNumeric().intValue());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.ADD_REDUCER;
+import static io.parsingdata.metal.Shorthand.DIV_REDUCER;
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -28,9 +29,11 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.foldLeft;
 import static io.parsingdata.metal.Shorthand.foldRight;
 import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
 
@@ -38,6 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseResult;
 
 /**
@@ -59,6 +63,13 @@ public class FoldEdgeCaseTest {
     public void valuesContainsEmpty() {
         assertTrue(foldLeft(div(con(1), con(0)), ADD_REDUCER).eval(stream(0), enc()).isEmpty());
         assertTrue(foldRight(div(con(1), con(0)), ADD_REDUCER).eval(stream(0), enc()).isEmpty());
+    }
+
+    @Test
+    public void foldToEmpty() throws IOException {
+        final Environment environment = rep(any("value")).parse(stream(1, 0), enc()).environment;
+        assertFalse(foldLeft(ref("value"), DIV_REDUCER).eval(environment, enc()).head.isPresent());
+        assertFalse(foldRight(ref("value"), DIV_REDUCER).eval(environment, enc()).head.isPresent());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -17,10 +17,13 @@
 package io.parsingdata.metal.expression.value;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import static io.parsingdata.metal.Shorthand.add;
+import static io.parsingdata.metal.Shorthand.ADD_REDUCER;
 import static io.parsingdata.metal.Shorthand.cho;
+import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.foldLeft;
 import static io.parsingdata.metal.Shorthand.foldRight;
@@ -42,13 +45,6 @@ import io.parsingdata.metal.data.ParseResult;
  */
 public class FoldEdgeCaseTest {
 
-    private final static Reducer ADD_REDUCER = new Reducer() {
-        @Override
-        public ValueExpression reduce(final ValueExpression left, final ValueExpression right) {
-            return add(left, right);
-        }
-    };
-
     private static final Reducer MULTIPLE_VALUE_REDUCER = new Reducer() {
         @Override
         public ValueExpression reduce(final ValueExpression left, final ValueExpression right) {
@@ -58,6 +54,12 @@ public class FoldEdgeCaseTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void valuesContainsEmpty() {
+        assertTrue(foldLeft(div(con(1), con(0)), ADD_REDUCER).eval(stream(0), enc()).isEmpty());
+        assertTrue(foldRight(div(con(1), con(0)), ADD_REDUCER).eval(stream(0), enc()).isEmpty());
+    }
 
     @Test
     public void multipleInits() throws IOException {
@@ -87,8 +89,7 @@ public class FoldEdgeCaseTest {
         assertFalse(parseResult.succeeded);
     }
 
-    @Test
-    public void faultyReducerFoldLeft() throws IOException {
+    private void faultyReducer(final ValueExpression expression) throws IOException {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("Reducer must yield a single value.");
 
@@ -97,22 +98,18 @@ public class FoldEdgeCaseTest {
             def("value", 1),
             def("toFold", 1),
             def("toFold", 1),
-            def("folded", 1, eq(foldLeft(ref("toFold"), MULTIPLE_VALUE_REDUCER)))
+            def("folded", 1, eq(expression))
         ).parse(stream(1, 2, 1, 2, 3), enc());
     }
 
     @Test
-    public void faultyReducerFoldRight() throws IOException {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Reducer must yield a single value.");
+    public void faultyReducerFoldLeft() throws IOException {
+        faultyReducer(foldLeft(ref("toFold"), MULTIPLE_VALUE_REDUCER));
+    }
 
-        seq(
-            def("value", 1), // the reducer returns a Ref to these two values
-            def("value", 1),
-            def("toFold", 1),
-            def("toFold", 1),
-            def("folded", 1, eq(foldRight(ref("toFold"), MULTIPLE_VALUE_REDUCER)))
-        ).parse(stream(1, 2, 1, 2, 3), enc());
+    @Test
+    public void faultyReducerFoldRight() throws IOException {
+        faultyReducer(foldRight(ref("toFold"), MULTIPLE_VALUE_REDUCER));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
@@ -16,6 +16,11 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.nth;
@@ -26,10 +31,6 @@ import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
@@ -65,87 +66,87 @@ public class NthExpressionTest {
     public void testNanIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [Nan], result = [Nan]
         final ParseResult result = format.parse(stream(5, 1, 2, 3, 4, 5, 0), enc());
-        final OptionalValueList list = nth(ref("value"), div(con(0), con(0))).eval(result.environment, enc());
-        assertThat(list.size, is(equalTo(1L)));
-        assertThat(list.head.isPresent(), is(equalTo(false)));
+        final OptionalValueList values = nth(ref("value"), div(con(0), con(0))).eval(result.environment, enc());
+        assertThat(values.size, is(equalTo(1L)));
+        assertThat(values.head.isPresent(), is(equalTo(false)));
     }
 
     @Test
     public void testEmptyValuesSingleIndex() throws IOException {
         // 0 values = [], 1 index = [0], result = [Nan]
-        final OptionalValueList list = makeList(stream(0, 1, 0), 1);
-        assertThat(list.head.isPresent(), is(equalTo(false)));
+        final OptionalValueList values = makeList(stream(0, 1, 0), 1);
+        assertThat(values.head.isPresent(), is(equalTo(false)));
     }
 
     @Test
     public void testNonExistingValueAtIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [42], result = [Nan]
-        final OptionalValueList list = makeList(stream(5, 1, 2, 3, 4, 5, 1, 42), 1);
-        assertThat(list.head.isPresent(), is(equalTo(false)));
+        final OptionalValueList values = makeList(stream(5, 1, 2, 3, 4, 5, 1, 42), 1);
+        assertThat(values.head.isPresent(), is(equalTo(false)));
     }
 
     @Test
     public void testNegativeIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [-1], result = [Nan]
-        final OptionalValueList list = makeList(stream(5, 1, 2, 3, 4, 5, 1, -1), 1);
-        assertThat(list.head.isPresent(), is(equalTo(false)));
+        final OptionalValueList values = makeList(stream(5, 1, 2, 3, 4, 5, 1, -1), 1);
+        assertThat(values.head.isPresent(), is(equalTo(false)));
     }
 
     @Test
     public void testSingleIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [0], result = [1]
-        final OptionalValueList list = makeList(stream(5, 1, 2, 3, 4, 5, 1, 0), 1);
-        assertThat(list.head.get().asNumeric().intValue(), is(equalTo(1)));
+        final OptionalValueList values = makeList(stream(5, 1, 2, 3, 4, 5, 1, 0), 1);
+        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(1)));
     }
 
     @Test
     public void testMultipleIndices() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 2 indices = [0, 2], result = [1, 3]
-        final OptionalValueList list = makeList(stream(5, 1, 2, 3, 4, 5, 2, 0, 2), 2);
-        assertThat(list.head.get().asNumeric().intValue(), is(equalTo(3)));
-        assertThat(list.tail.head.get().asNumeric().intValue(), is(equalTo(1)));
+        final OptionalValueList values = makeList(stream(5, 1, 2, 3, 4, 5, 2, 0, 2), 2);
+        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(3)));
+        assertThat(values.tail.head.get().asNumeric().intValue(), is(equalTo(1)));
     }
 
     @Test
     public void testMultipleIndicesMixedOrder() throws IOException {
         // 5 values = [5, 6, 7, 8, 9], 4 indices = [3, 2, 0, 4], result = [8, 7, 5, 9]
-        final OptionalValueList list = makeList(stream(5, 5, 6, 7, 8, 9, 4, 3, 2, 0, 4), 4);
-        assertThat(list.head.get().asNumeric().intValue(), is(equalTo(9)));
-        assertThat(list.tail.head.get().asNumeric().intValue(), is(equalTo(5)));
-        assertThat(list.tail.tail.head.get().asNumeric().intValue(), is(equalTo(7)));
-        assertThat(list.tail.tail.tail.head.get().asNumeric().intValue(), is(equalTo(8)));
+        final OptionalValueList values = makeList(stream(5, 5, 6, 7, 8, 9, 4, 3, 2, 0, 4), 4);
+        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(9)));
+        assertThat(values.tail.head.get().asNumeric().intValue(), is(equalTo(5)));
+        assertThat(values.tail.tail.head.get().asNumeric().intValue(), is(equalTo(7)));
+        assertThat(values.tail.tail.tail.head.get().asNumeric().intValue(), is(equalTo(8)));
     }
 
     @Test
     public void testMixedExistingNonExistingIndices() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 3 indices = [0, 42, 2], result = [1, Nan, 3]
-        final OptionalValueList list = makeList(stream(5, 1, 2, 3, 4, 5, 3, 0, 42, 2), 3);
-        assertThat(list.head.get().asNumeric().intValue(), is(equalTo(3)));
-        assertThat(list.tail.head.isPresent(), is(equalTo(false)));
-        assertThat(list.tail.tail.head.get().asNumeric().intValue(), is(equalTo(1)));
+        final OptionalValueList values = makeList(stream(5, 1, 2, 3, 4, 5, 3, 0, 42, 2), 3);
+        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(3)));
+        assertThat(values.tail.head.isPresent(), is(equalTo(false)));
+        assertThat(values.tail.tail.head.get().asNumeric().intValue(), is(equalTo(1)));
     }
 
     @Test
     public void testResultLengthEqualsIndicesLength() throws IOException {
         // 1 value = [1], 8 indices = [1, 2, 3, 4, 5, 6, 7, 8], result = [Nan, Nan, Nan, Nan, Nan]
-        final OptionalValueList list = makeList(stream(1, 1, 5, 1, 2, 3, 4, 5), 5);
-        assertNonePresent(list);
+        final OptionalValueList values = makeList(stream(1, 1, 5, 1, 2, 3, 4, 5), 5);
+        assertNonePresent(values);
     }
 
-    private void assertNonePresent(final OptionalValueList list) {
-        OptionalValueList l = list;
-        while (!l.isEmpty()) {
-            assertThat(l.head.isPresent(), is(equalTo(false)));
-            l = l.tail;
+    private void assertNonePresent(final OptionalValueList inputValues) {
+        OptionalValueList values = inputValues;
+        while (!values.isEmpty()) {
+            assertThat(values.head.isPresent(), is(equalTo(false)));
+            values = values.tail;
         }
     }
 
     private OptionalValueList makeList(final Environment environment, final long listSize) throws IOException {
         final ParseResult result = format.parse(environment, signed());
         assertTrue(result.succeeded);
-        final OptionalValueList list = nth.eval(result.environment, signed());
-        assertThat(list.size, is(equalTo(listSize)));
-        return list;
+        final OptionalValueList values = nth.eval(result.environment, signed());
+        assertThat(values.size, is(equalTo(listSize)));
+        return values;
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionListSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionListSemanticsTest.java
@@ -22,11 +22,13 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.first;
 import static io.parsingdata.metal.Shorthand.last;
+import static io.parsingdata.metal.Shorthand.neg;
 import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.offset;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -41,7 +43,7 @@ import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
-public class BinaryValueExpressionListSemanticsTest extends ParameterizedParse {
+public class ValueExpressionListSemanticsTest extends ParameterizedParse {
 
     @Parameterized.Parameters(name="{0} ({4})")
     public static Collection<Object[]> data() {
@@ -60,11 +62,21 @@ public class BinaryValueExpressionListSemanticsTest extends ParameterizedParse {
             { "a, a, b, b, first(not(a)+not(b))", pred2(eq(first(add(not(ref("a")), not(ref("b")))))), stream(230, 2, 25, 4, -1), enc(), true },
             { "a, a, a, b, b, last(not(a)+not(b))", pred3(eq(last(add(not(ref("a")), not(ref("b")))))), stream(1, 2, 200, 4, 55, -1), enc(), true },
             { "a, a, a, b, b, first(not(a)+not(b))", pred3(eq(first(add(not(ref("a")), not(ref("b")))))), stream(200, 2, 3, 55, 5, -1), enc(), false },
+            { "a, a, last(neg(a))", pred(eq(last(neg(ref("a"))))), stream(1, 2, -2), signed(), true },
+            { "a, a, first(neg(a))", pred(eq(first(neg(ref("a"))))), stream(1, 2, -1), signed(), true }
+
         });
     }
 
-    public BinaryValueExpressionListSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+    public ValueExpressionListSemanticsTest(final String description, final Token token, final Environment environment, final Encoding encoding, final boolean result) {
         super(token, environment, encoding, result);
+    }
+
+    private static Token pred(Expression predicate) {
+        return
+            seq(any("a"),
+                any("a"),
+                def("b", con(1), predicate));
     }
 
     private static Token pred2(Expression predicate) {

--- a/core/src/test/java/io/parsingdata/metal/util/ClassDefinition.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ClassDefinition.java
@@ -25,25 +25,25 @@ import java.lang.reflect.Modifier;
 
 public class ClassDefinition {
 
-    public static void checkUtilityClass(Class<?> c) throws ReflectiveOperationException {
-        final String simpleName = c.getSimpleName();
+    public static void checkUtilityClass(Class<?> utilityClass) throws ReflectiveOperationException {
+        final String simpleName = utilityClass.getSimpleName();
         // class is final
-        assertTrue(simpleName + " should be final", Modifier.isFinal(c.getModifiers()));
+        assertTrue(simpleName + " should be final", Modifier.isFinal(utilityClass.getModifiers()));
 
         // has one constructor
-        final Constructor<?>[] cons = c.getDeclaredConstructors();
-        assertEquals(simpleName + " should have exactly 1 constructor", 1, cons.length);
+        final Constructor<?>[] constructors = utilityClass.getDeclaredConstructors();
+        assertEquals(simpleName + " should have exactly 1 constructor", 1, constructors.length);
 
         // which is private
-        assertTrue(simpleName + " should have a private constructor", Modifier.isPrivate(cons[0].getModifiers()));
+        assertTrue(simpleName + " should have a private constructor", Modifier.isPrivate(constructors[0].getModifiers()));
 
         // call it for coverage
-        cons[0].setAccessible(true);
-        cons[0].newInstance();
+        constructors[0].setAccessible(true);
+        constructors[0].newInstance();
 
         // check that all declared methods are static
-        for (final Method m : c.getDeclaredMethods()) {
-            assertTrue("method '" + m.getName()  + "' in " + simpleName + " should be static", Modifier.isStatic(m.getModifiers()));
+        for (final Method method : utilityClass.getDeclaredMethods()) {
+            assertTrue("method '" + method.getName()  + "' in " + simpleName + " should be static", Modifier.isStatic(method.getModifiers()));
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/util/EnvironmentFactory.java
+++ b/core/src/test/java/io/parsingdata/metal/util/EnvironmentFactory.java
@@ -40,8 +40,8 @@ public class EnvironmentFactory {
         return new Environment(new InMemoryByteStream(value.getBytes(charset)));
     }
 
-    public static Environment seek(final Environment env, final int offset) {
-        return new Environment(env.order, env.input, offset, env.callbacks);
+    public static Environment seek(final Environment environment, final int offset) {
+        return new Environment(environment.order, environment.input, offset, environment.callbacks);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -22,22 +22,22 @@ import io.parsingdata.metal.data.ByteStream;
 
 public class InMemoryByteStream implements ByteStream {
 
-    private final byte[] _data;
+    private final byte[] data;
 
     public InMemoryByteStream(final byte[] data) {
-        _data = data;
+        this.data = data;
     }
 
     public int read(final long offset, final byte[] data) throws IOException {
-        if (offset >= _data.length) { return 0; }
-        final int toCopy = (int)offset + data.length > _data.length ? _data.length - (int)offset : data.length;
-        System.arraycopy(_data, (int)offset, data, 0, toCopy);
+        if (offset >= this.data.length) { return 0; }
+        final int toCopy = (int)offset + data.length > this.data.length ? this.data.length - (int)offset : data.length;
+        System.arraycopy(this.data, (int)offset, data, 0, toCopy);
         return toCopy;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + _data.length + ")";
+        return getClass().getSimpleName() + "(" + data.length + ")";
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
@@ -18,35 +18,35 @@ package io.parsingdata.metal.util;
 
 import java.io.IOException;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.token.Token;
-
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.token.Token;
+
 @Ignore
 @RunWith(Parameterized.class)
 public class ParameterizedParse {
 
-    private final Token _token;
-    private final Environment _env;
-    private final Encoding _enc;
-    private final boolean _result;
+    private final Token token;
+    private final Environment environment;
+    private final Encoding encoding;
+    private final boolean result;
 
-    public ParameterizedParse(final Token token, final Environment env, final Encoding enc, final boolean result) {
-        _token = token;
-        _env = env;
-        _enc = enc;
-        _result = result;
+    public ParameterizedParse(final Token token, final Environment environment, final Encoding encoding, final boolean result) {
+        this.token = token;
+        this.environment = environment;
+        this.encoding = encoding;
+        this.result = result;
     }
 
     @Test
     public void test() throws IOException {
-        Assert.assertEquals(_result, _token.parse(_env, _enc).succeeded);
+        Assert.assertEquals(result, token.parse(environment, encoding).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
@@ -16,9 +16,10 @@
 
 package io.parsingdata.metal.util;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +47,7 @@ public class ParameterizedParse {
 
     @Test
     public void test() throws IOException {
-        Assert.assertEquals(result, token.parse(environment, encoding).succeeded);
+        assertEquals(result, token.parse(environment, encoding).succeeded);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
+++ b/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
@@ -16,12 +16,17 @@
 
 package io.parsingdata.metal.util;
 
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.expTrue;
+import static io.parsingdata.metal.Shorthand.not;
+import static io.parsingdata.metal.Shorthand.ref;
+
 import io.parsingdata.metal.Shorthand;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
-
-import static io.parsingdata.metal.Shorthand.*;
 
 public class TokenDefinitions {
 

--- a/formats/src/main/java/io/parsingdata/metal/format/Callback.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/Callback.java
@@ -32,17 +32,17 @@ public final class Callback {
     public static ValueExpression crc32(final ValueExpression target) {
         return new UnaryValueExpression(target) {
             @Override
-            public OptionalValue eval(final Value v, final Environment env, final Encoding enc) {
+            public OptionalValue eval(final Value v, final Environment environment, final Encoding encoding) {
                 return v.operation(new ValueOperation() {
                     @Override
                     public OptionalValue execute(final Value value) {
                         final CRC32 crc = new CRC32();
                         crc.update(value.getValue());
                         final long crcValue = crc.getValue();
-                        return OptionalValue.of(new Value(enc.getByteOrder().apply(new byte[] { (byte)((crcValue & 0xff000000) >> 24),
+                        return OptionalValue.of(new Value(encoding.getByteOrder().apply(new byte[] { (byte)((crcValue & 0xff000000) >> 24),
                                                                                                 (byte)((crcValue & 0xff0000) >> 16),
                                                                                                 (byte)((crcValue & 0xff00) >> 8),
-                                                                                                (byte)(crcValue & 0xff) }), enc));
+                                                                                                (byte)(crcValue & 0xff) }), encoding));
                     }
                 });
             }
@@ -52,7 +52,7 @@ public final class Callback {
     public static ValueExpression inflate(final ValueExpression target) {
         return new UnaryValueExpression(target) {
             @Override
-            public OptionalValue eval(final Value v, final Environment env, final Encoding enc) {
+            public OptionalValue eval(final Value v, final Environment environment, final Encoding encoding) {
                 return v.operation(new ValueOperation() {
                     @Override
                     public OptionalValue execute(final Value value) {
@@ -68,7 +68,7 @@ public final class Callback {
                                 return OptionalValue.empty();
                             }
                         }
-                        return OptionalValue.of(new Value(out.toByteArray(), enc));
+                        return OptionalValue.of(new Value(out.toByteArray(), encoding));
                     }
                 });
             }

--- a/formats/src/main/java/io/parsingdata/metal/format/Callback.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/Callback.java
@@ -43,10 +43,10 @@ public final class Callback {
                         final CRC32 crc = new CRC32();
                         crc.update(value.getValue());
                         final long crcValue = crc.getValue();
-                        return OptionalValue.of(new Value(encoding.getByteOrder().apply(new byte[] { (byte)((crcValue & 0xff000000) >> 24),
-                                                                                                     (byte)((crcValue & 0xff0000) >> 16),
-                                                                                                     (byte)((crcValue & 0xff00) >> 8),
-                                                                                                     (byte) (crcValue & 0xff) }), encoding));
+                        return OptionalValue.of(new Value(encoding.byteOrder.apply(new byte[] { (byte)((crcValue & 0xff000000) >> 24),
+                                                                                                (byte)((crcValue & 0xff0000) >> 16),
+                                                                                                (byte)((crcValue & 0xff00) >> 8),
+                                                                                                (byte) (crcValue & 0xff) }), encoding));
                     }
                 });
             }

--- a/formats/src/main/java/io/parsingdata/metal/format/Callback.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/Callback.java
@@ -16,14 +16,18 @@
 
 package io.parsingdata.metal.format;
 
-import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.*;
-
 import java.io.ByteArrayOutputStream;
 import java.util.zip.CRC32;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.OptionalValue;
+import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.ValueOperation;
 
 public final class Callback {
 
@@ -40,9 +44,9 @@ public final class Callback {
                         crc.update(value.getValue());
                         final long crcValue = crc.getValue();
                         return OptionalValue.of(new Value(encoding.getByteOrder().apply(new byte[] { (byte)((crcValue & 0xff000000) >> 24),
-                                                                                                (byte)((crcValue & 0xff0000) >> 16),
-                                                                                                (byte)((crcValue & 0xff00) >> 8),
-                                                                                                (byte)(crcValue & 0xff) }), encoding));
+                                                                                                     (byte)((crcValue & 0xff0000) >> 16),
+                                                                                                     (byte)((crcValue & 0xff00) >> 8),
+                                                                                                     (byte) (crcValue & 0xff) }), encoding));
                     }
                 });
             }

--- a/formats/src/main/java/io/parsingdata/metal/format/Callback.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/Callback.java
@@ -36,8 +36,8 @@ public final class Callback {
     public static ValueExpression crc32(final ValueExpression target) {
         return new UnaryValueExpression(target) {
             @Override
-            public OptionalValue eval(final Value v, final Environment environment, final Encoding encoding) {
-                return v.operation(new ValueOperation() {
+            public OptionalValue eval(final Value value, final Environment environment, final Encoding encoding) {
+                return value.operation(new ValueOperation() {
                     @Override
                     public OptionalValue execute(final Value value) {
                         final CRC32 crc = new CRC32();
@@ -56,8 +56,8 @@ public final class Callback {
     public static ValueExpression inflate(final ValueExpression target) {
         return new UnaryValueExpression(target) {
             @Override
-            public OptionalValue eval(final Value v, final Environment environment, final Encoding encoding) {
-                return v.operation(new ValueOperation() {
+            public OptionalValue eval(final Value value, final Environment environment, final Encoding encoding) {
+                return value.operation(new ValueOperation() {
                     @Override
                     public OptionalValue execute(final Value value) {
                         final Inflater inf = new Inflater(true);

--- a/formats/src/test/java/io/parsingdata/metal/FormatTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/FormatTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal;
 
+import static org.junit.Assert.assertTrue;
+
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
@@ -23,14 +25,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import io.parsingdata.metal.format.JPEG;
-import io.parsingdata.metal.format.PNG;
-import io.parsingdata.metal.format.ZIP;
-
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import io.parsingdata.metal.format.JPEG;
+import io.parsingdata.metal.format.PNG;
+import io.parsingdata.metal.format.ZIP;
 
 @RunWith(JUnit4.class)
 public class FormatTest {
@@ -42,22 +43,22 @@ public class FormatTest {
 
     @Test
     public void parsePNG() throws IOException, URISyntaxException {
-        Assert.assertTrue(PNG.FORMAT.parse(stream(toURI(PNGFILE)), enc()).succeeded);
+        assertTrue(PNG.FORMAT.parse(stream(toURI(PNGFILE)), enc()).succeeded);
     }
 
     @Test
     public void parseZIP() throws IOException, URISyntaxException {
-        Assert.assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE1)), enc()).succeeded);
+        assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE1)), enc()).succeeded);
     }
 
     @Test
     public void parseZIP2() throws IOException, URISyntaxException {
-        Assert.assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE2)), enc()).succeeded);
+        assertTrue(ZIP.FORMAT.parse(stream(toURI(ZIPFILE2)), enc()).succeeded);
     }
 
     @Test
     public void parseJPEG() throws IOException, URISyntaxException {
-        Assert.assertTrue(JPEG.FORMAT.parse(stream(toURI(JPEGFILE)), enc()).succeeded);
+        assertTrue(JPEG.FORMAT.parse(stream(toURI(JPEGFILE)), enc()).succeeded);
     }
 
     private URI toURI(final String resource) throws URISyntaxException {


### PR DESCRIPTION
Resolves #8: Definition tests for all relevant tokens.
Resolves #59: Unified variable naming. No more abbreviations.
Resolves #76: `env` and `enc` are now `environment` and `encoding`.
Resolves #82: Removed `final` modifiers from interface method arguments.
Resolves #110: 100% code coverage.
Brought `Encoding` in line with previously completed #58.
Some additional small style nitpicks.