### PR TITLE
Optimize last(ref(x)) expressions

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -17,8 +17,6 @@
 package io.parsingdata.metal;
 
 import static io.parsingdata.metal.Util.createFromBytes;
-import static io.parsingdata.metal.expression.value.reference.Ref.nameRef;
-import static io.parsingdata.metal.expression.value.reference.Ref.tokenRef;
 import static io.parsingdata.metal.token.Token.NO_NAME;
 
 import java.util.function.BiFunction;
@@ -64,6 +62,8 @@ import io.parsingdata.metal.expression.value.reference.Last;
 import io.parsingdata.metal.expression.value.reference.Len;
 import io.parsingdata.metal.expression.value.reference.Nth;
 import io.parsingdata.metal.expression.value.reference.Offset;
+import io.parsingdata.metal.expression.value.reference.Ref.DefinitionRef;
+import io.parsingdata.metal.expression.value.reference.Ref.NameRef;
 import io.parsingdata.metal.expression.value.reference.Self;
 import io.parsingdata.metal.token.Cho;
 import io.parsingdata.metal.token.Def;
@@ -159,10 +159,12 @@ public final class Shorthand {
     public static ValueExpression con(final byte[] value, final Encoding encoding) { return con(ConstantFactory.createFromBytes(value, encoding)); }
     public static final ValueExpression self = new Self();
     public static ValueExpression len(final ValueExpression operand) { return new Len(operand); }
-    public static ValueExpression ref(final String name) { return nameRef(name); }
-    public static ValueExpression ref(final Token definition) { return tokenRef(definition); }
+    public static NameRef ref(final String name) { return new NameRef(name); }
+    public static DefinitionRef ref(final Token definition) { return new DefinitionRef(definition); }
     public static ValueExpression first(final ValueExpression operand) { return new First(operand); }
     public static ValueExpression last(final ValueExpression operand) { return new Last(operand); }
+    public static ValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, 1)); }
+    public static ValueExpression last(final DefinitionRef operand) { return new Last(new DefinitionRef(operand.reference, 1)); }
     public static ValueExpression nth(final ValueExpression values, final ValueExpression indices) { return new Nth(values, indices); }
     public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
     public static final ValueExpression currentOffset = elvis(add(offset(self), len(self)), con(0));

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -159,12 +159,14 @@ public final class Shorthand {
     public static ValueExpression con(final byte[] value, final Encoding encoding) { return con(ConstantFactory.createFromBytes(value, encoding)); }
     public static final ValueExpression self = new Self();
     public static ValueExpression len(final ValueExpression operand) { return new Len(operand); }
-    public static NameRef ref(final String name) { return new NameRef(name); }
-    public static DefinitionRef ref(final Token definition) { return new DefinitionRef(definition); }
+    public static NameRef ref(final String name) { return ref(name, null); }
+    public static NameRef ref(final String name, final ValueExpression limit) { return new NameRef(name, limit); }
+    public static DefinitionRef ref(final Token definition) { return ref(definition, null); }
+    public static DefinitionRef ref(final Token definition, final ValueExpression limit) { return new DefinitionRef(definition, limit); }
     public static ValueExpression first(final ValueExpression operand) { return new First(operand); }
     public static ValueExpression last(final ValueExpression operand) { return new Last(operand); }
-    public static ValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, 1)); }
-    public static ValueExpression last(final DefinitionRef operand) { return new Last(new DefinitionRef(operand.reference, 1)); }
+    public static ValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, con(1))); }
+    public static ValueExpression last(final DefinitionRef operand) { return new Last(new DefinitionRef(operand.reference, con(1))); }
     public static ValueExpression nth(final ValueExpression values, final ValueExpression indices) { return new Nth(values, indices); }
     public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
     public static final ValueExpression currentOffset = elvis(add(offset(self), len(self)), con(0));

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByName.java
@@ -17,7 +17,6 @@
 package io.parsingdata.metal.data.selection;
 
 import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.selection.ByPredicate.NO_LIMIT;
 import static io.parsingdata.metal.data.transformation.Reversal.reverse;
 
 import io.parsingdata.metal.data.ImmutableList;
