### PR TITLE
Def and Until tokens should not allow empty name

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal;
 
 import static io.parsingdata.metal.Util.createFromBytes;
+import static io.parsingdata.metal.token.Token.EMPTY;
 import static io.parsingdata.metal.token.Token.NO_NAME;
 
 import java.util.function.BiFunction;
@@ -91,7 +92,7 @@ public final class Shorthand {
     public static Token def(final String name, final long size, final Expression predicate) { return def(name, size, predicate, null); }
     public static Token def(final String name, final long size, final Encoding encoding) { return def(name, con(size), encoding); }
     public static Token def(final String name, final long size) { return def(name, size, (Encoding)null); }
-    public static final Token empty = def(NO_NAME, 0L);
+    public static final Token empty = def(EMPTY, 0L);
     public static Token cho(final String name, final Encoding encoding, final Token token1, final Token token2, final Token... tokens) { return new Cho(name, encoding, token1, token2, tokens); }
     public static Token cho(final String name, final Token token1, final Token token2, final Token... tokens) { return cho(name, null, token1, token2, tokens); }
     public static Token cho(final Encoding encoding, final Token token1, final Token token2, final Token... tokens) { return cho(NO_NAME, encoding, token1, token2, tokens); }

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -50,7 +50,7 @@ public final class Util {
     }
 
     public static String checkNotEmpty(final String argument, final String name) {
-        if (argument.isEmpty()) { throw new IllegalArgumentException("Argument " + name + " may not be empty."); }
+        if (checkNotNull(argument, name).isEmpty()) { throw new IllegalArgumentException("Argument " + name + " may not be empty."); }
         return argument;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -49,6 +49,11 @@ public final class Util {
         return arguments;
     }
 
+    public static String checkNotEmpty(final String argument, final String name) {
+        if (argument.isEmpty()) { throw new IllegalArgumentException("Argument " + name + " may not be empty."); }
+        return argument;
+    }
+
     public static boolean notNullAndSameClass(final Object object, final Object other) {
         return other != null
             && object.getClass() == other.getClass();

--- a/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
@@ -32,7 +32,7 @@ public class ParseValue extends Value implements ParseItem {
 
     public ParseValue(final String name, final Token definition, final Slice slice, final Encoding encoding) {
         super(slice, encoding);
-        this.name = checkNotEmpty(checkNotNull(name, "name"), "name");
+        this.name = checkNotEmpty(name, "name");
         this.definition = checkNotNull(definition, "definition");
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
@@ -16,6 +16,7 @@
 
 package io.parsingdata.metal.data;
 
+import static io.parsingdata.metal.Util.checkNotEmpty;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.util.Objects;
@@ -31,7 +32,7 @@ public class ParseValue extends Value implements ParseItem {
 
     public ParseValue(final String name, final Token definition, final Slice slice, final Encoding encoding) {
         super(slice, encoding);
-        this.name = checkNotNull(name, "name");
+        this.name = checkNotEmpty(checkNotNull(name, "name"), "name");
         this.definition = checkNotNull(definition, "definition");
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -50,8 +50,7 @@ public class Def extends Token {
     public final ValueExpression size;
 
     public Def(final String name, final ValueExpression size, final Encoding encoding) {
-        super(name, encoding);
-        checkNotEmpty(name, "name");
+        super(checkNotEmpty(name, "name"), encoding);
         this.size = checkNotNull(size, "size");
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -16,6 +16,7 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.Util.checkNotEmpty;
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.Util.failure;
 import static io.parsingdata.metal.Util.success;
@@ -50,6 +51,7 @@ public class Def extends Token {
 
     public Def(final String name, final ValueExpression size, final Encoding encoding) {
         super(name, encoding);
+        checkNotEmpty(name, "name");
         this.size = checkNotNull(size, "size");
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -52,6 +52,7 @@ public abstract class Token {
 
     public static final String NO_NAME = "";
     public static final String SEPARATOR = ".";
+    public static final String EMPTY = "__EMPTY__";
 
     public final String name;
     public final Encoding encoding;

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -48,8 +48,7 @@ public class Until extends Token {
     public final Token terminator;
 
     public Until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) {
-        super(name, encoding);
-        checkNotEmpty(name, "name");
+        super(checkNotEmpty(name, "name"), encoding);
         this.initialSize = initialSize == null ? DEFAULT_INITIAL : initialSize;
         this.stepSize = stepSize == null ? DEFAULT_STEP : stepSize;
         this.maxSize = maxSize == null ? DEFAULT_MAX : maxSize;

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.token;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
+import static io.parsingdata.metal.Util.checkNotEmpty;
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.Util.success;
 
@@ -48,6 +49,7 @@ public class Until extends Token {
 
     public Until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) {
         super(name, encoding);
+        checkNotEmpty(name, "name");
         this.initialSize = initialSize == null ? DEFAULT_INITIAL : initialSize;
         this.stepSize = stepSize == null ? DEFAULT_STEP : stepSize;
         this.maxSize = maxSize == null ? DEFAULT_MAX : maxSize;

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -57,7 +57,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * <p>
  * If the <code>ValueExpressions</code> evaluate to lists, they are treated
  * as sets of values to attempt. If <code>stepSize</code> is negative,
- * <code>maxSize</code> is must be smaller than <code>initialSize</code>.
+ * <code>maxSize</code> must be smaller than <code>initialSize</code>.
  * Parsing fails if <code>stepSize</code> is zero.
  *
  * @see ValueExpression

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -93,4 +93,12 @@ public class ParseValueTest {
         value.asGraph();
     }
 
+    @Test
+    public void emptyName() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Argument name may not be empty.");
+
+        new ParseValue("", definition, createFromBytes(new byte[] { 1 }), enc());
+    }
+
 }

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -26,17 +26,30 @@ import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.io.IOException;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class DefTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
-    public void testScopeWithoutEncoding() throws IOException {
+    public void scopeWithoutEncoding() throws IOException {
         assertEquals(1, getValue(def("a", 1).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValue());
     }
 
     @Test
-    public void testScopeWithEncoding() throws IOException {
+    public void scopeWithEncoding() throws IOException {
         assertEquals(1, getValue(def("a", 1, signed()).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValue());
     }
+
+    @Test
+    public void emptyName() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Argument name may not be empty.");
+        def("", 1);
+    }
+
 }


### PR DESCRIPTION
This is because a `ParseValue` with an empty name leads to `matches()` anomalies.

```java
    public boolean matches(final String name) {
        return this.name.equals(name) || this.name.endsWith(Token.SEPARATOR + name);
    }
```