### PR TITLE
Change item order returned by ByToken#getAllRoots

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
@@ -96,8 +96,8 @@ public final class ByToken {
             : new ImmutableList<>();
         if (item.isGraph() && !item.asGraph().isEmpty()) {
             return result
-                .add(getAllRootsRecursive(item.asGraph().tail, item.asGraph(), definition)
-                    .add(getAllRootsRecursive(item.asGraph().head, item.asGraph(), definition)));
+                .add(getAllRootsRecursive(item.asGraph().tail, item.asGraph(), definition))
+                .add(getAllRootsRecursive(item.asGraph().head, item.asGraph(), definition));
         }
         return result;
     }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByToken.java
@@ -92,12 +92,12 @@ public final class ByToken {
 
     private static ImmutableList<ParseItem> getAllRootsRecursive(final ParseItem item, final ParseGraph parent, final Token definition) {
         final ImmutableList<ParseItem> result = item.getDefinition().equals(definition) && (parent == null || !parent.getDefinition().equals(definition))
-                ? ImmutableList.create(item)
-                : new ImmutableList();
+            ? ImmutableList.create(item)
+            : new ImmutableList<>();
         if (item.isGraph() && !item.asGraph().isEmpty()) {
-            return getAllRootsRecursive(item.asGraph().tail, item.asGraph(), definition)
-                    .add(getAllRootsRecursive(item.asGraph().head, item.asGraph(), definition))
-                    .add(result);
+            return result
+                .add(getAllRootsRecursive(item.asGraph().tail, item.asGraph(), definition)
+                    .add(getAllRootsRecursive(item.asGraph().head, item.asGraph(), definition)));
         }
         return result;
     }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -366,12 +366,12 @@ public class ByTokenTest {
         // item.head is the MUT_REC_1 graph containing [3, 4, 5], with '3' having the DEF1 definition
         final ImmutableList<ParseItem> firstMutRecValues = getAll(items.head.asGraph(), DEF1);
         assertThat(firstMutRecValues.size, is(equalTo(1L)));
-        assertThat(firstMutRecValues.head.asValue().asNumeric().intValue(), is(equalTo(3)));
+        assertThat(lastItem(firstMutRecValues).asValue().asNumeric().intValue(), is(equalTo(3)));
 
         // item.tail.head is the MUT_REC_1 graph containing [0, 1, 2, 3, 4, 5], with '0' and '3' having the DEF1 definition
         final ImmutableList<ParseItem> secondMutRecValues = getAll(items.tail.head.asGraph(), DEF1);
         assertThat(secondMutRecValues.size, is(equalTo(2L)));
-        assertThat(secondMutRecValues.tail.head.asValue().asNumeric().intValue(), is(equalTo(0)));
+        assertThat(lastItem(secondMutRecValues).asValue().asNumeric().intValue(), is(equalTo(0)));
     }
 
     @Test


### PR DESCRIPTION
For recursive structures, the order returned now reflects the parsing order.

Resolves #165.