### PR TITLE
Added Until token for variable size values

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -137,7 +137,13 @@ public final class Shorthand {
     public static Token tie(final String name, final Token token, final ValueExpression dataExpression) { return tie(name, token, dataExpression, null); }
     public static Token tie(final Token token, final ValueExpression dataExpression, final Encoding encoding) { return tie(NO_NAME, token, dataExpression, encoding); }
     public static Token tie(final Token token, final ValueExpression dataExpression) { return tie(token, dataExpression, null); }
-    public static Token until(final String name, final Token terminator, final Encoding encoding) { return new Until(name, terminator, encoding); }
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, encoding); }
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return until(name, initialSize, stepSize, maxSize, terminator, null); }
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, stepSize, null, terminator, encoding); }
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return until(name, initialSize, stepSize, null, terminator, null); }
+    public static Token until(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, null, terminator, encoding); }
+    public static Token until(final String name, final ValueExpression initialSize, final Token terminator) { return until(name, initialSize, null, terminator, null); }
+    public static Token until(final String name, final Token terminator, final Encoding encoding) { return until(name, null, terminator, encoding); }
     public static Token until(final String name, final Token terminator) { return until(name, terminator, null); }
 
     public static BinaryValueExpression add(final ValueExpression left, final ValueExpression right) { return new Add(left, right); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -76,6 +76,7 @@ import io.parsingdata.metal.token.Seq;
 import io.parsingdata.metal.token.Tie;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
+import io.parsingdata.metal.token.Until;
 import io.parsingdata.metal.token.While;
 
 public final class Shorthand {
@@ -136,6 +137,8 @@ public final class Shorthand {
     public static Token tie(final String name, final Token token, final ValueExpression dataExpression) { return tie(name, token, dataExpression, null); }
     public static Token tie(final Token token, final ValueExpression dataExpression, final Encoding encoding) { return tie(NO_NAME, token, dataExpression, encoding); }
     public static Token tie(final Token token, final ValueExpression dataExpression) { return tie(token, dataExpression, null); }
+    public static Token until(final String name, final Token terminator, final Encoding encoding) { return new Until(name, terminator, encoding); }
+    public static Token until(final String name, final Token terminator) { return until(name, terminator, null); }
 
     public static BinaryValueExpression add(final ValueExpression left, final ValueExpression right) { return new Add(left, right); }
     public static BinaryValueExpression div(final ValueExpression left, final ValueExpression right) { return new Div(left, right); }

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -31,10 +31,36 @@ import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.data.Slice;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
+/**
+ * A {@link Token} that specifies a value to parse in the input until
+ * another token is parsed.
+ * <p>
+ * An Until consists of an <code>initialSize</code>, a <code>stepSize</code>
+ * and a <code>maxSize</code> (all {@link ValueExpression}s) and a
+ * <code>terminator</code>(a {@link Token}). First <code>initialSize</code>,
+ * <code>stepSize</code>, and <code>maxSize</code> are evaluated. Using this
+ * token's name, a value of length <code>initialSize</code> is added to the
+ * <code>Environment</code> and an attempt is made to parse the
+ * <code>terminator</code>. If it succeeds, the resulting environment is
+ * returned. Otherwise, <code>stepSize</code> is added to the
+ * <code>initialSize</code> and if the resulting value is below
+ * <code>maxSize</code>, a value with the resulting size is added to the
+ * original <code>Environment</code> and a new attempt to parse the
+ * <code>terminator</code> is made. Parsing fails if no combination of any size
+ * is found where the <code>terminator</code> parses successfully.
+ * <p>
+ * If the <code>ValueExpressions</code> evaluate to lists, they are treated
+ * as sets of values to attempt. If <code>stepSize</code> is negative,
+ * <code>maxSize</code> is allowed to be smaller than <code>initialSize</code>.
+ * A <code>stepSize</code> of zero is not allowed.
+ *
+ * @see ValueExpression
+ */
 public class Until extends Token {
 
     public static final ValueExpression DEFAULT_INITIAL = con(0);
@@ -68,7 +94,9 @@ public class Until extends Token {
 
     private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final int currentSize, final int stepSize, final int maxSize, final Encoding encoding) throws IOException {
         if (stepSize == 0 || stepSize > 0 && currentSize > maxSize || stepSize < 0 && currentSize < maxSize) { return complete(Util::failure); }
-        return terminator.parse(scope, currentSize == 0 ? environment : environment.add(new ParseValue(name, this, environment.slice(currentSize), encoding)).seek(environment.offset + currentSize), encoding)
+        final Slice slice = environment.slice(currentSize);
+        if (slice.size != currentSize) { return complete(Util::failure); }
+        return terminator.parse(scope, currentSize == 0 ? environment : environment.add(new ParseValue(name, this, slice, encoding)).seek(environment.offset + currentSize), encoding)
             .map(nextEnvironment -> complete(() -> success(nextEnvironment)))
             .orElseGet(() -> intermediate(() -> iterate(scope, environment, currentSize + stepSize, stepSize, maxSize, encoding)));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -60,14 +60,14 @@ public class Until extends Token {
     }
 
     private Trampoline<Optional<Environment>> handleInterval(final String scope, final Environment environment, final ImmutableList<Optional<Value>> initialSizes, final ImmutableList<Optional<Value>> stepSizes, final ImmutableList<Optional<Value>> maxSizes, final Encoding encoding) throws IOException {
-        if (checkNotValidList(initialSizes) || checkNotValidList(maxSizes) || checkNotValidList(stepSizes)) { return complete(Util::failure); }
+        if (checkNotValidList(initialSizes) || checkNotValidList(stepSizes) || checkNotValidList(maxSizes)) { return complete(Util::failure); }
         return iterate(scope, environment, getInt(initialSizes), getInt(stepSizes), getInt(maxSizes), encoding).computeResult()
             .map(nextEnvironment -> complete(() -> success(nextEnvironment)))
             .orElseGet(() -> intermediate(() -> handleInterval(scope, environment, initialSizes.tail, stepSizes.tail, maxSizes.tail, encoding)));
     }
 
     private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final int currentSize, final int stepSize, final int maxSize, final Encoding encoding) throws IOException {
-        if (currentSize > maxSize) { return complete(Util::failure); }
+        if (currentSize > maxSize || stepSize == 0) { return complete(Util::failure); }
         return terminator.parse(scope, currentSize == 0 ? environment : environment.add(new ParseValue(name, this, environment.slice(currentSize), encoding)).seek(environment.offset + currentSize), encoding)
             .map(nextEnvironment -> complete(() -> success(nextEnvironment)))
             .orElseGet(() -> intermediate(() -> iterate(scope, environment, currentSize + stepSize, stepSize, maxSize, encoding)));

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.token;
+
+import static io.parsingdata.metal.Trampoline.complete;
+import static io.parsingdata.metal.Trampoline.intermediate;
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.Util.success;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.parsingdata.metal.Trampoline;
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.encoding.Encoding;
+
+public class Until extends Token {
+
+    private final Token terminator;
+
+    public Until(final String name, final Token terminator, final Encoding encoding) {
+        super(name, encoding);
+        this.terminator = checkNotNull(terminator, "terminator");
+    }
+
+    @Override
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) throws IOException {
+        return iterate(scope, environment, encoding, 0).computeResult();
+    }
+
+    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding, final int currentSize) throws IOException {
+        return terminator.parse(scope, currentSize == 0 ? environment : environment.add(new ParseValue(name, this, environment.slice(currentSize), encoding)).seek(environment.offset + currentSize), encoding)
+            .map(nextEnvironment -> complete(() -> success(nextEnvironment)))
+            .orElseGet(() -> intermediate(() -> iterate(scope, environment, encoding, currentSize + 1)));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + makeNameFragment() + terminator + ")";
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return super.equals(obj)
+            && Objects.equals(terminator, ((Until)obj).terminator);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), terminator);
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -67,7 +67,7 @@ public class Until extends Token {
     }
 
     private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final int currentSize, final int stepSize, final int maxSize, final Encoding encoding) throws IOException {
-        if (currentSize > maxSize || stepSize == 0) { return complete(Util::failure); }
+        if (stepSize == 0 || stepSize > 0 && currentSize > maxSize || stepSize < 0 && currentSize < maxSize) { return complete(Util::failure); }
         return terminator.parse(scope, currentSize == 0 ? environment : environment.add(new ParseValue(name, this, environment.slice(currentSize), encoding)).seek(environment.offset + currentSize), encoding)
             .map(nextEnvironment -> complete(() -> success(nextEnvironment)))
             .orElseGet(() -> intermediate(() -> iterate(scope, environment, currentSize + stepSize, stepSize, maxSize, encoding)));

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -56,8 +56,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * <p>
  * If the <code>ValueExpressions</code> evaluate to lists, they are treated
  * as sets of values to attempt. If <code>stepSize</code> is negative,
- * <code>maxSize</code> is allowed to be smaller than <code>initialSize</code>.
- * A <code>stepSize</code> of zero is not allowed.
+ * <code>maxSize</code> is must be smaller than <code>initialSize</code>.
+ * Parsing fails if <code>stepSize</code> is zero.
  *
  * @see ValueExpression
  */

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -63,6 +63,7 @@ import io.parsingdata.metal.token.Seq;
 import io.parsingdata.metal.token.Sub;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
+import io.parsingdata.metal.token.Until;
 import io.parsingdata.metal.token.While;
 
 @RunWith(Parameterized.class)
@@ -135,7 +136,9 @@ public class ArgumentsTest {
             { TokenRef.class, new Object[] { VALID_NAME, null, null } },
             { TokenRef.class, new Object[] { null, VALID_NAME, null } },
             { TokenRef.class, new Object[] { null, null, null } },
-            { TokenRef.class, new Object[] { VALID_NAME, EMPTY_NAME, null } }
+            { TokenRef.class, new Object[] { VALID_NAME, EMPTY_NAME, null } },
+            { Until.class, new Object[] { null, VALID_VE, VALID_VE, VALID_VE, VALID_T, null }},
+            { Until.class, new Object[] { VALID_NAME, VALID_VE, VALID_VE, VALID_VE, null, null }}
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -103,6 +103,7 @@ import io.parsingdata.metal.token.Sub;
 import io.parsingdata.metal.token.Tie;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
+import io.parsingdata.metal.token.Until;
 import io.parsingdata.metal.token.While;
 import io.parsingdata.metal.util.InMemoryByteStream;
 
@@ -153,7 +154,7 @@ public class AutoEqualityTest {
     public static Collection<Object[]> data() throws IllegalAccessException, InvocationTargetException, InstantiationException {
         return generateObjectArrays(
             Cho.class, Def.class, Nod.class, Pre.class, Rep.class, RepN.class, Seq.class, Sub.class, Tie.class,
-            TokenRef.class, While.class, Post.class,
+            TokenRef.class, While.class, Post.class, Until.class,
             Len.class, Offset.class, Neg.class, Not.class, Count.class, First.class, Last.class, Reverse.class,
             And.class, Or.class, ShiftLeft.class, ShiftRight.class, Add.class, Div.class, Mod.class, Mul.class,
             io.parsingdata.metal.expression.value.arithmetic.Sub.class, Cat.class, Eq.class, EqNum.class, EqStr.class,

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -56,6 +56,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.Shorthand.token;
+import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.Util.createFromBytes;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
@@ -99,7 +100,7 @@ public class ToStringTest {
     @Test
     public void validateToStringImplementation() {
         final Expression e = not(and(eq(v(), v()), or(eqNum(v()), and(eqStr(v()), or(gtNum(v()), ltNum(v()))))));
-        final Token t = post(repn(sub(opt(pre(rep(cho(token("refName"), any(n()), seq(tie(nod(v()), v()), whl(def(n(), con(1), e), e), tie(t(), con(1))))), e)), v()), v()), e);
+        final Token t = until("untilName", v(), v(), v(), post(repn(sub(opt(pre(rep(cho(token("refName"), any(n()), seq(tie(nod(v()), v()), whl(def(n(), con(1), e), e), tie(t(), con(1))))), e)), v()), v()), e));
         final String output = t.toString();
         for (int i = 0; i < count; i++) {
             assertTrue(output.contains(prefix + i));

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -21,8 +21,10 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.empty;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.exp;
+import static io.parsingdata.metal.Shorthand.expTrue;
 import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.ref;
@@ -56,8 +58,9 @@ public class ParameterizedUntilTest extends ParameterizedParse {
             { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
             { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
             { "[] i=NaN",                         untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")), stream("", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=1 ab",         untilToken(0, 1, con('c'), con("ab")), stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0 ab",             untilToken(0, con('c'), con("ab")), stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=1 ab",         untilToken(0, 1, con('c'), con("ab")),        stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0 ab",             untilToken(0, con('c'), con("ab")),           stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",     untilTokenAlwaysTrueTerminator(2, 1, 6),      stream("a", US_ASCII), enc(), false },
         });
     }
 
@@ -75,6 +78,10 @@ public class ParameterizedUntilTest extends ParameterizedParse {
 
     private static Token untilToken(final int initial, final ValueExpression terminator, final ValueExpression expectedValue) {
         return post(until("value", con(initial), def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
+    }
+
+    private static Token untilTokenAlwaysTrueTerminator(final int initial, final int step, final int max) {
+        return until("value", con(initial), con(step, signed()), con(max), post(empty, expTrue()));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -49,13 +49,15 @@ public class ParameterizedUntilTest extends ParameterizedParse {
             { "[a,b,c,a,b,c] i=0,s=2,m=6 ab",     untilToken(0, 2, 6, con('c'), con("ab")),     stream("abcabc", US_ASCII), enc(), true },
             { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",  untilToken(1, 2, 6, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
             { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(0, 3, 6, con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=0,m=6",        untilToken(0, 0, 6, con(""), con("")),       stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=0,m=6",        untilToken(0, 0, 6, con(""), con("")),        stream("abcabc", US_ASCII), enc(), false },
             { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab", untilToken(6, -1, 0, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
-            { "[] i=0,s=-1,m=6",                  untilToken(0, -1, 6, con(""), con("")),      stream("", US_ASCII), enc(), false },
-            { "[] i=6,s=1,m=0",                   untilToken(6, 1, 0, con(""), con("")),       stream("", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
-            { "[] i=NaN",                         untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")),       stream("", US_ASCII), enc(), false },
+            { "[] i=0,s=-1,m=6",                  untilToken(0, -1, 6, con(""), con("")),       stream("", US_ASCII), enc(), false },
+            { "[] i=6,s=1,m=0",                   untilToken(6, 1, 0, con(""), con("")),        stream("", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
+            { "[] i=NaN",                         untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")), stream("", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=1 ab",         untilToken(0, 1, con('c'), con("ab")), stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0 ab",             untilToken(0, con('c'), con("ab")), stream("abcabc", US_ASCII), enc(), true },
         });
     }
 
@@ -65,6 +67,14 @@ public class ParameterizedUntilTest extends ParameterizedParse {
 
     private static Token untilToken(final ValueExpression initial, final ValueExpression step, final ValueExpression max, final ValueExpression terminator, final ValueExpression expectedValue) {
         return post(until("value", initial, step, max, def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
+    }
+
+    private static Token untilToken(final int initial, final int step, final ValueExpression terminator, final ValueExpression expectedValue) {
+        return post(until("value", con(initial), con(step, signed()), def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
+    }
+
+    private static Token untilToken(final int initial, final ValueExpression terminator, final ValueExpression expectedValue) {
+        return post(until("value", con(initial), def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.token;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.last;
+import static io.parsingdata.metal.Shorthand.post;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.until;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized.Parameters;
+
+import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.util.ParameterizedParse;
+
+public class ParameterizedUntilTest extends ParameterizedParse {
+
+    @Parameters(name = "{0} ({4})")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",    untilToken(0, 1, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab", untilToken(3, 1, 6, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=2,m=6 ab",    untilToken(0, 2, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab", untilToken(1, 2, 6, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",       untilToken(0, 3, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), false },
+            //{ "[a,b,c,a,b,c] i=0,s=0,m=6",       untilToken(0, 0, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), false },
+        });
+    }
+
+    private static Token untilToken(final int initial, final int step, final int max, final ValueExpression terminator, final ValueExpression expectedValue) {
+        return post(until("value", con(initial), con(step), con(max), def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -20,12 +20,15 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.exp;
 import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.util.Arrays;
@@ -41,17 +44,27 @@ public class ParameterizedUntilTest extends ParameterizedParse {
     @Parameters(name = "{0} ({4})")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",    untilToken(0, 1, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab", untilToken(3, 1, 6, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=2,m=6 ab",    untilToken(0, 2, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab", untilToken(1, 2, 6, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",       untilToken(0, 3, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=0,m=6",       untilToken(0, 0, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",     untilToken(0, 1, 6, con('c'), con("ab")),     stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",  untilToken(3, 1, 6, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=2,m=6 ab",     untilToken(0, 2, 6, con('c'), con("ab")),     stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",  untilToken(1, 2, 6, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(0, 3, 6, con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=0,m=6",        untilToken(0, 0, 6, con(""), con("")),       stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab", untilToken(6, -1, 0, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
+            { "[] i=0,s=-1,m=6",                  untilToken(0, -1, 6, con(""), con("")),      stream("", US_ASCII), enc(), false },
+            { "[] i=6,s=1,m=0",                   untilToken(6, 1, 0, con(""), con("")),       stream("", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
+            { "[] i=NaN",                         untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")),       stream("", US_ASCII), enc(), false },
         });
     }
 
     private static Token untilToken(final int initial, final int step, final int max, final ValueExpression terminator, final ValueExpression expectedValue) {
-        return post(until("value", con(initial), con(step), con(max), def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
+        return post(until("value", con(initial), con(step, signed()), con(max), def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
+    }
+
+    private static Token untilToken(final ValueExpression initial, final ValueExpression step, final ValueExpression max, final ValueExpression terminator, final ValueExpression expectedValue) {
+        return post(until("value", initial, step, max, def("terminator", 1, eq(terminator))), eq(last(ref("value")), expectedValue));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -46,7 +46,7 @@ public class ParameterizedUntilTest extends ParameterizedParse {
             { "[a,b,c,a,b,c] i=0,s=2,m=6 ab",    untilToken(0, 2, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), true },
             { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab", untilToken(1, 2, 6, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
             { "[a,b,c,a,b,c] i=0,s=3,m=6",       untilToken(0, 3, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), false },
-            //{ "[a,b,c,a,b,c] i=0,s=0,m=6",       untilToken(0, 0, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=0,m=6",       untilToken(0, 0, 6, con('c'), con("ab")),    stream("abcabc", US_ASCII), enc(), false },
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.token;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.post;
+import static io.parsingdata.metal.Shorthand.repn;
+import static io.parsingdata.metal.Shorthand.until;
+import static io.parsingdata.metal.data.selection.ByName.getAllValues;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.util.InMemoryByteStream;
+
+public class UntilTest {
+
+    @Test
+    public void threeNewLines() throws IOException {
+        final String input1 = "Hello, World!";
+        final String input2 = "Another line...";
+        final String input3 = "Another way to scroll...";
+        final String input = input1 + "\n" + input2 + "\n" + input3 + "\n";
+        final Optional<Environment> environment =
+            repn(
+                until(
+                    "line",
+                    post(def("newline", con(1)), eq(con('\n')))),
+                con(3)
+            ).parse(new Environment(new InMemoryByteStream(input.getBytes(StandardCharsets.US_ASCII))), enc());
+        assertTrue(environment.isPresent());
+        ImmutableList<ParseValue> values = getAllValues(environment.get().order, "line");
+        assertEquals(3, values.size);
+        assertEquals(values.head.asString(), input3);
+        assertEquals(values.tail.head.asString(), input2);
+        assertEquals(values.tail.tail.head.asString(), input1);
+    }
+
+}


### PR DESCRIPTION
Resolves #109.

This token can be used to parse zero-terminated strings and *varints*.

See `UntilTest` for examples of inclusive (`untilInclusive()`) and exclusive (`threeNewLines()`) parsing.