### PR TITLE
Improved hashCode() implementations to prevent collisions

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -54,7 +54,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     public int hashCode() {
-        return Objects.hash(input);
+        return Objects.hash(getClass().hashCode(), input);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -21,6 +21,7 @@ import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 import io.parsingdata.metal.Util;
 
@@ -54,7 +55,7 @@ public class ConstantSource extends Source {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(data);
+        return Objects.hash(getClass().hashCode(), data);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -77,7 +77,7 @@ public class DataExpressionSource extends Source {
 
     @Override
     public int hashCode() {
-        return Objects.hash(dataExpression, index, graph, encoding);
+        return Objects.hash(getClass().hashCode(), dataExpression, index, graph, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ImmutableList.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ImmutableList.java
@@ -89,7 +89,7 @@ public class ImmutableList<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(head, tail);
+        return Objects.hash(getClass().hashCode(), head, tail);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -138,7 +138,7 @@ public class ParseGraph implements ParseItem {
 
     @Override
     public int hashCode() {
-        return Objects.hash(head, tail, branched, definition);
+        return Objects.hash(getClass().hashCode(), head, tail, branched, definition);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
@@ -61,7 +61,7 @@ public class ParseReference implements ParseItem {
 
     @Override
     public int hashCode() {
-        return Objects.hash(location, source, definition);
+        return Objects.hash(getClass().hashCode(), location, source, definition);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -56,7 +56,7 @@ public class Slice {
 
     @Override
     public int hashCode() {
-        return Objects.hash(source, offset, size);
+        return Objects.hash(getClass().hashCode(), source, offset, size);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
@@ -69,7 +69,7 @@ public class Encoding {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sign, charset, byteOrder);
+        return Objects.hash(getClass().hashCode(), sign, charset, byteOrder);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/True.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/True.java
@@ -43,7 +43,7 @@ public class True implements Expression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(true);
+        return Objects.hash(getClass().hashCode(), true);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/True.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/True.java
@@ -16,8 +16,6 @@
 
 package io.parsingdata.metal.expression;
 
-import java.util.Objects;
-
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.encoding.Encoding;
@@ -43,7 +41,7 @@ public class True implements Expression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), true);
+        return getClass().hashCode();
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -89,7 +89,7 @@ public abstract class ComparisonExpression implements Expression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value, predicate);
+        return Objects.hash(getClass().hashCode(), value, predicate);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/BinaryLogicalExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/BinaryLogicalExpression.java
@@ -55,7 +55,7 @@ public abstract class BinaryLogicalExpression implements LogicalExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(left, right);
+        return Objects.hash(getClass().hashCode(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/UnaryLogicalExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/UnaryLogicalExpression.java
@@ -52,7 +52,7 @@ public abstract class UnaryLogicalExpression implements LogicalExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(operand);
+        return Objects.hash(getClass().hashCode(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -101,7 +101,7 @@ public abstract class BinaryValueExpression implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(left, right);
+        return Objects.hash(getClass().hashCode(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -84,7 +84,7 @@ public class Bytes implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(operand);
+        return Objects.hash(getClass().hashCode(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -56,7 +56,7 @@ public class Const implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(getClass().hashCode(), value);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -77,7 +77,7 @@ public class Elvis implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(left, right);
+        return Objects.hash(getClass().hashCode(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -78,7 +78,7 @@ public class Expand implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(base, count);
+        return Objects.hash(getClass().hashCode(), base, count);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -95,7 +95,7 @@ public abstract class Fold implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(values, reducer, initial);
+        return Objects.hash(getClass().hashCode(), values, reducer, initial);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
@@ -54,7 +54,7 @@ public class Reverse implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(values);
+        return Objects.hash(getClass().hashCode(), values);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -78,7 +78,7 @@ public abstract class UnaryValueExpression implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(operand);
+        return Objects.hash(getClass().hashCode(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
@@ -69,7 +69,7 @@ public class Value {
 
     @Override
     public int hashCode() {
-        return Objects.hash(slice, encoding);
+        return Objects.hash(getClass().hashCode(), slice, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -65,7 +65,7 @@ public class Count implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(operand);
+        return Objects.hash(getClass().hashCode(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -66,7 +66,7 @@ public class First implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(operand);
+        return Objects.hash(getClass().hashCode(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -59,7 +59,7 @@ public class Last implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(operand);
+        return Objects.hash(getClass().hashCode(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -95,7 +95,7 @@ public class Nth implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(values, indices);
+        return Objects.hash(getClass().hashCode(), values, indices);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -98,7 +98,7 @@ public class Ref<T> implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(reference, limit);
+        return Objects.hash(getClass().hashCode(), reference, limit);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -51,7 +51,7 @@ public class Self implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return 2;
+        return getClass().hashCode();
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -96,7 +96,7 @@ public abstract class Token {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, encoding);
+        return Objects.hash(getClass().hashCode(), name, encoding);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal.util;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ByteStream;
@@ -50,7 +51,7 @@ public class InMemoryByteStream implements ByteStream {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(data);
+        return Objects.hash(getClass().hashCode(), data);
     }
 
 }


### PR DESCRIPTION
Resolves #150.

Because we have many classes with the same set of fields (e.g., `Cho` <-> `Seq`, `And` <-> `Or`, `First` <-> `Last`, etc.), basing the value returned by `hashCode()` solely on an object's fields will cause many collisions. To remedy this, the value of `getClass().hashCode()` has been added to all overridden `hashCode()` calculations.

For some classes this may be unnecessary (e.g., `DataExpressionSource`, `ParseGraph`, etc.), but to prevent us from having to reexamine `hashCode()` implementations whenever some subclass is added, the call has been added to all instances.