### PR TITLE
Convert methods that may return a null to returning an Optional

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -98,14 +98,14 @@ public class ParseGraph implements ParseItem {
     /**
      * @return The first value (bottom-up) in this graph
      */
-    public ParseValue current() {
+    public Optional<ParseValue> current() {
         return current(ImmutableList.create(this)).computeResult();
     }
 
-    private SafeTrampoline<ParseValue> current(ImmutableList<ParseItem> items) {
-        if (items.isEmpty()) { return complete(() -> null); }
+    private SafeTrampoline<Optional<ParseValue>> current(ImmutableList<ParseItem> items) {
+        if (items.isEmpty()) { return complete(Optional::empty); }
         final ParseItem item = items.head;
-        if (item.isValue()) { return complete(item::asValue); }
+        if (item.isValue()) { return complete(() -> Optional.of(item.asValue())); }
         if (item.isGraph() && !item.asGraph().isEmpty()) {
             return intermediate(() -> current(items.tail.add(item.asGraph().tail)
                                                         .add(item.asGraph().head)));

--- a/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
@@ -21,6 +21,7 @@ import static io.parsingdata.metal.data.selection.ByOffset.findItemAtOffset;
 import static io.parsingdata.metal.data.selection.ByToken.getAllRoots;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.token.Token;
@@ -37,7 +38,7 @@ public class ParseReference implements ParseItem {
         this.definition = checkNotNull(definition, "definition");
     }
 
-    public ParseItem resolve(final ParseGraph root) {
+    public Optional<ParseItem> resolve(final ParseGraph root) {
         return findItemAtOffset(getAllRoots(root, definition), location, source).computeResult();
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByOffset.java
@@ -21,6 +21,8 @@ import static io.parsingdata.metal.SafeTrampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.selection.ByToken.getAllRoots;
 
+import java.util.Optional;
+
 import io.parsingdata.metal.SafeTrampoline;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
@@ -34,18 +36,18 @@ public final class ByOffset {
     private ByOffset() {}
 
     public static boolean hasRootAtOffset(final ParseGraph graph, final Token definition, final long offset, final Source source) {
-        return findItemAtOffset(getAllRoots(graph, definition), offset, source).computeResult() != null;
+        return findItemAtOffset(getAllRoots(graph, definition), offset, source).computeResult().isPresent();
     }
 
-    public static SafeTrampoline<ParseItem> findItemAtOffset(final ImmutableList<ParseItem> items, final long offset, final Source source) {
+    public static SafeTrampoline<Optional<ParseItem>> findItemAtOffset(final ImmutableList<ParseItem> items, final long offset, final Source source) {
         checkNotNull(items, "items");
         checkNotNull(source, "source");
-        if (items.isEmpty()) { return complete(() -> null); }
+        if (items.isEmpty()) { return complete(Optional::empty); }
         final ParseItem head = items.head;
-        if (head.isValue() && matchesLocation(head.asValue(), offset, source)) { return complete(() -> head); }
+        if (head.isValue() && matchesLocation(head.asValue(), offset, source)) { return complete(() -> Optional.of(head)); }
         if (head.isGraph()) {
             final ParseValue value = getLowestOffsetValue(ImmutableList.create(head.asGraph()), null).computeResult();
-            if (value != null && matchesLocation(value, offset, source)) { return complete(() -> head); }
+            if (value != null && matchesLocation(value, offset, source)) { return complete(() -> Optional.of(head)); }
         }
         return intermediate(() -> findItemAtOffset(items.tail, offset, source));
     }

--- a/core/src/main/java/io/parsingdata/metal/data/selection/ByType.java
+++ b/core/src/main/java/io/parsingdata/metal/data/selection/ByType.java
@@ -18,6 +18,8 @@ package io.parsingdata.metal.data.selection;
 
 import static io.parsingdata.metal.Util.checkNotNull;
 
+import java.util.Optional;
+
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
@@ -26,16 +28,16 @@ public final class ByType {
 
     private ByType() {}
 
-    public static ImmutableList<ParseItem> getReferences(final ParseGraph graph) {
+    public static ImmutableList<Optional<ParseItem>> getReferences(final ParseGraph graph) {
         checkNotNull(graph, "graph");
         return getReferences(graph, graph);
     }
 
-    private static ImmutableList<ParseItem> getReferences(final ParseGraph graph, final ParseGraph root) {
+    private static ImmutableList<Optional<ParseItem>> getReferences(final ParseGraph graph, final ParseGraph root) {
         if (graph.isEmpty()) { return new ImmutableList<>(); }
         final ParseItem head = graph.head;
-        if (head.isReference() && head.asReference().resolve(root) == null) { throw new IllegalStateException("A ParseReference must point to an existing graph."); }
-        return getReferences(graph.tail, root).add(head.isGraph() ? getReferences(head.asGraph(), root) : (head.isReference() ? ImmutableList.create(head.asReference().resolve(root)) : new ImmutableList<ParseItem>()));
+        if (head.isReference() && !head.asReference().resolve(root).isPresent()) { throw new IllegalStateException("A ParseReference must point to an existing graph."); }
+        return getReferences(graph.tail, root).add(head.isGraph() ? getReferences(head.asGraph(), root) : (head.isReference() ? ImmutableList.create(head.asReference().resolve(root)) : new ImmutableList<>()));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.comparison;
 
+import static java.util.function.Function.identity;
+
 import static io.parsingdata.metal.SafeTrampoline.complete;
 import static io.parsingdata.metal.SafeTrampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNull;
@@ -57,7 +59,7 @@ public abstract class ComparisonExpression implements Expression {
 
     @Override
     public boolean eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> values = value == null ? ImmutableList.create(graph.current().map(parseValue -> parseValue)) : value.eval(graph, encoding);
+        final ImmutableList<Optional<Value>> values = value == null ? ImmutableList.create(graph.current().map(identity())) : value.eval(graph, encoding);
         if (values.isEmpty()) { return false; }
         final ImmutableList<Optional<Value>> predicates = predicate.eval(graph, encoding);
         if (values.size != predicates.size) { return false; }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -57,7 +57,7 @@ public abstract class ComparisonExpression implements Expression {
 
     @Override
     public boolean eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> values = value == null ? ImmutableList.create(Optional.of(graph.current())) : value.eval(graph, encoding);
+        final ImmutableList<Optional<Value>> values = value == null ? ImmutableList.create(graph.current().map(parseValue -> parseValue)) : value.eval(graph, encoding);
         if (values.isEmpty()) { return false; }
         final ImmutableList<Optional<Value>> predicates = predicate.eval(graph, encoding);
         if (values.size != predicates.size) { return false; }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -34,7 +34,7 @@ public class Self implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return ImmutableList.create(Optional.of(graph.current()));
+        return ImmutableList.create(graph.current().map(parseValue -> parseValue));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
+import static java.util.function.Function.identity;
+
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
@@ -34,7 +36,7 @@ public class Self implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return ImmutableList.create(graph.current().map(parseValue -> parseValue));
+        return ImmutableList.create(graph.current().map(identity()));
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -102,7 +102,7 @@ public class ShorthandsTest {
     private void runChoice(final int data, final String matched) throws IOException {
         final Optional<Environment> result = multiChoice.parse(stream(data), enc());
         assertTrue(result.isPresent());
-        assertTrue(result.get().order.current().matches(matched));
+        assertTrue(result.get().order.current().get().matches(matched));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -85,7 +85,7 @@ public class SubStructTableTest {
         final ParseGraph graph = result.get().order;
         checkStruct(graph.head.asGraph().head.asGraph().head.asGraph(), 7);
         assertTrue(graph.head.asGraph().head.asGraph().tail.head.isReference());
-        checkStruct(graph.head.asGraph().head.asGraph().tail.head.asReference().resolve(graph).asGraph(), 5);
+        checkStruct(graph.head.asGraph().head.asGraph().tail.head.asReference().resolve(graph).get().asGraph(), 5);
         checkStruct(graph.head.asGraph().head.asGraph().tail.tail.head.asGraph(), 5);
         checkStruct(graph.head.asGraph().head.asGraph().tail.tail.tail.head.asGraph(), 10);
     }

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -93,7 +93,7 @@ public class SubStructTest {
         checkBranch(first, 0, 0);
 
         final ParseReference reference = first.tail.head.asGraph().head.asGraph().head.asReference();
-        checkBranch(reference.resolve(graph).asGraph(), 0, 0); // Check cycle
+        checkBranch(reference.resolve(graph).get().asGraph(), 0, 0); // Check cycle
     }
 
     private ParseGraph startCycle(final int offset) throws IOException {
@@ -115,7 +115,7 @@ public class SubStructTest {
         checkBranch(second, 4, 0);
 
         final ParseReference reference = second.tail.head.asGraph().head.asGraph().head.asReference();
-        checkBranch(reference.resolve(graph).asGraph(), 0, 4); // Check cycle
+        checkBranch(reference.resolve(graph).get().asGraph(), 0, 4); // Check cycle
     }
 
     @Test
@@ -129,7 +129,7 @@ public class SubStructTest {
         checkBranch(second, 0, 4);
 
         final ParseReference reference = second.tail.head.asGraph().head.asGraph().head.asReference();
-        checkBranch(reference.resolve(graph).asGraph(), 4, 0); // Check cycle
+        checkBranch(reference.resolve(graph).get().asGraph(), 4, 0); // Check cycle
     }
 
     private void checkBranch(final ParseGraph graph, final int graphOffset, final int nextOffset) {

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -140,7 +140,7 @@ public class TreeTest {
     }
 
     private void checkResolve(final ParseReference reference, final ParseGraph root, final int offset) {
-        checkHeader(reference.resolve(root).asGraph().tail.tail, offset); // Only check header on cycle to prevent loop
+        checkHeader(reference.resolve(root).get().asGraph().tail.tail, offset); // Only check header on cycle to prevent loop
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -142,7 +142,7 @@ public class ParseGraphTest {
         assertEquals(2, pgc.size);
         assertTrue(pgc.head.isGraph());
         assertTrue(pgc.head.asGraph().head.isReference());
-        assertEquals(a, pgc.head.asGraph().head.asReference().resolve(pgc));
+        assertEquals(a, pgc.head.asGraph().head.asReference().resolve(pgc).get());
         assertTrue(pgc.head.asGraph().tail.head.isValue());
         assertEquals(b, pgc.head.asGraph().tail.head);
         assertTrue(pgc.tail.head.isValue());

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal.data;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -254,9 +255,9 @@ public class ParseGraphTest {
 
     @Test
     public void testCurrent() {
-        assertNull(EMPTY.current());
-        assertNull(EMPTY.add(new ParseReference(0, EMPTY_SOURCE, NONE)).current());
-        assertNull(EMPTY.addBranch(NONE).current());
+        assertFalse(EMPTY.current().isPresent());
+        assertFalse(EMPTY.add(new ParseReference(0, EMPTY_SOURCE, NONE)).current().isPresent());
+        assertFalse(EMPTY.addBranch(NONE).current().isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByOffsetTest.java
@@ -41,7 +41,7 @@ public class ByOffsetTest {
         assertEquals("the_one",
             findItemAtOffset(ImmutableList.create(ParseGraph.EMPTY.add(new ParseValue("two", any("a"), new Slice(source, 2, new byte[] { 1, 2 }), new Encoding()))
                                                                   .add(new ParseValue("zero", any("a"), new Slice(source, 0, new byte[] { 1, 2 }), new Encoding()))
-                                                                  .add(new ParseValue("the_one", any("a"), new Slice(source, 1, new byte[] { 1, 2 }), new Encoding()))), 0, source).computeResult().asGraph().head.asValue().name);
+                                                                  .add(new ParseValue("the_one", any("a"), new Slice(source, 1, new byte[] { 1, 2 }), new Encoding()))), 0, source).computeResult().get().asGraph().head.asValue().name);
     }
 
 }


### PR DESCRIPTION
Resolves #161.

Two methods converted: `ParseGraph.current()` and `ByOffset.findItemAtOffset()`. There are some more methods, but they are scheduled to be removed from core (see #166).

One pattern that is used a couple of times is notable: there are placed where `A extends B` and we must return an `Optional<B>` but we have an `Optional<A>`. This can be easily done by mapping to the identity function: `var.map(x -> x)` which maps the value inside the `Optional` to the desired type. This happens where we have an `Optional<ParseValue>` but we need an `Optional<Value>`.