### PR TITLE
Adds Shorthands for map function (mapLeft/mapRight) using Expand ValueExpression

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -171,6 +171,8 @@ public final class Shorthand {
     public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) { return foldRight(values, reducer, initial); }
     public static ValueExpression rev(final ValueExpression values) { return new Reverse(values); }
     public static ValueExpression exp(final ValueExpression base, final ValueExpression count) { return new Expand(base, count); }
+    public static BinaryValueExpression mapLeft(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression left, final ValueExpression rightExpand) { return func.apply(left, exp(rightExpand, count(left))); }
+    public static BinaryValueExpression mapRight(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression leftExpand, final ValueExpression right) { return func.apply(exp(leftExpand, count(right)), right); }
 
     public static BinaryLogicalExpression and(final Expression left, final Expression right) { return new And(left, right); }
     public static BinaryLogicalExpression or(final Expression left, final Expression right) { return new Or(left, right); }

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -30,6 +30,8 @@ import static io.parsingdata.metal.Shorthand.eqStr;
 import static io.parsingdata.metal.Shorthand.expTrue;
 import static io.parsingdata.metal.Shorthand.gtNum;
 import static io.parsingdata.metal.Shorthand.last;
+import static io.parsingdata.metal.Shorthand.mapLeft;
+import static io.parsingdata.metal.Shorthand.mapRight;
 import static io.parsingdata.metal.Shorthand.opt;
 import static io.parsingdata.metal.Shorthand.pre;
 import static io.parsingdata.metal.Shorthand.ref;
@@ -38,6 +40,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
+import static io.parsingdata.metal.expression.value.ExpandTest.createParseValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -52,6 +55,7 @@ import org.junit.rules.ExpectedException;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.token.Cho;
@@ -212,6 +216,30 @@ public class ShorthandsTest {
         assertEquals(2, seq.tokens.size);
         assertEquals(DEFA, seq.tokens.head);
         assertEquals(DEFB, seq.tokens.tail.head);
+    }
+
+    final ParseGraph PARSEGRAPH = ParseGraph.EMPTY.add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42));
+
+    @Test
+    public void mapLeftWithSub() {
+        ImmutableList<Optional<Value>> result = mapLeft(Shorthand::sub, ref("a"), con(2)).eval(PARSEGRAPH, enc());
+        assertEquals(3, result.size);
+        for (int i = 0; i < 3; i++) {
+            assertTrue(result.head.isPresent());
+            assertEquals((i * 42) + 40, result.head.get().asNumeric().intValue());
+            result = result.tail;
+        }
+    }
+
+    @Test
+    public void mapRightWithSub() {
+        ImmutableList<Optional<Value>> result = mapRight(Shorthand::sub, con(126), ref("a")).eval(PARSEGRAPH, enc());
+        assertEquals(3, result.size);
+        for (int i = 0; i < 3; i++) {
+            assertTrue(result.head.isPresent());
+            assertEquals(((3 - i) * 42) - 42, result.head.get().asNumeric().intValue());
+            result = result.tail;
+        }
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -99,7 +99,7 @@ public class ExpandTest {
         }
     }
 
-    private static ParseValue createParseValue(String name, int value) {
+    public static ParseValue createParseValue(String name, int value) {
         return new ParseValue(name, any(name), createFromBytes(new byte[] { (byte)value }), enc());
     }
 


### PR DESCRIPTION
Resolves #113.

Adds `mapLeft()` and `mapRight()` to `Shorthand` using the new `Expand` `ValueExpression` to allow _map_-functionality for `BinaryValueExpression`s.

Part of this PR should also be commit 645f9b40fc4884b6101c1932adbd240c73bb4ae6, which was accidentally committed directly to the master.