### PR TITLE
Removed all uses of instanceof.

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -40,10 +40,7 @@ public class Offset extends UnaryValueExpression {
 
     @Override
     public Optional<Value> eval(final Value value, final Environment environment, final Encoding encoding) {
-        if (value instanceof ParseValue) {
-            return Optional.of(ConstantFactory.createFromNumeric(((ParseValue) value).slice.offset, value.encoding));
-        }
-        return Optional.empty();
+        return Optional.of(ConstantFactory.createFromNumeric(value.slice.offset, value.encoding));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.con;
@@ -90,14 +91,6 @@ public class ErrorsTest {
             );
         ParseResult result = multiRepN.parse(stream(2, 2, 2, 2), enc());
         assertFalse(result.succeeded);
-    }
-
-    @Test
-    public void definedValueHasNoOffset() {
-        final ImmutableList<Optional<Value>> offsetCon = offset(con(1)).eval(stream(), enc());
-        assertFalse(offsetCon.isEmpty());
-        assertEquals(1, offsetCon.size);
-        assertFalse(offsetCon.head.isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -16,16 +16,13 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.neg;
-import static io.parsingdata.metal.Shorthand.offset;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
@@ -34,7 +31,6 @@ import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,9 +38,7 @@ import org.junit.rules.ExpectedException;
 
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseResult;
-import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.token.Token;
 
 public class ErrorsTest {

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
@@ -1,0 +1,30 @@
+package io.parsingdata.metal.expression.value.reference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.expression.value.Value;
+
+public class OffsetTest {
+
+    @Test
+    public void definedValueOffset() {
+        final ImmutableList<Optional<Value>> offsetCon = offset(con(1)).eval(stream(), enc());
+        assertFalse(offsetCon.isEmpty());
+        assertEquals(1, offsetCon.size);
+        assertTrue(offsetCon.head.isPresent());
+        assertEquals(0, offsetCon.head.get().asNumeric().intValue());
+    }
+
+}


### PR DESCRIPTION
The only remaining `instanceof` was in `Offset`, where a `Value` was checked to be a `ParseValue` before retrieving its `offset`. But since 5.0.0, every `Value` has a `.slice.offset`, so this check (and the accompanying cast can be removed).

Resolves #63.