### PR TITLE
Converted the is/as methods on ParseItem into default methods.

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -105,13 +105,9 @@ public class ParseGraph implements ParseItem {
         return tail.current(); // Ignore current if it's a reference (or an empty graph)
     }
 
-    @Override public boolean isValue() { return false; }
-    @Override public boolean isGraph() { return true; }
-    @Override public boolean isReference() { return false; }
-    @Override public ParseValue asValue() { throw new UnsupportedOperationException("Cannot convert ParseGraph to ParseValue."); }
-    @Override public ParseGraph asGraph() { return this; }
-    @Override public ParseReference asReference() { throw new UnsupportedOperationException("Cannot convert ParseGraph to ParseReference."); }
-    @Override public Token getDefinition() { return definition; }
+    public boolean isGraph() { return true; }
+    public ParseGraph asGraph() { return this; }
+    public Token getDefinition() { return definition; }
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseItem.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseItem.java
@@ -20,12 +20,12 @@ import io.parsingdata.metal.token.Token;
 
 public interface ParseItem {
 
-    boolean isValue();
-    boolean isGraph();
-    boolean isReference();
-    ParseValue asValue();
-    ParseReference asReference();
-    ParseGraph asGraph();
+    default boolean isValue() { return false; }
+    default boolean isGraph() { return false; }
+    default boolean isReference() { return false; }
+    default ParseValue asValue() { throw new UnsupportedOperationException("Cannot convert to ParseValue."); }
+    default ParseReference asReference() { throw new UnsupportedOperationException("Cannot convert to ParseReference."); }
+    default ParseGraph asGraph() { throw new UnsupportedOperationException("Cannot convert to ParseGraph."); }
     Token getDefinition();
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
@@ -38,13 +38,9 @@ public class ParseReference implements ParseItem {
         return findItemAtOffset(getAllRoots(root, definition), location, source);
     }
 
-    @Override public boolean isValue() { return false; }
-    @Override public boolean isGraph() { return false; }
-    @Override public boolean isReference() { return true; }
-    @Override public ParseValue asValue() { throw new UnsupportedOperationException("Cannot convert ParseReference to ParseValue."); }
-    @Override public ParseGraph asGraph() { throw new UnsupportedOperationException("Cannot convert ParseReference to ParseGraph."); }
-    @Override public ParseReference asReference() { return this; }
-    @Override public Token getDefinition() { return definition; }
+    public boolean isReference() { return true; }
+    public ParseReference asReference() { return this; }
+    public Token getDefinition() { return definition; }
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
@@ -37,13 +37,9 @@ public class ParseValue extends Value implements ParseItem {
         return this.name.equals(name) || this.name.endsWith(Token.SEPARATOR + name);
     }
 
-    @Override public boolean isValue() { return true; }
-    @Override public boolean isGraph() { return false; }
-    @Override public boolean isReference() { return false; }
-    @Override public ParseValue asValue() { return this; }
-    @Override public ParseGraph asGraph() { throw new UnsupportedOperationException("Cannot convert ParseValue to ParseGraph."); }
-    @Override public ParseReference asReference() { throw new UnsupportedOperationException("Cannot convert ParseValue to ParseReference."); }
-    @Override public Token getDefinition() { return definition; }
+    public boolean isValue() { return true; }
+    public ParseValue asValue() { return this; }
+    public Token getDefinition() { return definition; }
 
     @Override
     public String toString() {

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -257,14 +257,14 @@ public class ParseGraphTest {
     @Test
     public void testAsValue() {
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseGraph to ParseValue.");
+        thrown.expectMessage("Cannot convert to ParseValue.");
         EMPTY.asValue();
     }
 
     @Test
     public void testAsRef() {
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseGraph to ParseReference.");
+        thrown.expectMessage("Cannot convert to ParseReference.");
         EMPTY.asReference();
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -70,7 +70,7 @@ public class ParseReferenceTest {
         assertFalse(reference.isValue());
 
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseReference to ParseValue");
+        thrown.expectMessage("Cannot convert to ParseValue");
         reference.asValue();
     }
 
@@ -79,7 +79,7 @@ public class ParseReferenceTest {
         assertFalse(reference.isGraph());
 
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseReference to ParseGraph");
+        thrown.expectMessage("Cannot convert to ParseGraph");
         reference.asGraph();
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -80,7 +80,7 @@ public class ParseValueTest {
         assertFalse(value.isReference());
 
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseValue to ParseReference");
+        thrown.expectMessage("Cannot convert to ParseReference");
         value.asReference();
     }
 
@@ -89,7 +89,7 @@ public class ParseValueTest {
         assertFalse(value.isGraph());
 
         thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert ParseValue to ParseGraph");
+        thrown.expectMessage("Cannot convert to ParseGraph");
         value.asGraph();
     }
 


### PR DESCRIPTION
Resolves #140.