### PR TITLE
#196: Fixed hashCode() on classes that encapsulate a byte array.

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -55,7 +55,7 @@ public class ConstantSource extends Source {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), data);
+        return Objects.hash(getClass().hashCode(), Arrays.hashCode(data));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -51,7 +51,7 @@ public class InMemoryByteStream implements ByteStream {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), data);
+        return Objects.hash(getClass().hashCode(), Arrays.hashCode(data));
     }
 
 }


### PR DESCRIPTION
Bug was introduced in #195. Resolves #196. See that issue for a detailed description of the issue and fix.