@@ -34,7 +33,7 @@ public final class ByName {
      * @return The first value (bottom-up) with the provided name in the provided graph
      */
     public static ParseValue getValue(final ParseGraph graph, final String name) {
-        return ByPredicate.getAllValues(ImmutableList.create(graph), new ImmutableList<>(), (value) -> value.matches(name), 1).computeResult().head;
+        return ByPredicate.getAllValues(graph, (value) -> value.matches(name), 1).head;
     }
 
     /**
@@ -45,7 +44,7 @@ public final class ByName {
     public static ImmutableList<ParseValue> getAllValues(final ParseGraph graph, final String name) {
         checkNotNull(graph, "graph");
         checkNotNull(name, "name");
-        return reverse(ByPredicate.getAllValues(ImmutableList.create(graph), new ImmutableList<>(), (value) -> value.matches(name), NO_LIMIT).computeResult());
+        return reverse(ByPredicate.getAllValues(graph, (value) -> value.matches(name)));
     }
 
     public static ParseValue get(final ImmutableList<ParseValue> list, final String name) {

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByPredicate.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByPredicate.java
@@ -33,11 +33,15 @@ public final class ByPredicate {
 
     public static final int NO_LIMIT = -1;
 
-    public static ImmutableList<ParseValue> getAllValues(final ParseGraph graph, final Predicate<ParseValue> predicate) {
-        return getAllValues(ImmutableList.create(graph), new ImmutableList<>(), predicate, NO_LIMIT).computeResult();
+    public static ImmutableList<ParseValue> getAllValues(final ParseGraph graph, final Predicate<ParseValue> predicate, final int limit) {
+        return getAllValues(ImmutableList.create(graph), new ImmutableList<>(), predicate, limit).computeResult();
     }
 
-    static SafeTrampoline<ImmutableList<ParseValue>> getAllValues(final ImmutableList<ParseGraph> graphList, final ImmutableList<ParseValue> valueList, final Predicate<ParseValue> predicate, final int limit) {
+    public static ImmutableList<ParseValue> getAllValues(final ParseGraph graph, final Predicate<ParseValue> predicate) {
+        return getAllValues(graph, predicate, NO_LIMIT);
+    }
+
+    private static SafeTrampoline<ImmutableList<ParseValue>> getAllValues(final ImmutableList<ParseGraph> graphList, final ImmutableList<ParseValue> valueList, final Predicate<ParseValue> predicate, final int limit) {
         if (graphList.isEmpty() || valueList.size == limit) { return complete(() -> valueList); }
         final ParseGraph graph = graphList.head;
         if (graph.isEmpty()) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -55,7 +55,7 @@ public class Expand implements ValueExpression {
         final ImmutableList<Optional<Value>> base = this.base.eval(graph, encoding);
         if (base.isEmpty()) { return base; }
         final ImmutableList<Optional<Value>> count = this.count.eval(graph, encoding);
-        if (count.size != 1 || !count.head.isPresent()) { throw new IllegalStateException("Count must yield a single non-empty value."); }
+        if (count.size != 1 || !count.head.isPresent()) { throw new IllegalArgumentException("Count must evaluate to a single non-empty value."); }
         return expand(base, count.head.get().asNumeric().intValue(), new ImmutableList<>()).computeResult();
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -71,7 +71,7 @@ public abstract class Fold implements ValueExpression {
     private SafeTrampoline<Optional<Value>> fold(final ParseGraph graph, final Encoding encoding, final BinaryOperator<ValueExpression> reducer, final Optional<Value> head, final ImmutableList<Optional<Value>> tail) {
         if (!head.isPresent() || tail.isEmpty()) { return complete(() -> head); }
         final ImmutableList<Optional<Value>> reducedValue = reduce(reducer, head.get(), tail.head.get()).eval(graph, encoding);
-        if (reducedValue.size != 1) { throw new IllegalStateException("Reducer must yield a single value."); }
+        if (reducedValue.size != 1) { throw new IllegalArgumentException("Reducer must evaluate to a single value."); }
         return intermediate(() -> fold(graph, encoding, reducer, reducedValue.head, tail.tail));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -69,7 +69,7 @@ public class Ref<T> implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return wrap(getAllValues(graph, predicate), new ImmutableList<Optional<Value>>()).computeResult();
+        return wrap(getAllValues(graph, predicate, limit), new ImmutableList<Optional<Value>>()).computeResult();
     }
 
     private static <T, U extends T> SafeTrampoline<ImmutableList<Optional<T>>> wrap(final ImmutableList<U> input, final ImmutableList<Optional<T>> output) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value.reference;
 import static io.parsingdata.metal.SafeTrampoline.complete;
 import static io.parsingdata.metal.SafeTrampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.data.selection.ByPredicate.NO_LIMIT;
 import static io.parsingdata.metal.data.selection.ByPredicate.getAllValues;
 
 import java.util.Objects;
@@ -38,27 +39,32 @@ import io.parsingdata.metal.token.Token;
 /**
  * A {@link ValueExpression} that represents all {@link Value}s in the parse
  * state that match a provided object. This class only has a private
- * constructor and instead must be instantiated through one of its factory
- * methods: {@link #nameRef} (to match on name) and {@link #tokenRef} (to
- * match on definition).
+ * constructor and instead must be instantiated through one of its subclasses:
+ * {@link NameRef} (to match on name) and {@link DefinitionRef} (to match on
+ * definition). A limit argument may be provided to specify an upper bound to
+ * the amount of returned results.
  * @param <T> The type of reference to match on.
  */
 public class Ref<T> implements ValueExpression {
 
     public final T reference;
     public final Predicate<ParseValue> predicate;
+    public final int limit;
 
-    private Ref(final T reference, final Predicate<ParseValue> predicate) {
+    private Ref(final T reference, final Predicate<ParseValue> predicate, final int limit) {
         this.reference = checkNotNull(reference, "reference");
         this.predicate = checkNotNull(predicate, "predicate");
+        this.limit = limit;
     }
 
-    public static Ref<String> nameRef(final String name) {
-        return new Ref<>(name, (value) -> value.matches(name));
+    public static class NameRef extends Ref<String> {
+        public NameRef(final String reference) { this(reference, NO_LIMIT); }
+        public NameRef(final String reference, final int limit) { super(reference, (value) -> value.matches(reference), limit); }
     }
 
-    public static Ref<Token> tokenRef(final Token definition) {
-        return new Ref<>(definition, (value) -> value.definition.equals(definition));
+    public static class DefinitionRef extends Ref<Token> {
+        public DefinitionRef(final Token reference) { this(reference, NO_LIMIT); }
+        public DefinitionRef(final Token reference, final int limit) { super(reference, (value) -> value.definition.equals(reference), limit); }
     }
 
     @Override
@@ -73,18 +79,19 @@ public class Ref<T> implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + reference + ")";
+        return getClass().getSimpleName() + "(" + reference + (limit == NO_LIMIT ? "" : "," + limit) + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(reference, ((Ref)obj).reference);
+            && Objects.equals(reference, ((Ref)obj).reference)
+            && Objects.equals(limit, ((Ref)obj).limit);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(reference);
+        return Objects.hash(reference, limit);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -32,7 +32,6 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.Util.createFromBytes;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
-import static io.parsingdata.metal.data.selection.ByPredicate.NO_LIMIT;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
@@ -176,10 +175,9 @@ public class EqualityTest {
         assertFalse(object.equals(null));
         assertFalse(object.equals("name"));
         assertEquals(object, new NameRef("name"));
-        assertEquals(object, new NameRef("name", NO_LIMIT));
         assertNotEquals(object, new NameRef("otherName"));
         assertNotEquals(object, new DefinitionRef(any("name")));
-        assertNotEquals(object, new NameRef("name", 1));
+        assertNotEquals(object, new NameRef("name", con(1)));
     }
 
     @Test
@@ -188,10 +186,9 @@ public class EqualityTest {
         assertFalse(object.equals(null));
         assertFalse(object.equals("name"));
         assertEquals(object, new DefinitionRef(any("name")));
-        assertEquals(object, new DefinitionRef(any("name"), NO_LIMIT));
         assertNotEquals(object, new DefinitionRef(any("otherName")));
         assertNotEquals(object, new NameRef("name"));
-        assertNotEquals(object, new DefinitionRef(any("name"), 1));
+        assertNotEquals(object, new DefinitionRef(any("name"), con(1)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -32,9 +32,8 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.Util.createFromBytes;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
+import static io.parsingdata.metal.data.selection.ByPredicate.NO_LIMIT;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
-import static io.parsingdata.metal.expression.value.reference.Ref.nameRef;
-import static io.parsingdata.metal.expression.value.reference.Ref.tokenRef;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
@@ -56,6 +55,8 @@ import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.True;
 import io.parsingdata.metal.expression.value.reference.Ref;
+import io.parsingdata.metal.expression.value.reference.Ref.DefinitionRef;
+import io.parsingdata.metal.expression.value.reference.Ref.NameRef;
 import io.parsingdata.metal.expression.value.reference.Self;
 import io.parsingdata.metal.token.Token;
 
@@ -171,22 +172,26 @@ public class EqualityTest {
 
     @Test
     public void stringRef() {
-        final Ref object = nameRef("name");
+        final Ref object = new NameRef("name");
         assertFalse(object.equals(null));
         assertFalse(object.equals("name"));
-        assertEquals(object, nameRef("name"));
-        assertNotEquals(object, nameRef("otherName"));
-        assertNotEquals(object, tokenRef(any("name")));
+        assertEquals(object, new NameRef("name"));
+        assertEquals(object, new NameRef("name", NO_LIMIT));
+        assertNotEquals(object, new NameRef("otherName"));
+        assertNotEquals(object, new DefinitionRef(any("name")));
+        assertNotEquals(object, new NameRef("name", 1));
     }
 
     @Test
     public void definitionRef() {
-        final Ref object = tokenRef(any("name"));
+        final Ref object = new DefinitionRef(any("name"));
         assertFalse(object.equals(null));
         assertFalse(object.equals("name"));
-        assertEquals(object, tokenRef(any("name")));
-        assertNotEquals(object, tokenRef(any("otherName")));
-        assertNotEquals(object, nameRef("name"));
+        assertEquals(object, new DefinitionRef(any("name")));
+        assertEquals(object, new DefinitionRef(any("name"), NO_LIMIT));
+        assertNotEquals(object, new DefinitionRef(any("otherName")));
+        assertNotEquals(object, new NameRef("name"));
+        assertNotEquals(object, new DefinitionRef(any("name"), 1));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -112,7 +112,7 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
         return
             seq(rep(def("a", con(1), not(eq(con(0))))),
                 def("zero", con(1), eq(con(0))),
-                def("sum", con(1), eq(fold(new NameRef("a", limit), Shorthand::add))));
+                def("sum", con(1), eq(fold(new NameRef("a", con(limit)), Shorthand::add))));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -112,7 +112,7 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
         return
             seq(rep(def("a", con(1), not(eq(con(0))))),
                 def("zero", con(1), eq(con(0))),
-                def("sum", con(1), eq(fold(new NameRef("a", con(limit)), Shorthand::add))));
+                def("sum", con(1), eq(fold(ref("a", con(limit)), Shorthand::add))));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -174,7 +174,7 @@ public class ToStringTest {
         final Environment oneValueEnvironment = stream().add(pv1);
         final Environment twoValueEnvironment = oneValueEnvironment.add(new ParseValue("name2", NONE, new DataExpressionSource(ref("name"), 0, oneValueEnvironment.order, enc()).slice(0, 2), enc()));
         final String dataExpressionSliceString = getValue(twoValueEnvironment.order, "name2").slice.toString();
-        assertTrue(dataExpressionSliceString.startsWith("Ref(name)[0]("));
+        assertTrue(dataExpressionSliceString.startsWith("NameRef(name)[0]("));
         assertTrue(dataExpressionSliceString.endsWith(")@0:2"));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByPredicateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByPredicateTest.java
@@ -29,7 +29,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ImmutableList;
 
 public class ByPredicateTest {
 
@@ -38,10 +37,7 @@ public class ByPredicateTest {
         Optional<Environment> environment = rep(any("a")).parse(stream(1, 2, 3, 4, 5), enc());
         Assert.assertTrue(environment.isPresent());
         for (int i = 0; i < 7; i++) {
-            Assert.assertEquals(Math.min(5, i), getAllValues(ImmutableList.create(environment.get().order),
-                                                             new ImmutableList<>(),
-                                                             (value) -> value.matches("a"),
-                                                             i).computeResult().size);
+            Assert.assertEquals(Math.min(5, i), getAllValues(environment.get().order, (value) -> value.matches("a"), i).size);
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByPredicateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByPredicateTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data.selection;
 
+import static org.junit.Assert.assertEquals;
+
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.data.selection.ByPredicate.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
@@ -37,7 +39,7 @@ public class ByPredicateTest {
         Optional<Environment> environment = rep(any("a")).parse(stream(1, 2, 3, 4, 5), enc());
         Assert.assertTrue(environment.isPresent());
         for (int i = 0; i < 7; i++) {
-            Assert.assertEquals(Math.min(5, i), getAllValues(environment.get().order, (value) -> value.matches("a"), i).size);
+            assertEquals(Math.min(5, i), getAllValues(environment.get().order, (value) -> value.matches("a"), i).size);
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -133,7 +133,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void toStringTest() {
-        assertThat(elvisExpression.toString(), is(equalTo("Elvis(Ref(a),Ref(b))")));
+        assertThat(elvisExpression.toString(), is(equalTo("Elvis(NameRef(a),NameRef(b))")));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -56,15 +56,15 @@ public class ExpandTest {
 
     @Test
     public void expandEmptyTimes() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Count must yield a single non-empty value.");
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Count must evaluate to a single non-empty value.");
         exp(con(1), div(con(1), con(0))).eval(ParseGraph.EMPTY, enc());
     }
 
     @Test
     public void expandListTimes() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Count must yield a single non-empty value.");
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Count must evaluate to a single non-empty value.");
         exp(con(1), ref("a")).eval(ParseGraph.EMPTY.add(PARSEVALUE_1).add(PARSEVALUE_2), enc());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -110,8 +110,8 @@ public class FoldEdgeCaseTest {
     }
 
     private void faultyReducer(final ValueExpression expression) throws IOException {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Reducer must yield a single value.");
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Reducer must evaluate to a single value.");
 
         seq(
             def("value", 1), // the reducer returns a Ref to these two values

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.exp;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.rep;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import io.parsingdata.metal.data.ParseGraph;
+
+public class RefEdgeCaseTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    final ParseGraph parseGraph;
+
+    public RefEdgeCaseTest() throws IOException {
+        this.parseGraph = rep(any("a")).parse(stream(1, 2, 3), enc()).get().order;
+    }
+
+    @Test
+    public void multiLimit() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Limit must evaluate to a single non-empty value.");
+        ref("a", exp(con(1), con(3))).eval(parseGraph, enc());
+    }
+
+    @Test
+    public void emptyLimit() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Limit must evaluate to a single non-empty value.");
+        ref("a", div(con(1), con(0))).eval(parseGraph, enc());
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,10 +39,11 @@ public class RefEdgeCaseTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    final ParseGraph parseGraph;
+    ParseGraph parseGraph;
 
-    public RefEdgeCaseTest() throws IOException {
-        this.parseGraph = rep(any("a")).parse(stream(1, 2, 3), enc()).get().order;
+    @Before
+    public void before() throws IOException {
+        parseGraph = rep(any("a")).parse(stream(1, 2, 3), enc()).get().order;
     }
 
     @Test


### PR DESCRIPTION
Resolves #169.

Turned the `limit` argument into a `ValueExpression` as well. Added accompanying `Shorthand` definitions. Added various tests.