### PR TITLE
Improved and unified toString() implementations, added some missing ones

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -64,17 +64,13 @@ public final class Util {
     public static String bytesToShortHexString(final byte[] bytes) {
         checkNotNull(bytes, "bytes");
         if (bytes.length > (MAX_VALUES_IN_HEX_STRING + 1)) {
-            final char[] hexChars = new char[(MAX_VALUES_IN_HEX_STRING * 2) + 3];
-            hexChars[hexChars.length-1] = '.';
-            hexChars[hexChars.length-2] = '.';
-            hexChars[hexChars.length-3] = '.';
-            return fillHexDigits(bytes, hexChars, MAX_VALUES_IN_HEX_STRING);
-        } else {
-            return fillHexDigits(bytes, new char[bytes.length * 2], bytes.length);
+            return fillHexDigits(bytes, MAX_VALUES_IN_HEX_STRING) + "...";
         }
+        return fillHexDigits(bytes, bytes.length);
     }
 
-    private static String fillHexDigits(final byte[] bytes, final char[] hexChars, final int count) {
+    private static String fillHexDigits(final byte[] bytes, final int count) {
+        char[] hexChars = new char[count * 2];
         for (int j = 0; j < count; j++) {
             final int v = bytes[j] & 0xFF;
             hexChars[j * 2] = HEX_ARRAY[v >>> 4];

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -34,6 +34,8 @@ public final class Util {
 
     private Util() {}
 
+    final public static int MAX_VALUES_IN_HEX_STRING = 10;
+
     final private static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray(); // Private because array content is mutable.
 
     public static <T>T checkNotNull(final T argument, final String name) {
@@ -59,10 +61,21 @@ public final class Util {
             && object.getClass() == other.getClass();
     }
 
-    public static String bytesToHexString(final byte[] bytes) {
+    public static String bytesToShortHexString(final byte[] bytes) {
         checkNotNull(bytes, "bytes");
-        final char[] hexChars = new char[bytes.length * 2];
-        for (int j = 0; j < bytes.length; j++) {
+        if (bytes.length > (MAX_VALUES_IN_HEX_STRING + 1)) {
+            final char[] hexChars = new char[(MAX_VALUES_IN_HEX_STRING * 2) + 3];
+            hexChars[hexChars.length-1] = '.';
+            hexChars[hexChars.length-2] = '.';
+            hexChars[hexChars.length-3] = '.';
+            return fillHexDigits(bytes, hexChars, MAX_VALUES_IN_HEX_STRING);
+        } else {
+            return fillHexDigits(bytes, new char[bytes.length * 2], bytes.length);
+        }
+    }
+
+    private static String fillHexDigits(final byte[] bytes, final char[] hexChars, final int count) {
+        for (int j = 0; j < count; j++) {
             final int v = bytes[j] & 0xFF;
             hexChars[j * 2] = HEX_ARRAY[v >>> 4];
             hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -43,7 +43,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     public String toString() {
-        return input.toString();
+        return getClass().getSimpleName() + "(" + input.toString() + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.data;
 
-import static io.parsingdata.metal.Util.bytesToHexString;
+import static io.parsingdata.metal.Util.bytesToShortHexString;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.io.IOException;
@@ -44,7 +44,7 @@ public class ConstantSource extends Source {
 
     @Override
     public String toString() {
-        return bytesToHexString(data);
+        return getClass().getSimpleName() + "(0x" + bytesToShortHexString(data) + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -63,7 +63,7 @@ public class DataExpressionSource extends Source {
 
     @Override
     public String toString() {
-        return dataExpression.toString() + "[" + index + "](" + graph + "," + encoding + ")";
+        return getClass().getSimpleName() + "(" + dataExpression.toString() + "[" + index + "](" + graph + "," + encoding + "))";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/Environment.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Environment.java
@@ -85,7 +85,7 @@ public class Environment {
 
     @Override
     public String toString() {
-        return "source: " + source + "; offset: " + offset + "; order: " + order + "; callbacks: " + callbacks;
+        return getClass().getSimpleName() + "(source:" + source + ";offset:" + offset + ";order:" + order + ";callbacks:" + callbacks + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -119,11 +119,11 @@ public class ParseGraph implements ParseItem {
 
     @Override
     public String toString() {
-        if (this == EMPTY) { return "graph(EMPTY)"; }
+        if (this == EMPTY) { return "pg(EMPTY)"; }
         if (head == null) {
-            return "graph(terminator:" + definition.getClass().getSimpleName() + ")";
+            return "pg(terminator:" + definition.getClass().getSimpleName() + ")";
         }
-        return "graph(" + head + ", " + tail + ", " + branched + ")";
+        return "pg(" + head + "," + tail + "," + branched + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
@@ -48,7 +48,7 @@ public class ParseReference implements ParseItem {
 
     @Override
     public String toString() {
-        return "ref(@" + location + ")";
+        return "pref(@" + location + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseValue.java
@@ -46,7 +46,7 @@ public class ParseValue extends Value implements ParseItem {
 
     @Override
     public String toString() {
-        return name + "(" + super.toString() + ")";
+        return "pval(" + name + ":" + super.toString() + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -42,7 +42,7 @@ public class Slice {
 
     @Override
     public String toString() {
-        return source + "@" + offset + ":" + (offset+size);
+        return getClass().getSimpleName() + "(" + source + "@" + offset + ":" + (offset+size) + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -86,6 +86,11 @@ public abstract class Fold implements ValueExpression {
     protected abstract ValueExpression reduce(BinaryOperator<ValueExpression> reducer, Value head, Value tail);
 
     @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + values + "," + reducer + (initial == null ? "" : "," + initial) + ")";
+    }
+
+    @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
             && Objects.equals(values, ((Fold)obj).values)

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
@@ -47,6 +47,11 @@ public class Reverse implements ValueExpression {
     }
 
     @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + values + ")";
+    }
+
+    @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
             && Objects.equals(values, ((Reverse)obj).values);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
@@ -16,6 +16,7 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Util.bytesToShortHexString;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.math.BigInteger;
@@ -57,7 +58,7 @@ public class Value {
 
     @Override
     public String toString() {
-        return "0x" + Util.bytesToHexString(getValue());
+        return "0x" + bytesToShortHexString(getValue());
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Post.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Post.java
@@ -60,7 +60,7 @@ public class Post extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + makeNameFragment() + token + ", " + predicate + ")";
+        return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + predicate + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -64,7 +64,7 @@ public class Pre extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + makeNameFragment() + token + ", " + predicate + ")";
+        return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + predicate + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -96,7 +96,7 @@ public class Sub extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + makeNameFragment() + token + ", " + address + ")";
+        return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + address + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Tie.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Tie.java
@@ -82,7 +82,7 @@ public class Tie extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + makeNameFragment() + token + ", " + dataExpression + ")";
+        return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + dataExpression + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -72,7 +72,7 @@ public class While extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + makeNameFragment() + token + ", " + predicate + ")";
+        return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + predicate + ")";
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/UtilHexTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilHexTest.java
@@ -19,25 +19,14 @@ package io.parsingdata.metal;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
-import static io.parsingdata.metal.Shorthand.con;
-import static io.parsingdata.metal.Util.inflate;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
-
-import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.expression.value.Value;
 
 @RunWith(Parameterized.class)
 public class UtilHexTest {
@@ -51,22 +40,19 @@ public class UtilHexTest {
     @Parameterized.Parameters(name = "{1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef}, "0123456789ABCDEF" },
-                { new byte[] { -1 }, "FF" },
-                { new byte[0], "" }
+            { new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef}, "0123456789ABCDEF" },
+            { new byte[] { -1 }, "FF" },
+            { new byte[0], "" },
+            { new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A }, "0102030405060708090A" },
+            { new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B }, "0102030405060708090A0B" },
+            { new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C }, "0102030405060708090A..." },
+            { new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D }, "0102030405060708090A..." }
         });
     }
 
     @Test
     public void byteToHex() {
-        assertThat(Util.bytesToHexString(input), is(equalTo(output)));
-    }
-
-    @Test
-    public void inflateDataFormatError() {
-        final ImmutableList<Optional<Value>> result = inflate(con(0xffffffff)).eval(stream().order, enc());
-        assertEquals(1, result.size);
-        assertFalse(result.head.isPresent());
+        assertThat(Util.bytesToShortHexString(input), is(equalTo(output)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Util.inflate;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.expression.value.Value;
+
+public class UtilInflateTest {
+
+    @Test
+    public void inflateDataFormatError() {
+        final ImmutableList<Optional<Value>> result = inflate(con(0xffffffff)).eval(stream().order, enc());
+        assertEquals(1, result.size);
+        assertFalse(result.head.isPresent());
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -34,7 +34,6 @@ import static io.parsingdata.metal.data.selection.ByTypeTest.EMPTY_SOURCE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static junit.framework.TestCase.assertNull;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -208,17 +207,17 @@ public class ParseGraphTest {
 
     @Test
     public void testSimpleToString() {
-        assertThat(pg.toString(), is("graph(h(0x68), graph(g(0x67), graph(graph(f(0x66), graph(graph(e(0x65), graph(d(0x64), graph(terminator:Def), false), false), graph(c(0x63), graph(terminator:Def), false), false), false), graph(b(0x62), graph(a(0x61), graph(EMPTY), false), false), false), false), false)"));
+        assertThat(pg.toString(), is("pg(pval(h:0x68),pg(pval(g:0x67),pg(pg(pval(f:0x66),pg(pg(pval(e:0x65),pg(pval(d:0x64),pg(terminator:Def),false),false),pg(pval(c:0x63),pg(terminator:Def),false),false),false),pg(pval(b:0x62),pg(pval(a:0x61),pg(EMPTY),false),false),false),false),false)"));
     }
 
     @Test
     public void testCycleToString() {
-        assertThat(pgc.toString(), is("graph(graph(ref(@0), graph(b(0x62), graph(terminator:Def), false), false), graph(a(0x61), graph(EMPTY), false), false)"));
+        assertThat(pgc.toString(), is("pg(pg(pref(@0),pg(pval(b:0x62),pg(terminator:Def),false),false),pg(pval(a:0x61),pg(EMPTY),false),false)"));
     }
 
     @Test
     public void testLongToString() {
-        assertThat(pgl.toString(), is("graph(graph(f(0x66), graph(terminator:Def), false), graph(e(0x65), graph(graph(graph(d(0x64), graph(terminator:Def), false), graph(c(0x63), graph(graph(terminator:Def), graph(graph(b(0x62), graph(terminator:Def), false), graph(terminator:Def), false), false), false), false), graph(a(0x61), graph(EMPTY), false), false), false), false)"));
+        assertThat(pgl.toString(), is("pg(pg(pval(f:0x66),pg(terminator:Def),false),pg(pval(e:0x65),pg(pg(pg(pval(d:0x64),pg(terminator:Def),false),pg(pval(c:0x63),pg(pg(terminator:Def),pg(pg(pval(b:0x62),pg(terminator:Def),false),pg(terminator:Def),false),false),false),false),pg(pval(a:0x61),pg(EMPTY),false),false),false),false)"));
     }
 
     @Rule

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -56,7 +56,7 @@ public class ParseReferenceTest {
 
     @Test
     public void toStringTest() {
-        assertThat(reference.toString(), is("ref(@0)"));
+        assertThat(reference.toString(), is("pref(@0)"));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -66,7 +66,7 @@ public class ParseValueTest {
 
     @Test
     public void toStringTest() {
-        assertThat(value.toString(), is("value(0x01)"));
+        assertThat(value.toString(), is("pval(value:0x01)"));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/PostTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PostTest.java
@@ -72,7 +72,7 @@ public class PostTest {
     @Test
     public void testToString() {
         final Token simpleWhile = post("pname", def("value", con(1)), eq(con(1)));
-        final String simpleWhileString = "Post(pname,Def(value,Const(0x01)), Eq(Const(0x01)))";
+        final String simpleWhileString = "Post(pname,Def(value,Const(0x01)),Eq(Const(0x01)))";
         assertThat(simpleWhile.toString(), is(equalTo(simpleWhileString)));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/PreTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PreTest.java
@@ -68,7 +68,7 @@ public class PreTest {
     @Test
     public void testToString() {
         final Token simpleWhile = pre("pname", def("value", con(1)), eq(con(1)));
-        final String simpleWhileString = "Pre(pname,Def(value,Const(0x01)), Eq(Const(0x01)))";
+        final String simpleWhileString = "Pre(pname,Def(value,Const(0x01)),Eq(Const(0x01)))";
         assertThat(simpleWhile.toString(), is(equalTo(simpleWhileString)));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -77,7 +77,7 @@ public class WhileTest {
     @Test
     public void testToString() {
         final Token simpleWhile = whl(def("value", con(1)), eq(con(1)));
-        final String simpleWhileString = "While(Def(value,Const(0x01)), Eq(Const(0x01)))";
+        final String simpleWhileString = "While(Def(value,Const(0x01)),Eq(Const(0x01)))";
         assertThat(simpleWhile.toString(), is(equalTo(simpleWhileString)));
     }
 


### PR DESCRIPTION
Resolves #132.

- Added missing `toString()` implementations for `Fold` (and by extension `FoldLeft` and `FoldRight`) and `Reverse`.
- Added class name to `toString()` implementations where missing (`ByteStreamSource`, `ConstantSource`, `DataExpressionSource`, `Environment` and `Slice`), with some small exceptions:
  - `ImmutableList` is such as basic data structure that it doesn't mention its class name at all.
  - `ParseGraph`, `ParseReference` and `ParseValue` are so common that they are abbreviated to `pg`, `pref` and `pval` respectively (actually `ParseReference` is quite rare, but it's nice to have a uniform naming scheme).
- Removed spaces from `toString()` implementations to make the strings more compact.
- Unified printing of hex strings:
  - Prefix everywhere with "0x".
  - Maximum amount of printed bytes in a hex string is 11. When an array is bigger, only the first 10 bytes are printed followed by an ellipsis.