### PR TITLE
Null checks on Token.parse() for the scope and environment arguments.

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -63,7 +63,7 @@ public abstract class Token {
 
     public Optional<Environment> parse(final String scope, final Environment environment, final Encoding encoding) throws IOException {
         final Encoding activeEncoding = this.encoding != null ? this.encoding : encoding;
-        final Optional<Environment> result = parseImpl(makeScope(scope), environment, activeEncoding);
+        final Optional<Environment> result = parseImpl(makeScope(checkNotNull(scope, "scope")), checkNotNull(environment, "environment"), activeEncoding);
         environment.callbacks.handle(this, environment, result);
         return result;
     }

--- a/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
@@ -1,0 +1,40 @@
+package io.parsingdata.metal.token;
+
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.encoding.Encoding;
+
+public class TokenTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    private final Token token = new Token("", null) {
+        @Override
+        protected Optional<Environment> parseImpl(String scope, Environment environment, Encoding encoding) throws IOException {
+            return null;
+        }
+    };;
+
+    @Test
+    public void parseNullEnvironment() throws IOException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Argument environment may not be null.");
+        token.parse("", null, new Encoding());
+    }
+
+    @Test
+    public void parseNullScope() throws IOException {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Argument scope may not be null.");
+        token.parse(null, stream(), new Encoding());
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
@@ -21,7 +21,7 @@ public class TokenTest {
         protected Optional<Environment> parseImpl(String scope, Environment environment, Encoding encoding) throws IOException {
             return null;
         }
-    };;
+    };
 
     @Test
     public void parseNullEnvironment() throws IOException {


### PR DESCRIPTION
Resolves #175.