### PR TITLE
Converted offset to BigInteger

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
@@ -17,11 +17,12 @@
 package io.parsingdata.metal.data;
 
 import java.io.IOException;
+import java.math.BigInteger;
 
 public interface ByteStream {
 
-    byte[] read(long offset, int length) throws IOException;
+    byte[] read(BigInteger offset, int length) throws IOException;
 
-    boolean isAvailable(long offset, int length);
+    boolean isAvailable(BigInteger offset, int length);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -34,7 +34,7 @@ public class ByteStreamSource extends Source {
     }
 
     @Override
-    protected byte[] getData(final long offset, final BigInteger length) {
+    protected byte[] getData(final BigInteger offset, final BigInteger length) {
         if (!isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         try {
             return input.read(offset, length.intValue());
@@ -44,7 +44,7 @@ public class ByteStreamSource extends Source {
     }
 
     @Override
-    protected boolean isAvailable(final long offset, final BigInteger length) {
+    protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
         return input.isAvailable(offset, length.intValue());
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -37,7 +37,7 @@ public class ByteStreamSource extends Source {
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
         if (!isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         try {
-            return input.read(offset, length.intValue());
+            return input.read(offset, length.intValueExact());
         } catch (final IOException exception) {
             throw new UncheckedIOException(exception);
         }
@@ -45,7 +45,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
-        return input.isAvailable(offset, length.intValue());
+        return input.isAvailable(offset, length.intValueExact());
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -34,16 +34,16 @@ public class ConstantSource extends Source {
     }
 
     @Override
-    protected byte[] getData(final long offset, final BigInteger length) {
+    protected byte[] getData(final BigInteger offset, final BigInteger length) {
         if (!isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         final byte[] outputData = new byte[length.intValue()];
-        System.arraycopy(data, (int)offset, outputData, 0, outputData.length);
+        System.arraycopy(data, offset.intValue(), outputData, 0, outputData.length);
         return outputData;
     }
 
     @Override
-    protected boolean isAvailable(final long offset, final BigInteger length) {
-        return length.intValue() + offset <= data.length;
+    protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
+        return length.add(offset).compareTo(BigInteger.valueOf(data.length)) <= 0;
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -36,8 +36,8 @@ public class ConstantSource extends Source {
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
         if (!isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
-        final byte[] outputData = new byte[length.intValue()];
-        System.arraycopy(data, offset.intValue(), outputData, 0, outputData.length);
+        final byte[] outputData = new byte[length.intValueExact()];
+        System.arraycopy(data, offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -48,8 +48,8 @@ public class DataExpressionSource extends Source {
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
         final Value inputValue = getValue();
         if (length.add(offset).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
-        final byte[] outputData = new byte[length.intValue()];
-        System.arraycopy(inputValue.getValue(), offset.intValue(), outputData, 0, outputData.length);
+        final byte[] outputData = new byte[length.intValueExact()];
+        System.arraycopy(inputValue.getValue(), offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -45,17 +45,17 @@ public class DataExpressionSource extends Source {
     }
 
     @Override
-    protected byte[] getData(final long offset, final BigInteger length) {
+    protected byte[] getData(final BigInteger offset, final BigInteger length) {
         final Value inputValue = getValue();
-        if (length.add(BigInteger.valueOf(offset)).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (length.add(offset).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         final byte[] outputData = new byte[length.intValue()];
-        System.arraycopy(inputValue.getValue(), (int)offset, outputData, 0, outputData.length);
+        System.arraycopy(inputValue.getValue(), offset.intValue(), outputData, 0, outputData.length);
         return outputData;
     }
 
     @Override
-    protected boolean isAvailable(final long offset, final BigInteger length) {
-        return offset + length.intValue() <= getValue().slice.length.intValue();
+    protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
+        return offset.add(length).compareTo(getValue().slice.length) <= 0;
     }
 
     private Value getValue() {

--- a/core/src/main/java/io/parsingdata/metal/data/Environment.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Environment.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ZERO;
+
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
@@ -30,31 +32,31 @@ import io.parsingdata.metal.token.Token;
 public class Environment {
 
     public final ParseGraph order;
-    public final long offset;
+    public final BigInteger offset;
     public final Source source;
     public final Callbacks callbacks;
 
-    public Environment(final ParseGraph order, final Source source, final long offset, final Callbacks callbacks) {
+    public Environment(final ParseGraph order, final Source source, final BigInteger offset, final Callbacks callbacks) {
         this.order = checkNotNull(order, "order");
         this.source = checkNotNull(source, "source");
-        this.offset = offset;
+        this.offset = checkNotNull(offset, "offset");
         this.callbacks = checkNotNull(callbacks, "callbacks");
     }
 
-    public Environment(final ByteStream input, final long offset, final Callbacks callbacks) {
+    public Environment(final ByteStream input, final BigInteger offset, final Callbacks callbacks) {
         this(ParseGraph.EMPTY, new ByteStreamSource(input), offset, callbacks);
     }
 
-    public Environment(final ByteStream input, final long offset) {
+    public Environment(final ByteStream input, final BigInteger offset) {
         this(input, offset, Callbacks.NONE);
     }
 
     public Environment(final ByteStream input, final Callbacks callbacks) {
-        this(input, 0L, callbacks);
+        this(input, ZERO, callbacks);
     }
 
     public Environment(final ByteStream input) {
-        this(input, 0L);
+        this(input, ZERO);
     }
 
     public Environment addBranch(final Token token) {
@@ -73,12 +75,12 @@ public class Environment {
         return new Environment(order.add(parseReference), source, offset, callbacks);
     }
 
-    public Environment seek(final long newOffset) {
+    public Environment seek(final BigInteger newOffset) {
         return new Environment(order, source, newOffset, callbacks);
     }
 
     public Environment source(final ValueExpression dataExpression, final int index, final Environment environment, final Encoding encoding) {
-        return new Environment(order, new DataExpressionSource(dataExpression, index, environment.order, encoding), 0L, callbacks);
+        return new Environment(order, new DataExpressionSource(dataExpression, index, environment.order, encoding), ZERO, callbacks);
     }
 
     public Optional<Slice> slice(final BigInteger length) {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
@@ -20,6 +20,7 @@ import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.Selection.findItemAtOffset;
 import static io.parsingdata.metal.data.Selection.getAllRoots;
 
+import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -28,12 +29,12 @@ import io.parsingdata.metal.token.Token;
 
 public class ParseReference implements ParseItem {
 
-    public final long location;
+    public final BigInteger location;
     public final Source source;
     public final Token definition;
 
-    public ParseReference(final long location, final Source source, final Token definition) {
-        this.location = location;
+    public ParseReference(final BigInteger location, final Source source, final Token definition) {
+        this.location = checkNotNull(location, "location");
         this.source = checkNotNull(source, "source");
         this.definition = checkNotNull(definition, "definition");
     }

--- a/core/src/main/java/io/parsingdata/metal/data/Selection.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Selection.java
@@ -20,6 +20,7 @@ import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNull;
 
+import java.math.BigInteger;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -32,11 +33,11 @@ public final class Selection {
 
     private Selection() {}
 
-    public static boolean hasRootAtOffset(final ParseGraph graph, final Token definition, final long offset, final Source source) {
+    public static boolean hasRootAtOffset(final ParseGraph graph, final Token definition, final BigInteger offset, final Source source) {
         return findItemAtOffset(getAllRoots(graph, definition), offset, source).computeResult().isPresent();
     }
 
-    public static Trampoline<Optional<ParseItem>> findItemAtOffset(final ImmutableList<ParseItem> items, final long offset, final Source source) {
+    public static Trampoline<Optional<ParseItem>> findItemAtOffset(final ImmutableList<ParseItem> items, final BigInteger offset, final Source source) {
         checkNotNull(items, "items");
         checkNotNull(source, "source");
         if (items.isEmpty()) { return complete(Optional::empty); }
@@ -49,8 +50,8 @@ public final class Selection {
         return intermediate(() -> findItemAtOffset(items.tail, offset, source));
     }
 
-    private static boolean matchesLocation(final ParseValue value, final long offset, final Source source) {
-        return value.slice.offset == offset && value.slice.source.equals(source);
+    private static boolean matchesLocation(final ParseValue value, final BigInteger offset, final Source source) {
+        return value.slice.offset.compareTo(offset) == 0 && value.slice.source.equals(source);
     }
 
     private static Trampoline<ParseValue> getLowestOffsetValue(final ImmutableList<ParseGraph> graphList, final ParseValue lowest) {
@@ -68,7 +69,7 @@ public final class Selection {
     }
 
     private static ParseValue getLowest(final ParseValue lowest, final ParseValue value) {
-        return lowest == null || lowest.slice.offset > value.slice.offset ? value : lowest;
+        return lowest == null || lowest.slice.offset.compareTo(value.slice.offset) > 0 ? value : lowest;
     }
 
     private static ImmutableList<ParseGraph> addIfGraph(final ImmutableList<ParseGraph> graphList, final ParseItem head) {

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -44,7 +44,7 @@ public class Slice {
     }
 
     public static Slice createFromBytes(final byte[] data) {
-        return new Slice(new ConstantSource(checkNotNull(data, "data")), BigInteger.ZERO, BigInteger.valueOf(data.length));
+        return new Slice(new ConstantSource(checkNotNull(data, "data")), ZERO, BigInteger.valueOf(data.length));
     }
 
     public byte[] getData() {
@@ -52,7 +52,7 @@ public class Slice {
     }
 
     public byte[] getData(final BigInteger limit) {
-        if (limit.compareTo(BigInteger.ZERO) < 0) { throw new IllegalArgumentException("Argument limit may not be negative."); }
+        if (limit.compareTo(ZERO) < 0) { throw new IllegalArgumentException("Argument limit may not be negative."); }
         final BigInteger calculatedLength = limit.compareTo(length) > 0 ? length : limit;
         return source.getData(offset, calculatedLength);
     }

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -29,22 +29,22 @@ import io.parsingdata.metal.Util;
 public class Slice {
 
     public final Source source;
-    public final long offset;
+    public final BigInteger offset;
     public final BigInteger length;
 
-    private Slice(final Source source, final long offset, final BigInteger length) {
+    private Slice(final Source source, final BigInteger offset, final BigInteger length) {
         this.source = checkNotNull(source, "source");
-        this.offset = offset;
+        this.offset = checkNotNull(offset, "offset");
         this.length = checkNotNull(length, "length");
     }
 
-    public static Optional<Slice> createFromSource(final Source source, final long offset, final BigInteger length) {
+    public static Optional<Slice> createFromSource(final Source source, final BigInteger offset, final BigInteger length) {
         if (checkNotNull(length, "length").compareTo(ZERO) < 0 || !checkNotNull(source, "source").isAvailable(offset, length)) { return Optional.empty(); }
         return Optional.of(new Slice(source, offset, length));
     }
 
     public static Slice createFromBytes(final byte[] data) {
-        return new Slice(new ConstantSource(checkNotNull(data, "data")), 0, BigInteger.valueOf(data.length));
+        return new Slice(new ConstantSource(checkNotNull(data, "data")), BigInteger.ZERO, BigInteger.valueOf(data.length));
     }
 
     public byte[] getData() {
@@ -59,7 +59,7 @@ public class Slice {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + source + "@" + offset + ":" + length.add(BigInteger.valueOf(offset)) + ")";
+        return getClass().getSimpleName() + "(" + source + "@" + offset + ":" + length.add(offset) + ")";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/Source.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Source.java
@@ -20,8 +20,8 @@ import java.math.BigInteger;
 
 public abstract class Source {
 
-    protected abstract byte[] getData(long offset, BigInteger length);
+    protected abstract byte[] getData(BigInteger offset, BigInteger length);
 
-    protected abstract boolean isAvailable(long offset, BigInteger length);
+    protected abstract boolean isAvailable(BigInteger offset, BigInteger length);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -56,7 +56,7 @@ public class Expand implements ValueExpression {
         if (base.isEmpty()) { return base; }
         final ImmutableList<Optional<Value>> count = this.count.eval(graph, encoding);
         if (count.size != 1 || !count.head.isPresent()) { throw new IllegalArgumentException("Count must evaluate to a single non-empty value."); }
-        return expand(base, count.head.get().asNumeric().intValue(), new ImmutableList<>()).computeResult();
+        return expand(base, count.head.get().asNumeric().intValueExact(), new ImmutableList<>()).computeResult();
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> expand(final ImmutableList<Optional<Value>> base, final int count, final ImmutableList<Optional<Value>> aggregate) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.value.arithmetic;
 
+import static java.math.BigInteger.ZERO;
+
 import java.math.BigInteger;
 import java.util.Optional;
 
@@ -40,7 +42,7 @@ public class Div extends BinaryValueExpression {
 
     @Override
     public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
-        if (right.asNumeric().equals(BigInteger.ZERO)) {
+        if (right.asNumeric().equals(ZERO)) {
             return Optional.empty();
         }
         return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().divide(right.asNumeric()), encoding));

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.value.arithmetic;
 
+import static java.math.BigInteger.ZERO;
+
 import java.math.BigInteger;
 import java.util.Optional;
 
@@ -40,7 +42,7 @@ public class Mod extends BinaryValueExpression {
 
     @Override
     public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
-        if (right.asNumeric().compareTo(BigInteger.ZERO) <= 0) {
+        if (right.asNumeric().compareTo(ZERO) <= 0) {
             return Optional.empty();
         }
         return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().mod(right.asNumeric()), encoding));

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
@@ -39,7 +39,7 @@ public class ShiftLeft extends BinaryValueExpression {
     @Override
     public Optional<Value> eval(final Value operand, final Value positions, final ParseGraph graph, final Encoding encoding) {
         final BitSet leftBits = operand.asBitSet();
-        final int shiftLeft = positions.asNumeric().intValue();
+        final int shiftLeft = positions.asNumeric().intValueExact();
         final int bitCount = leftBits.length() + shiftLeft;
         final BitSet out = new BitSet(bitCount);
         for (int i = leftBits.nextSetBit(0); i >= 0; i = leftBits.nextSetBit(i+1)) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
@@ -39,7 +39,7 @@ public class ShiftRight extends BinaryValueExpression {
     @Override
     public Optional<Value> eval(final Value operand, final Value positions, final ParseGraph graph, final Encoding encoding) {
         final BitSet leftBits = operand.asBitSet();
-        final int shift = positions.asNumeric().intValue();
+        final int shift = positions.asNumeric().intValueExact();
         return Optional.of(ConstantFactory.createFromBitSet(leftBits.get(shift, Math.max(shift, leftBits.length())), operand.getValue().length, encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -72,7 +72,7 @@ public class Ref<T> implements ValueExpression {
         if (limit == null) { return evalImpl(graph, NO_LIMIT); }
         ImmutableList<Optional<Value>> evaluatedLimit = limit.eval(graph, encoding);
         if (evaluatedLimit.size != 1 || !evaluatedLimit.head.isPresent()) { throw new IllegalArgumentException("Limit must evaluate to a single non-empty value."); }
-        return evalImpl(graph, evaluatedLimit.head.get().asNumeric().intValue());
+        return evalImpl(graph, evaluatedLimit.head.get().asNumeric().intValueExact());
     }
 
     private ImmutableList<Optional<Value>> evalImpl(final ParseGraph graph, final int limit) {

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -66,7 +66,7 @@ public class Def extends Token {
         }
         return environment
             .slice(dataSize)
-            .map(slice -> success(environment.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(BigInteger.valueOf(environment.offset)).longValue())))
+            .map(slice -> success(environment.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(environment.offset))))
             .orElse(failure());
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -62,7 +62,7 @@ public class RepN extends Token {
         if (counts.size != 1 || !counts.head.isPresent()) {
             return failure();
         }
-        return iterate(scope, environment.addBranch(this), encoding, counts.head.get().asNumeric().longValue()).computeResult();
+        return iterate(scope, environment.addBranch(this), encoding, counts.head.get().asNumeric().longValueExact()).computeResult();
     }
 
     private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding, final long count) {

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -23,6 +23,7 @@ import static io.parsingdata.metal.Util.failure;
 import static io.parsingdata.metal.Util.success;
 import static io.parsingdata.metal.data.Selection.hasRootAtOffset;
 
+import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -77,12 +78,12 @@ public class Sub extends Token {
         if (!addresses.head.isPresent()) {
             return complete(Util::failure);
         }
-        return parse(scope, addresses.head.get().asNumeric().longValue(), environment, encoding)
+        return parse(scope, addresses.head.get().asNumeric(), environment, encoding)
             .map(nextEnvironment -> intermediate(() -> iterate(scope, addresses.tail, nextEnvironment, encoding)))
             .orElseGet(() -> complete(Util::failure));
     }
 
-    private Optional<Environment> parse(final String scope, final long offset, final Environment environment, final Encoding encoding) {
+    private Optional<Environment> parse(final String scope, final BigInteger offset, final Environment environment, final Encoding encoding) {
         if (hasRootAtOffset(environment.order, token.getCanonical(environment), offset, environment.source)) {
             return success(environment.add(new ParseReference(offset, environment.source, token.getCanonical(environment))));
         }

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -107,7 +107,7 @@ public class Until extends Token {
 
     private Trampoline<Optional<Environment>> parseSlice(String scope, Environment environment, BigInteger currentSize, BigInteger stepSize, BigInteger maxSize, Encoding encoding, Slice slice) {
         return terminator
-            .parse(scope, currentSize.compareTo(ZERO) == 0 ? environment : environment.add(new ParseValue(name, this, slice, encoding)).seek(environment.offset + currentSize.longValue()), encoding)
+            .parse(scope, currentSize.compareTo(ZERO) == 0 ? environment : environment.add(new ParseValue(name, this, slice, encoding)).seek(environment.offset.add(currentSize)), encoding)
             .map(nextEnvironment -> complete(() -> success(nextEnvironment)))
             .orElseGet(() -> intermediate(() -> iterate(scope, environment, currentSize.add(stepSize), stepSize, maxSize, encoding)));
     }

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -116,12 +116,12 @@ import io.parsingdata.metal.util.InMemoryByteStream;
 public class AutoEqualityTest {
 
     public static final ByteStream DUMMY_STREAM = new ByteStream() {
-        @Override public byte[] read(long offset, int length) throws IOException { return new byte[0]; }
-        @Override public boolean isAvailable(long offset, int length) { return false; }
+        @Override public byte[] read(BigInteger offset, int length) throws IOException { return new byte[0]; }
+        @Override public boolean isAvailable(BigInteger offset, int length) { return false; }
     };
 
     private static final ParseValue PARSEVALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-    private static final ParseGraph GRAPH_WITH_REFERENCE = ParseGraph.EMPTY.add(new ParseReference(0, new ConstantSource(new byte[]{1, 2}), any("a")));
+    private static final ParseGraph GRAPH_WITH_REFERENCE = ParseGraph.EMPTY.add(new ParseReference(BigInteger.ZERO, new ConstantSource(new byte[]{1, 2}), any("a")));
     private static final ParseGraph BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).order;
     private static final ParseGraph CLOSED_BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
 
@@ -133,7 +133,7 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()));
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
-    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, ParseGraph.EMPTY.add(PARSEVALUE).add(PARSEVALUE), enc()), 0, BigInteger.valueOf(2)).get());
+    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, ParseGraph.EMPTY.add(PARSEVALUE).add(PARSEVALUE), enc()), BigInteger.ZERO, BigInteger.valueOf(2)).get());
     private static final List<Supplier<Object>> BYTE_ARRAYS = Arrays.asList(() -> new byte[] { 0 }, () -> new byte[] { 1, 2 }, () -> new byte[] {});
     private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, ParseGraph.EMPTY.add(PARSEVALUE), signed()));
     private static final List<Supplier<Object>> LONGS = Arrays.asList(() -> 0L, () -> 1L, () -> 31L, () -> 100000L);

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal;
 
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -121,7 +124,7 @@ public class AutoEqualityTest {
     };
 
     private static final ParseValue PARSEVALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-    private static final ParseGraph GRAPH_WITH_REFERENCE = ParseGraph.EMPTY.add(new ParseReference(BigInteger.ZERO, new ConstantSource(new byte[]{1, 2}), any("a")));
+    private static final ParseGraph GRAPH_WITH_REFERENCE = ParseGraph.EMPTY.add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a")));
     private static final ParseGraph BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).order;
     private static final ParseGraph CLOSED_BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
 
@@ -133,7 +136,7 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()));
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
-    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, ParseGraph.EMPTY.add(PARSEVALUE).add(PARSEVALUE), enc()), BigInteger.ZERO, BigInteger.valueOf(2)).get());
+    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, ParseGraph.EMPTY.add(PARSEVALUE).add(PARSEVALUE), enc()), ZERO, BigInteger.valueOf(2)).get());
     private static final List<Supplier<Object>> BYTE_ARRAYS = Arrays.asList(() -> new byte[] { 0 }, () -> new byte[] { 1, 2 }, () -> new byte[] {});
     private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, ParseGraph.EMPTY.add(PARSEVALUE), signed()));
     private static final List<Supplier<Object>> LONGS = Arrays.asList(() -> 0L, () -> 1L, () -> 31L, () -> 100000L);
@@ -141,7 +144,7 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> PARSEGRAPHS = Arrays.asList(() -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE);
     private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> ParseGraph.EMPTY.add(PARSEVALUE), () -> ParseGraph.EMPTY.add(PARSEVALUE).add(PARSEVALUE), () -> BRANCHED_GRAPH);
     private static final List<Supplier<Object>> BYTESTREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
-    private static final List<Supplier<Object>> BIGINTEGERS = Arrays.asList(() -> BigInteger.ONE, () -> BigInteger.valueOf(3));
+    private static final List<Supplier<Object>> BIGINTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
     private static final Map<Class, List<Supplier<Object>>> mapping = new HashMap<Class, List<Supplier<Object>>>() {{
         put(String.class, STRINGS);
         put(Encoding.class, ENCODINGS);

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -70,7 +70,7 @@ public class ByteLengthTest {
 
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
-        assertEquals(5, getValue(graph, "length").asNumeric().byteValue());
+        assertEquals(5, getValue(graph, "length").asNumeric().byteValueExact());
         assertEquals("Hello", getValue(graph, "text1").asString());
         assertEquals("Metal", getValue(graph, "text2").asString());
     }

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -80,7 +80,7 @@ public class CurrentOffsetTest {
 
         final Optional<Environment> result = offsetValidation.parse(environment, new Encoding(Sign.UNSIGNED));
         assertTrue(result.isPresent());
-        assertEquals(256, result.get().offset);
+        assertEquals(256, result.get().offset.intValue());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -53,7 +53,7 @@ public class CurrentOffsetTest {
 
         assertNotNull(offset);
         assertEquals(1, offset.size);
-        assertEquals(size, offset.head.get().asNumeric().longValue());
+        assertEquals(size, offset.head.get().asNumeric().longValueExact());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class CurrentOffsetTest {
 
         final Optional<Environment> result = offsetValidation.parse(environment, new Encoding(Sign.UNSIGNED));
         assertTrue(result.isPresent());
-        assertEquals(256, result.get().offset.intValue());
+        assertEquals(256, result.get().offset.intValueExact());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal;
 
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -202,8 +205,8 @@ public class EqualityTest {
         assertFalse(object.equals("name"));
         assertEquals(object, Slice.createFromBytes(new byte[] { 0, 1, 2, 3 }));
         assertNotEquals(object, Slice.createFromBytes(new byte[] { 0, 1, 2, 4 }));
-        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ONE, BigInteger.valueOf(2)).get());
-        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(2)).get());
+        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), ONE, BigInteger.valueOf(2)).get());
+        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), ZERO, BigInteger.valueOf(2)).get());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -202,8 +202,8 @@ public class EqualityTest {
         assertFalse(object.equals("name"));
         assertEquals(object, Slice.createFromBytes(new byte[] { 0, 1, 2, 3 }));
         assertNotEquals(object, Slice.createFromBytes(new byte[] { 0, 1, 2, 4 }));
-        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), 1, BigInteger.valueOf(2)).get());
-        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), 0, BigInteger.valueOf(2)).get());
+        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ONE, BigInteger.valueOf(2)).get());
+        assertNotEquals(object, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(2)).get());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -207,7 +207,7 @@ public class ShorthandsTest {
         assertEquals(3, result.size);
         for (int i = 0; i < 3; i++) {
             assertTrue(result.head.isPresent());
-            assertEquals((i * 42) + 40, result.head.get().asNumeric().intValue());
+            assertEquals((i * 42) + 40, result.head.get().asNumeric().intValueExact());
             result = result.tail;
         }
     }
@@ -218,7 +218,7 @@ public class ShorthandsTest {
         assertEquals(3, result.size);
         for (int i = 0; i < 3; i++) {
             assertTrue(result.head.isPresent());
-            assertEquals(((3 - i) * 42) - 42, result.head.get().asNumeric().intValue());
+            assertEquals(((3 - i) * 42) - 42, result.head.get().asNumeric().intValueExact());
             result = result.tail;
         }
     }

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -165,7 +165,7 @@ public class ShorthandsTest {
         ImmutableList<Optional<Value>> values = ref(name).eval(env.order, enc());
         assertFalse(values.isEmpty());
         assertEquals(1, values.size);
-        assertEquals(value, values.head.get().asNumeric().intValue());
+        assertEquals(value, values.head.get().asNumeric().intValueExact());
 
         while (!values.isEmpty()) {
             final Value current = values.head.get();

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -61,7 +61,7 @@ public class SubStructTableTest {
                                      */
         final Optional<Environment> result = table.parse(environment, enc());
         assertTrue(result.isPresent());
-        assertEquals(4, result.get().offset);
+        assertEquals(4, result.get().offset.intValue());
         final ParseGraph graph = result.get().order;
         checkStruct(graph.head.asGraph().head.asGraph().head.asGraph(), 6);
         checkStruct(graph.head.asGraph().head.asGraph().tail.head.asGraph(), 4);
@@ -81,7 +81,7 @@ public class SubStructTableTest {
                                      */
         final Optional<Environment> result = table.parse(environment, enc());
         assertTrue(result.isPresent());
-        assertEquals(5, result.get().offset);
+        assertEquals(5, result.get().offset.intValue());
         final ParseGraph graph = result.get().order;
         checkStruct(graph.head.asGraph().head.asGraph().head.asGraph(), 7);
         assertTrue(graph.head.asGraph().head.asGraph().tail.head.isReference());
@@ -94,7 +94,7 @@ public class SubStructTableTest {
         assertTrue(graph.head.isGraph());
         assertEquals(84, graph.head.asGraph().head.asValue().asNumeric().intValue());
         assertEquals(42, graph.tail.head.asGraph().head.asValue().asNumeric().intValue());
-        assertEquals(offsetHeader, graph.tail.head.asGraph().head.asValue().slice.offset);
+        assertEquals(offsetHeader, graph.tail.head.asGraph().head.asValue().slice.offset.intValue());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -61,7 +61,7 @@ public class SubStructTableTest {
                                      */
         final Optional<Environment> result = table.parse(environment, enc());
         assertTrue(result.isPresent());
-        assertEquals(4, result.get().offset.intValue());
+        assertEquals(4, result.get().offset.intValueExact());
         final ParseGraph graph = result.get().order;
         checkStruct(graph.head.asGraph().head.asGraph().head.asGraph(), 6);
         checkStruct(graph.head.asGraph().head.asGraph().tail.head.asGraph(), 4);
@@ -81,7 +81,7 @@ public class SubStructTableTest {
                                      */
         final Optional<Environment> result = table.parse(environment, enc());
         assertTrue(result.isPresent());
-        assertEquals(5, result.get().offset.intValue());
+        assertEquals(5, result.get().offset.intValueExact());
         final ParseGraph graph = result.get().order;
         checkStruct(graph.head.asGraph().head.asGraph().head.asGraph(), 7);
         assertTrue(graph.head.asGraph().head.asGraph().tail.head.isReference());
@@ -92,9 +92,9 @@ public class SubStructTableTest {
 
     private void checkStruct(final ParseGraph graph, final int offsetHeader) {
         assertTrue(graph.head.isGraph());
-        assertEquals(84, graph.head.asGraph().head.asValue().asNumeric().intValue());
-        assertEquals(42, graph.tail.head.asGraph().head.asValue().asNumeric().intValue());
-        assertEquals(offsetHeader, graph.tail.head.asGraph().head.asValue().slice.offset.intValue());
+        assertEquals(84, graph.head.asGraph().head.asValue().asNumeric().intValueExact());
+        assertEquals(42, graph.tail.head.asGraph().head.asValue().asNumeric().intValueExact());
+        assertEquals(offsetHeader, graph.tail.head.asGraph().head.asValue().slice.offset.intValueExact());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -147,8 +147,8 @@ public class SubStructTest {
 
     private void checkValue(final ParseItem item, final int value, final int offset) {
         assertTrue(item.isValue());
-        assertEquals(value, item.asValue().asNumeric().intValue());
-        assertEquals(offset, item.asValue().slice.offset.intValue());
+        assertEquals(value, item.asValue().asNumeric().intValueExact());
+        assertEquals(offset, item.asValue().slice.offset.intValueExact());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -37,6 +37,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static junit.framework.TestCase.assertFalse;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -97,7 +98,7 @@ public class SubStructTest {
     }
 
     private ParseGraph startCycle(final int offset) throws IOException {
-        final Environment environment = stream(0, 4, 1, 21, 0, 0, 1).seek(offset);
+        final Environment environment = stream(0, 4, 1, 21, 0, 0, 1).seek(BigInteger.valueOf(offset));
         final Optional<Environment> result = LINKED_LIST.parse(environment, enc());
         assertTrue(result.isPresent());
         assertEquals(1, getReferences(result.get().order).size);
@@ -147,7 +148,7 @@ public class SubStructTest {
     private void checkValue(final ParseItem item, final int value, final int offset) {
         assertTrue(item.isValue());
         assertEquals(value, item.asValue().asNumeric().intValue());
-        assertEquals(offset, item.asValue().slice.offset);
+        assertEquals(offset, item.asValue().slice.offset.intValue());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/TrampolineTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TrampolineTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal;
 
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertEquals;
 
 import static io.parsingdata.metal.Trampoline.complete;
@@ -52,7 +55,7 @@ public class TrampolineTest {
     @Test
     public void noStackOverflow() {
         // The 100000th Fibonacci number has 20899 digits
-        assertEquals(20899, fibonacci(BigInteger.ZERO, BigInteger.ONE, 100000).computeResult().toString().length());
+        assertEquals(20899, fibonacci(ZERO, ONE, 100000).computeResult().toString().length());
     }
 
     private Trampoline<BigInteger> fibonacci(final BigInteger l, final BigInteger r, final long count) {

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -110,8 +110,8 @@ public class TreeTest {
         final ParseItem head = header.tail.head.asGraph().head; // tail = Seq, head = Post, head = Def("head")
         assertTrue(head.isValue());
         assertTrue(head.asValue().matches("head"));
-        assertEquals(HEAD, head.asValue().asNumeric().intValue());
-        assertEquals(offset, head.asValue().slice.offset.intValue());
+        assertEquals(HEAD, head.asValue().asNumeric().intValueExact());
+        assertEquals(offset, head.asValue().slice.offset.intValueExact());
         final ParseItem nr = header.head; // head = Def("nr")
         assertTrue(nr.isValue());
         assertTrue(nr.asValue().matches("nr"));
@@ -129,7 +129,7 @@ public class TreeTest {
         } else { // Otherwise, it's a Seq with a pointer and a Sub
             assertTrue(subStruct.tail.head.isValue()); // Def("[left|right]")
             assertTrue(subStruct.tail.head.asValue().matches(name));
-            final int pointer = subStruct.tail.head.asValue().asNumeric().intValue();
+            final int pointer = subStruct.tail.head.asValue().asNumeric().intValueExact();
             assertTrue(subStruct.head.isGraph()); // Sub
             if (subStruct.head.asGraph().head.isReference()) { // If the Sub contains a Reference, it's a cycle
                 checkResolve(subStruct.head.asGraph().head.asReference(), root, pointer);
@@ -153,7 +153,7 @@ public class TreeTest {
 
     private boolean contains(final ImmutableList<ParseValue> nrs, final int i) {
         if (nrs.isEmpty()) { return false; }
-        if (nrs.head.asNumeric().intValue() == i) { return true; }
+        if (nrs.head.asNumeric().intValueExact() == i) { return true; }
         if (nrs.tail != null) { return contains(nrs.tail, i); }
         return false;
     }

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -111,7 +111,7 @@ public class TreeTest {
         assertTrue(head.isValue());
         assertTrue(head.asValue().matches("head"));
         assertEquals(HEAD, head.asValue().asNumeric().intValue());
-        assertEquals(offset, head.asValue().slice.offset);
+        assertEquals(offset, head.asValue().slice.offset.intValue());
         final ParseItem nr = header.head; // head = Def("nr")
         assertTrue(nr.isValue());
         assertTrue(nr.asValue().matches("nr"));

--- a/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
@@ -33,9 +33,9 @@ public class ByteStreamSourceTest {
     public void brokenByteStream() {
         thrown.expect(UncheckedIOException.class);
         Slice.createFromSource(new ByteStreamSource(new ByteStream() {
-            @Override public byte[] read(long offset, int length) throws IOException { throw new IOException("Always fails."); }
-            @Override public boolean isAvailable(long offset, int length) { return true; }
-        }), 0, BigInteger.TEN).get().getData();
+            @Override public byte[] read(BigInteger offset, int length) throws IOException { throw new IOException("Always fails."); }
+            @Override public boolean isAvailable(BigInteger offset, int length) { return true; }
+        }), BigInteger.ZERO, BigInteger.TEN).get().getData();
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.TEN;
+import static java.math.BigInteger.ZERO;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
@@ -35,7 +38,7 @@ public class ByteStreamSourceTest {
         Slice.createFromSource(new ByteStreamSource(new ByteStream() {
             @Override public byte[] read(BigInteger offset, int length) throws IOException { throw new IOException("Always fails."); }
             @Override public boolean isAvailable(BigInteger offset, int length) { return true; }
-        }), BigInteger.ZERO, BigInteger.TEN).get().getData();
+        }), ZERO, TEN).get().getData();
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -46,7 +49,7 @@ public class ConstantSliceTest {
         final byte[] input = { 1, 2, 3, 4 };
         final Slice slice = createFromBytes(input);
         thrown.expect(IllegalStateException.class);
-        slice.source.getData(BigInteger.valueOf(4), BigInteger.ONE);
+        slice.source.getData(BigInteger.valueOf(4), ONE);
     }
 
     @Test
@@ -62,7 +65,7 @@ public class ConstantSliceTest {
     public void checkSource() throws IOException {
         final byte[] input = { 1, 2, 3, 4 };
         final Slice slice = createFromBytes(input);
-        final byte[] output = slice.source.getData(BigInteger.ZERO, BigInteger.valueOf(4));
+        final byte[] output = slice.source.getData(ZERO, BigInteger.valueOf(4));
         assertEquals(input.length, output.length);
         assertTrue(Arrays.equals(input, output));
     }

--- a/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
@@ -46,7 +46,7 @@ public class ConstantSliceTest {
         final byte[] input = { 1, 2, 3, 4 };
         final Slice slice = createFromBytes(input);
         thrown.expect(IllegalStateException.class);
-        slice.source.getData(4, BigInteger.ONE);
+        slice.source.getData(BigInteger.valueOf(4), BigInteger.ONE);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ConstantSliceTest {
     public void checkSource() throws IOException {
         final byte[] input = { 1, 2, 3, 4 };
         final Slice slice = createFromBytes(input);
-        final byte[] output = slice.source.getData(0, BigInteger.valueOf(4));
+        final byte[] output = slice.source.getData(BigInteger.ZERO, BigInteger.valueOf(4));
         assertEquals(input.length, output.length);
         assertTrue(Arrays.equals(input, output));
     }

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -43,8 +43,8 @@ public class DataExpressionSourceTest {
     @Test
     public void createSliceFromParseValue() {
         final ParseValue value = setupValue();
-        assertTrue(value.slice.source.isAvailable(0, BigInteger.valueOf(4)));
-        assertFalse(value.slice.source.isAvailable(0, BigInteger.valueOf(5)));
+        assertTrue(value.slice.source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(4)));
+        assertFalse(value.slice.source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(5)));
     }
 
     @Test
@@ -53,14 +53,14 @@ public class DataExpressionSourceTest {
         thrown.expectMessage("ValueExpression dataExpression yields 1 result(s) (expected at least 2).");
         final Optional<Environment> result = setupResult();
         final DataExpressionSource source = new DataExpressionSource(ref("a"), 1, result.get().order, enc());
-        source.getData(0, BigInteger.valueOf(4));
+        source.getData(BigInteger.ZERO, BigInteger.valueOf(4));
     }
 
     @Test
     public void emptyValue() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("ValueExpression dataExpression yields empty Value at index 0.");
-        new DataExpressionSource(div(con(1), con(0)), 0, ParseGraph.EMPTY, enc()).isAvailable(0, BigInteger.ZERO);
+        new DataExpressionSource(div(con(1), con(0)), 0, ParseGraph.EMPTY, enc()).isAvailable(BigInteger.ZERO, BigInteger.ZERO);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -1,5 +1,7 @@
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -43,8 +45,8 @@ public class DataExpressionSourceTest {
     @Test
     public void createSliceFromParseValue() {
         final ParseValue value = setupValue();
-        assertTrue(value.slice.source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(4)));
-        assertFalse(value.slice.source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(5)));
+        assertTrue(value.slice.source.isAvailable(ZERO, BigInteger.valueOf(4)));
+        assertFalse(value.slice.source.isAvailable(ZERO, BigInteger.valueOf(5)));
     }
 
     @Test
@@ -53,14 +55,14 @@ public class DataExpressionSourceTest {
         thrown.expectMessage("ValueExpression dataExpression yields 1 result(s) (expected at least 2).");
         final Optional<Environment> result = setupResult();
         final DataExpressionSource source = new DataExpressionSource(ref("a"), 1, result.get().order, enc());
-        source.getData(BigInteger.ZERO, BigInteger.valueOf(4));
+        source.getData(ZERO, BigInteger.valueOf(4));
     }
 
     @Test
     public void emptyValue() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("ValueExpression dataExpression yields empty Value at index 0.");
-        new DataExpressionSource(div(con(1), con(0)), 0, ParseGraph.EMPTY, enc()).isAvailable(BigInteger.ZERO, BigInteger.ZERO);
+        new DataExpressionSource(div(con(1), con(0)), 0, ParseGraph.EMPTY, enc()).isAvailable(ZERO, ZERO);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ZERO;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -239,7 +241,7 @@ public class ParseGraphTest {
     @Test
     public void testCurrent() {
         assertFalse(EMPTY.current().isPresent());
-        assertFalse(EMPTY.add(new ParseReference(BigInteger.ZERO, EMPTY_SOURCE, NONE)).current().isPresent());
+        assertFalse(EMPTY.add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).current().isPresent());
         assertFalse(EMPTY.addBranch(NONE).current().isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -32,6 +32,7 @@ import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Optional;
 
 import org.junit.Rule;
@@ -238,7 +239,7 @@ public class ParseGraphTest {
     @Test
     public void testCurrent() {
         assertFalse(EMPTY.current().isPresent());
-        assertFalse(EMPTY.add(new ParseReference(0, EMPTY_SOURCE, NONE)).current().isPresent());
+        assertFalse(EMPTY.add(new ParseReference(BigInteger.ZERO, EMPTY_SOURCE, NONE)).current().isPresent());
         assertFalse(EMPTY.addBranch(NONE).current().isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -27,6 +27,8 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.data.selection.ByTypeTest.EMPTY_SOURCE;
 import static junit.framework.TestCase.assertFalse;
 
+import java.math.BigInteger;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,12 +47,12 @@ public class ParseReferenceTest {
     @Before
     public void setUp() {
         definition = sub(def("value", 1), con(0));
-        reference = new ParseReference(0L, EMPTY_SOURCE, definition);
+        reference = new ParseReference(BigInteger.ZERO, EMPTY_SOURCE, definition);
     }
 
     @Test
     public void state() {
-        assertThat(reference.location, is(0L));
+        assertThat(reference.location.longValue(), is(0L));
         assertThat(reference.getDefinition(), is(definition));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -54,7 +54,7 @@ public class ParseReferenceTest {
 
     @Test
     public void state() {
-        assertThat(reference.location.longValue(), is(0L));
+        assertThat(reference.location.longValueExact(), is(0L));
         assertThat(reference.getDefinition(), is(definition));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ZERO;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
@@ -47,7 +49,7 @@ public class ParseReferenceTest {
     @Before
     public void setUp() {
         definition = sub(def("value", 1), con(0));
-        reference = new ParseReference(BigInteger.ZERO, EMPTY_SOURCE, definition);
+        reference = new ParseReference(ZERO, EMPTY_SOURCE, definition);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -54,7 +54,7 @@ public class ParseValueTest {
     public void state() {
         assertThat(value.name, is("value"));
         assertThat(value.getDefinition(), is(definition));
-        assertThat(value.slice.offset.longValue(), is(0L));
+        assertThat(value.slice.offset.longValueExact(), is(0L));
         assertThat(value.getValue(), is(equalTo(new byte[] { 1 })));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -54,7 +54,7 @@ public class ParseValueTest {
     public void state() {
         assertThat(value.name, is("value"));
         assertThat(value.getDefinition(), is(definition));
-        assertThat(value.slice.offset, is(0L));
+        assertThat(value.slice.offset.longValue(), is(0L));
         assertThat(value.getValue(), is(equalTo(new byte[] { 1 })));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
@@ -37,16 +37,16 @@ import io.parsingdata.metal.encoding.Encoding;
 public class SelectionTest {
 
     private final Source source = new Source() {
-        @Override protected byte[] getData(long offset, BigInteger length) { return new byte[0]; }
-        @Override protected boolean isAvailable(long offset, BigInteger length) { return true; }
+        @Override protected byte[] getData(BigInteger offset, BigInteger length) { return new byte[0]; }
+        @Override protected boolean isAvailable(BigInteger offset, BigInteger length) { return true; }
     };
 
     @Test
     public void findItemAtOffsetTest() {
         assertEquals("the_one",
-            findItemAtOffset(ImmutableList.create(ParseGraph.EMPTY.add(new ParseValue("two", any("a"), Slice.createFromSource(source, 2, BigInteger.valueOf(2)).get(), new Encoding()))
-                                                                  .add(new ParseValue("zero", any("a"), Slice.createFromSource(source, 0, BigInteger.valueOf(2)).get(), new Encoding()))
-                                                                  .add(new ParseValue("the_one", any("a"), Slice.createFromSource(source, 1, BigInteger.valueOf(2)).get(), new Encoding()))), 0, source).computeResult().get().asGraph().head.asValue().name);
+            findItemAtOffset(ImmutableList.create(ParseGraph.EMPTY.add(new ParseValue("two", any("a"), Slice.createFromSource(source, BigInteger.valueOf(2), BigInteger.valueOf(2)).get(), new Encoding()))
+                                                                  .add(new ParseValue("zero", any("a"), Slice.createFromSource(source, BigInteger.ZERO, BigInteger.valueOf(2)).get(), new Encoding()))
+                                                                  .add(new ParseValue("the_one", any("a"), Slice.createFromSource(source, BigInteger.ONE, BigInteger.valueOf(2)).get(), new Encoding()))), BigInteger.ZERO, source).computeResult().get().asGraph().head.asValue().name);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertEquals;
 
 import static io.parsingdata.metal.Shorthand.rep;
@@ -45,8 +48,8 @@ public class SelectionTest {
     public void findItemAtOffsetTest() {
         assertEquals("the_one",
             findItemAtOffset(ImmutableList.create(ParseGraph.EMPTY.add(new ParseValue("two", any("a"), Slice.createFromSource(source, BigInteger.valueOf(2), BigInteger.valueOf(2)).get(), new Encoding()))
-                                                                  .add(new ParseValue("zero", any("a"), Slice.createFromSource(source, BigInteger.ZERO, BigInteger.valueOf(2)).get(), new Encoding()))
-                                                                  .add(new ParseValue("the_one", any("a"), Slice.createFromSource(source, BigInteger.ONE, BigInteger.valueOf(2)).get(), new Encoding()))), BigInteger.ZERO, source).computeResult().get().asGraph().head.asValue().name);
+                                                                  .add(new ParseValue("zero", any("a"), Slice.createFromSource(source, ZERO, BigInteger.valueOf(2)).get(), new Encoding()))
+                                                                  .add(new ParseValue("the_one", any("a"), Slice.createFromSource(source, ONE, BigInteger.valueOf(2)).get(), new Encoding()))), ZERO, source).computeResult().get().asGraph().head.asValue().name);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -79,14 +79,14 @@ public class SliceTest {
     public void retrieveDataFromSliceWithNegativeLimit() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument limit may not be negative.");
-        assertArrayEquals(new byte[] {}, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), 0, BigInteger.valueOf(4)).get().getData(BigInteger.valueOf(-1)));
+        assertArrayEquals(new byte[] {}, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.valueOf(-1)));
     }
 
 
     @Test
     public void retrievePartialDataFromSlice() {
-        assertArrayEquals(new byte[] { 0 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), 0, BigInteger.valueOf(4)).get().getData(BigInteger.ONE));
-        assertArrayEquals(new byte[] { 0, 1, 2, 3 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), 0, BigInteger.valueOf(4)).get().getData(BigInteger.TEN));
+        assertArrayEquals(new byte[] { 0 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.ONE));
+        assertArrayEquals(new byte[] { 0, 1, 2, 3 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.TEN));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class SliceTest {
         final ParseValue pv1 = new ParseValue("name", NONE, createFromBytes(new byte[]{1, 2}), enc());
         assertEquals("Slice(ConstantSource(0x0102)@0:2)", pv1.slice.toString());
         final Environment oneValueEnvironment = stream().add(pv1);
-        final Environment twoValueEnvironment = oneValueEnvironment.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueEnvironment.order, enc()), 0, BigInteger.valueOf(2)).get(), enc()));
+        final Environment twoValueEnvironment = oneValueEnvironment.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueEnvironment.order, enc()), BigInteger.ZERO, BigInteger.valueOf(2)).get(), enc()));
         final String dataExpressionSliceString = getValue(twoValueEnvironment.order, "name2").slice.toString();
         assertTrue(dataExpressionSliceString.startsWith("Slice(DataExpressionSource(NameRef(name)[0]("));
         assertTrue(dataExpressionSliceString.endsWith(")@0:2)"));

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -16,6 +16,10 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.TEN;
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -79,14 +83,14 @@ public class SliceTest {
     public void retrieveDataFromSliceWithNegativeLimit() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument limit may not be negative.");
-        assertArrayEquals(new byte[] {}, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.valueOf(-1)));
+        assertArrayEquals(new byte[] {}, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.valueOf(-1)));
     }
 
 
     @Test
     public void retrievePartialDataFromSlice() {
-        assertArrayEquals(new byte[] { 0 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.ONE));
-        assertArrayEquals(new byte[] { 0, 1, 2, 3 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), BigInteger.ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.TEN));
+        assertArrayEquals(new byte[] { 0 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), ZERO, BigInteger.valueOf(4)).get().getData(ONE));
+        assertArrayEquals(new byte[] { 0, 1, 2, 3 }, Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), ZERO, BigInteger.valueOf(4)).get().getData(TEN));
     }
 
     @Test
@@ -94,7 +98,7 @@ public class SliceTest {
         final ParseValue pv1 = new ParseValue("name", NONE, createFromBytes(new byte[]{1, 2}), enc());
         assertEquals("Slice(ConstantSource(0x0102)@0:2)", pv1.slice.toString());
         final Environment oneValueEnvironment = stream().add(pv1);
-        final Environment twoValueEnvironment = oneValueEnvironment.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueEnvironment.order, enc()), BigInteger.ZERO, BigInteger.valueOf(2)).get(), enc()));
+        final Environment twoValueEnvironment = oneValueEnvironment.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueEnvironment.order, enc()), ZERO, BigInteger.valueOf(2)).get(), enc()));
         final String dataExpressionSliceString = getValue(twoValueEnvironment.order, "name2").slice.toString();
         assertTrue(dataExpressionSliceString.startsWith("Slice(DataExpressionSource(NameRef(name)[0]("));
         assertTrue(dataExpressionSliceString.endsWith(")@0:2)"));

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -16,6 +16,9 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -57,20 +60,20 @@ public class SourceAndSliceTest {
 
     @Test
     public void validSource() {
-        assertTrue(source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(4)));
-        assertTrue(source.isAvailable(BigInteger.ONE, BigInteger.valueOf(3)));
-        assertTrue(source.isAvailable(BigInteger.valueOf(2), BigInteger.ONE));
-        assertTrue(source.isAvailable(BigInteger.valueOf(4), BigInteger.ZERO));
-        assertFalse(source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(5)));
-        assertFalse(source.isAvailable(BigInteger.valueOf(4), BigInteger.ONE));
-        assertFalse(source.isAvailable(BigInteger.valueOf(5), BigInteger.ONE));
-        assertFalse(source.isAvailable(BigInteger.valueOf(5), BigInteger.ZERO));
+        assertTrue(source.isAvailable(ZERO, BigInteger.valueOf(4)));
+        assertTrue(source.isAvailable(ONE, BigInteger.valueOf(3)));
+        assertTrue(source.isAvailable(BigInteger.valueOf(2), ONE));
+        assertTrue(source.isAvailable(BigInteger.valueOf(4), ZERO));
+        assertFalse(source.isAvailable(ZERO, BigInteger.valueOf(5)));
+        assertFalse(source.isAvailable(BigInteger.valueOf(4), ONE));
+        assertFalse(source.isAvailable(BigInteger.valueOf(5), ONE));
+        assertFalse(source.isAvailable(BigInteger.valueOf(5), ZERO));
     }
 
     @Test
     public void validSlice() {
-        checkSlice(BigInteger.ZERO, 4);
-        checkSlice(BigInteger.ONE, 3);
+        checkSlice(ZERO, 4);
+        checkSlice(ONE, 3);
         checkSlice(BigInteger.valueOf(2), 1);
         checkSlice(BigInteger.valueOf(4), 0);
     }
@@ -89,23 +92,23 @@ public class SourceAndSliceTest {
     @Test
     public void readBeyondEndOfSource() throws IOException {
         thrown.expect(IllegalStateException.class);
-        source.getData(BigInteger.ONE, BigInteger.valueOf(4));
+        source.getData(ONE, BigInteger.valueOf(4));
     }
 
     @Test
     public void readBeyondEndOfSlice() {
-        assertFalse(Slice.createFromSource(source, BigInteger.ONE, BigInteger.valueOf(4)).isPresent());
+        assertFalse(Slice.createFromSource(source, ONE, BigInteger.valueOf(4)).isPresent());
     }
 
     @Test
     public void startReadBeyondEndOfSource() throws IOException {
         thrown.expect(IllegalStateException.class);
-        source.getData(BigInteger.valueOf(5), BigInteger.ZERO);
+        source.getData(BigInteger.valueOf(5), ZERO);
     }
 
     @Test
     public void startReadBeyondEndOfSlice() {
-        assertFalse(Slice.createFromSource(source, BigInteger.valueOf(5), BigInteger.ZERO).isPresent());
+        assertFalse(Slice.createFromSource(source, BigInteger.valueOf(5), ZERO).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -79,7 +79,7 @@ public class SourceAndSliceTest {
     }
 
     private void checkSlice(final BigInteger offset, final int length) {
-        assertTrue(compareDataSlices(Slice.createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset.intValue()));
+        assertTrue(compareDataSlices(Slice.createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset.intValueExact()));
     }
 
     private boolean compareDataSlices(byte[] data, int offset) {

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -57,26 +57,26 @@ public class SourceAndSliceTest {
 
     @Test
     public void validSource() {
-        assertTrue(source.isAvailable(0, BigInteger.valueOf(4)));
-        assertTrue(source.isAvailable(1, BigInteger.valueOf(3)));
-        assertTrue(source.isAvailable(2, BigInteger.valueOf(1)));
-        assertTrue(source.isAvailable(4, BigInteger.valueOf(0)));
-        assertFalse(source.isAvailable(0, BigInteger.valueOf(5)));
-        assertFalse(source.isAvailable(4, BigInteger.valueOf(1)));
-        assertFalse(source.isAvailable(5, BigInteger.valueOf(1)));
-        assertFalse(source.isAvailable(5, BigInteger.valueOf(0)));
+        assertTrue(source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(4)));
+        assertTrue(source.isAvailable(BigInteger.ONE, BigInteger.valueOf(3)));
+        assertTrue(source.isAvailable(BigInteger.valueOf(2), BigInteger.ONE));
+        assertTrue(source.isAvailable(BigInteger.valueOf(4), BigInteger.ZERO));
+        assertFalse(source.isAvailable(BigInteger.ZERO, BigInteger.valueOf(5)));
+        assertFalse(source.isAvailable(BigInteger.valueOf(4), BigInteger.ONE));
+        assertFalse(source.isAvailable(BigInteger.valueOf(5), BigInteger.ONE));
+        assertFalse(source.isAvailable(BigInteger.valueOf(5), BigInteger.ZERO));
     }
 
     @Test
     public void validSlice() {
-        checkSlice(0, 4);
-        checkSlice(1, 3);
-        checkSlice(2, 1);
-        checkSlice(4, 0);
+        checkSlice(BigInteger.ZERO, 4);
+        checkSlice(BigInteger.ONE, 3);
+        checkSlice(BigInteger.valueOf(2), 1);
+        checkSlice(BigInteger.valueOf(4), 0);
     }
 
-    private void checkSlice(final int offset, final int length) {
-        assertTrue(compareDataSlices(Slice.createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset));
+    private void checkSlice(final BigInteger offset, final int length) {
+        assertTrue(compareDataSlices(Slice.createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset.intValue()));
     }
 
     private boolean compareDataSlices(byte[] data, int offset) {
@@ -89,23 +89,23 @@ public class SourceAndSliceTest {
     @Test
     public void readBeyondEndOfSource() throws IOException {
         thrown.expect(IllegalStateException.class);
-        source.getData(1, BigInteger.valueOf(4));
+        source.getData(BigInteger.ONE, BigInteger.valueOf(4));
     }
 
     @Test
     public void readBeyondEndOfSlice() {
-        assertFalse(Slice.createFromSource(source, 1, BigInteger.valueOf(4)).isPresent());
+        assertFalse(Slice.createFromSource(source, BigInteger.ONE, BigInteger.valueOf(4)).isPresent());
     }
 
     @Test
     public void startReadBeyondEndOfSource() throws IOException {
         thrown.expect(IllegalStateException.class);
-        source.getData(5, BigInteger.valueOf(0));
+        source.getData(BigInteger.valueOf(5), BigInteger.ZERO);
     }
 
     @Test
     public void startReadBeyondEndOfSlice() {
-        assertFalse(Slice.createFromSource(source, 5, BigInteger.valueOf(0)).isPresent());
+        assertFalse(Slice.createFromSource(source, BigInteger.valueOf(5), BigInteger.ZERO).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -92,7 +92,7 @@ public class CallbackTest {
             @Override
             protected void handleSuccess(Token token, Environment before, Environment after) {
                 final ImmutableList<ParseItem> roots = getAllRoots(after.order, token);
-                assertEquals(offsets[count++], roots.head.asGraph().tail.head.asValue().slice.offset);
+                assertEquals(offsets[count++], roots.head.asGraph().tail.head.asValue().slice.offset.longValue());
             }
 
             @Override
@@ -129,8 +129,8 @@ public class CallbackTest {
                         assertEquals(2, seqRoots.size);
 
                         // verify order of the two Seq graphs:
-                        assertEquals(2, getValue(seqRoots.head.asGraph(), "a").slice.offset);
-                        assertEquals(0, getValue(seqRoots.tail.head.asGraph(), "a").slice.offset);
+                        assertEquals(2, getValue(seqRoots.head.asGraph(), "a").slice.offset.intValue());
+                        assertEquals(0, getValue(seqRoots.tail.head.asGraph(), "a").slice.offset.intValue());
                     }
 
                     @Override
@@ -222,13 +222,13 @@ public class CallbackTest {
 
         @Override
         protected void handleSuccess(Token token, Environment before, Environment after) {
-            assertThat(after.offset, is(equalTo(expectedSuccessOffsets.pop())));
+            assertThat(after.offset.longValue(), is(equalTo(expectedSuccessOffsets.pop())));
             assertThat(token, is(equalTo(expectedSuccessDefinitions.pop())));
         }
 
         @Override
         protected void handleFailure(Token token, Environment before) {
-            assertThat(before.offset, is(equalTo(expectedFailureOffsets.pop())));
+            assertThat(before.offset.longValue(), is(equalTo(expectedFailureOffsets.pop())));
             assertThat(token, is(equalTo(expectedFailureDefinitions.pop())));
         }
 

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -92,7 +92,7 @@ public class CallbackTest {
             @Override
             protected void handleSuccess(Token token, Environment before, Environment after) {
                 final ImmutableList<ParseItem> roots = getAllRoots(after.order, token);
-                assertEquals(offsets[count++], roots.head.asGraph().tail.head.asValue().slice.offset.longValue());
+                assertEquals(offsets[count++], roots.head.asGraph().tail.head.asValue().slice.offset.longValueExact());
             }
 
             @Override
@@ -129,8 +129,8 @@ public class CallbackTest {
                         assertEquals(2, seqRoots.size);
 
                         // verify order of the two Seq graphs:
-                        assertEquals(2, getValue(seqRoots.head.asGraph(), "a").slice.offset.intValue());
-                        assertEquals(0, getValue(seqRoots.tail.head.asGraph(), "a").slice.offset.intValue());
+                        assertEquals(2, getValue(seqRoots.head.asGraph(), "a").slice.offset.intValueExact());
+                        assertEquals(0, getValue(seqRoots.tail.head.asGraph(), "a").slice.offset.intValueExact());
                     }
 
                     @Override
@@ -222,13 +222,13 @@ public class CallbackTest {
 
         @Override
         protected void handleSuccess(Token token, Environment before, Environment after) {
-            assertThat(after.offset.longValue(), is(equalTo(expectedSuccessOffsets.pop())));
+            assertThat(after.offset.longValueExact(), is(equalTo(expectedSuccessOffsets.pop())));
             assertThat(token, is(equalTo(expectedSuccessDefinitions.pop())));
         }
 
         @Override
         protected void handleFailure(Token token, Environment before) {
-            assertThat(before.offset.longValue(), is(equalTo(expectedFailureOffsets.pop())));
+            assertThat(before.offset.longValueExact(), is(equalTo(expectedFailureOffsets.pop())));
             assertThat(token, is(equalTo(expectedFailureDefinitions.pop())));
         }
 

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -255,7 +255,7 @@ public class ByTokenTest {
         assertEquals(smallSeq, seqItems.head.getDefinition());
         final ParseValue c = seqItems.head.asGraph().head.asValue();
         assertEquals(3, c.asNumeric().intValue());
-        assertEquals(2, c.slice.offset);
+        assertEquals(2, c.slice.offset.intValue());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -179,8 +179,8 @@ public class ByTokenTest {
         assertThat(def1Items.head.getDefinition(), is(equalTo(DEF1)));
         assertThat(def2Items.head.getDefinition(), is(equalTo(DEF2)));
 
-        assertThat(def1Items.tail.head.asValue().asNumeric().intValue(), is(equalTo(2)));
-        assertThat(def2Items.tail.head.asValue().asNumeric().intValue(), is(equalTo(3)));
+        assertThat(def1Items.tail.head.asValue().asNumeric().intValueExact(), is(equalTo(2)));
+        assertThat(def2Items.tail.head.asValue().asNumeric().intValueExact(), is(equalTo(3)));
     }
 
     @Test
@@ -254,8 +254,8 @@ public class ByTokenTest {
         assertEquals(1, seqItems.size);
         assertEquals(smallSeq, seqItems.head.getDefinition());
         final ParseValue c = seqItems.head.asGraph().head.asValue();
-        assertEquals(3, c.asNumeric().intValue());
-        assertEquals(2, c.slice.offset.intValue());
+        assertEquals(3, c.asNumeric().intValueExact());
+        assertEquals(2, c.slice.offset.intValueExact());
     }
 
     @Test
@@ -268,9 +268,9 @@ public class ByTokenTest {
         assertEquals(smallSeq, seqItems.head.getDefinition());
         assertEquals(smallSeq, seqItems.tail.head.getDefinition());
         final ParseValue c1 = seqItems.head.asGraph().head.asValue();
-        assertEquals(3, c1.asNumeric().intValue());
+        assertEquals(3, c1.asNumeric().intValueExact());
         final ParseValue c2 = seqItems.tail.head.asGraph().head.asValue();
-        assertEquals(3, c2.asNumeric().intValue());
+        assertEquals(3, c2.asNumeric().intValueExact());
         assertNotEquals(seqItems.head.asGraph().head, seqItems.tail.head.asGraph().head);
     }
 
@@ -296,7 +296,7 @@ public class ByTokenTest {
         for (final ParseItem item : items) {
             assertTrue(item.isGraph());
             assertEquals(2, item.asGraph().size);
-            assertEquals(2, item.asGraph().head.asValue().asNumeric().intValue());
+            assertEquals(2, item.asGraph().head.asValue().asNumeric().intValueExact());
         }
     }
 
@@ -337,9 +337,9 @@ public class ByTokenTest {
         final ParseGraph graph = parseResultGraph(stream(0, 1, 2), rep(DEF1));
         final ImmutableList<ParseItem> items = getAllRoots(graph, DEF1);
         assertThat(items.size, is(equalTo(3L)));
-        assertThat(items.head.asValue().asNumeric().intValue(), is(equalTo(2)));
-        assertThat(items.tail.head.asValue().asNumeric().intValue(), is(equalTo(1)));
-        assertThat(items.tail.tail.head.asValue().asNumeric().intValue(), is(equalTo(0)));
+        assertThat(items.head.asValue().asNumeric().intValueExact(), is(equalTo(2)));
+        assertThat(items.tail.head.asValue().asNumeric().intValueExact(), is(equalTo(1)));
+        assertThat(items.tail.tail.head.asValue().asNumeric().intValueExact(), is(equalTo(0)));
     }
 
     @Test
@@ -347,8 +347,8 @@ public class ByTokenTest {
         final ParseGraph graph = parseResultGraph(stream(4, 2, 2, 3, 4, 5), SEQ_SUB);
         final ImmutableList<ParseItem> items = getAllRoots(graph, TWO_BYTES);
         assertThat(items.size, is(equalTo(2L)));
-        assertThat(items.head.asValue().asNumeric().intValue(), is(equalTo(0x0203)));
-        assertThat(items.tail.head.asValue().asNumeric().intValue(), is(equalTo(0x0405)));
+        assertThat(items.head.asValue().asNumeric().intValueExact(), is(equalTo(0x0203)));
+        assertThat(items.tail.head.asValue().asNumeric().intValueExact(), is(equalTo(0x0405)));
     }
 
     @Test
@@ -360,12 +360,12 @@ public class ByTokenTest {
         // item.head is the MUT_REC_1 graph containing [3, 4, 5], with '3' having the DEF1 definition
         final ImmutableList<ParseItem> firstMutRecValues = getAll(items.head.asGraph(), DEF1);
         assertThat(firstMutRecValues.size, is(equalTo(1L)));
-        assertThat(lastItem(firstMutRecValues).asValue().asNumeric().intValue(), is(equalTo(3)));
+        assertThat(lastItem(firstMutRecValues).asValue().asNumeric().intValueExact(), is(equalTo(3)));
 
         // item.tail.head is the MUT_REC_1 graph containing [0, 1, 2, 3, 4, 5], with '0' and '3' having the DEF1 definition
         final ImmutableList<ParseItem> secondMutRecValues = getAll(items.tail.head.asGraph(), DEF1);
         assertThat(secondMutRecValues.size, is(equalTo(2L)));
-        assertThat(lastItem(secondMutRecValues).asValue().asNumeric().intValue(), is(equalTo(0)));
+        assertThat(lastItem(secondMutRecValues).asValue().asNumeric().intValueExact(), is(equalTo(0)));
     }
 
     @Test
@@ -376,7 +376,7 @@ public class ByTokenTest {
 
         for (int value = 0xF; value >= 0xA; value--) {
             final ImmutableList<ParseItem> values = getAll(items.head.asGraph(), DEF1);
-            assertThat(lastItem(values).asValue().asNumeric().intValue(), is(equalTo(value)));
+            assertThat(lastItem(values).asValue().asNumeric().intValueExact(), is(equalTo(value)));
             items = items.tail;
         }
     }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data.selection;
 
+import static java.math.BigInteger.ZERO;
+
 import static io.parsingdata.metal.data.ParseGraph.EMPTY;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
@@ -44,7 +46,7 @@ public class ByTypeTest {
     public void unresolvableRef() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("A ParseReference must point to an existing graph.");
-        getReferences(EMPTY.add(new ParseReference(BigInteger.ZERO, EMPTY_SOURCE, NONE)));
+        getReferences(EMPTY.add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -33,8 +33,8 @@ import io.parsingdata.metal.data.Source;
 public class ByTypeTest {
 
     public static final Source EMPTY_SOURCE = new Source() {
-        @Override protected byte[] getData(long offset, BigInteger length) { throw new IllegalStateException(); }
-        @Override protected boolean isAvailable(long offset, BigInteger length) { return false; }
+        @Override protected byte[] getData(BigInteger offset, BigInteger length) { throw new IllegalStateException(); }
+        @Override protected boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
     };
 
     @Rule
@@ -44,7 +44,7 @@ public class ByTypeTest {
     public void unresolvableRef() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("A ParseReference must point to an existing graph.");
-        getReferences(EMPTY.add(new ParseReference(0, EMPTY_SOURCE, NONE)));
+        getReferences(EMPTY.add(new ParseReference(BigInteger.ZERO, EMPTY_SOURCE, NONE)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
@@ -61,10 +61,10 @@ public class BytesTest {
         assertTrue(result.isPresent());
         final ImmutableList<Optional<Value>> bytesAfterDivision = bytes(div(ref("value"), ref("divider"))).eval(result.get().order, enc());
         assertEquals(3, bytesAfterDivision.size); // 1 of the first division, 0 of the second, 2 of the third
-        assertEquals(1, bytesAfterDivision.head.get().asNumeric().intValue()); // first value (0x0100) / first divider (0xFF)
+        assertEquals(1, bytesAfterDivision.head.get().asNumeric().intValueExact()); // first value (0x0100) / first divider (0xFF)
         // second division result is missing because of division by zero
-        assertEquals(0, bytesAfterDivision.tail.head.get().asNumeric().intValue()); // third value (0x7F00) / third divider (0x01), right byte
-        assertEquals(127, bytesAfterDivision.tail.tail.head.get().asNumeric().intValue()); // left byte
+        assertEquals(0, bytesAfterDivision.tail.head.get().asNumeric().intValueExact()); // third value (0x7F00) / third divider (0x01), right byte
+        assertEquals(127, bytesAfterDivision.tail.tail.head.get().asNumeric().intValueExact()); // left byte
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryLongTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryLongTest.java
@@ -58,9 +58,9 @@ public class ConstantFactoryLongTest {
 
     @Test
     public void checkLong() {
-        assertEquals(value, ConstantFactory.createFromNumeric(value, signed()).asNumeric().longValue());
+        assertEquals(value, ConstantFactory.createFromNumeric(value, signed()).asNumeric().longValueExact());
         if (value >= 0) {
-            assertEquals(value, ConstantFactory.createFromNumeric(value, enc()).asNumeric().longValue());
+            assertEquals(value, ConstantFactory.createFromNumeric(value, enc()).asNumeric().longValueExact());
         } else {
             assertEquals(0, calculateUnsignedValue(value).compareTo(ConstantFactory.createFromNumeric(value, enc()).asNumeric()));
         }
@@ -68,7 +68,7 @@ public class ConstantFactoryLongTest {
 
     private BigInteger calculateUnsignedValue(final long input) {
         for (int i = 8; i < 64; i+=8) {
-            final long maxValue = BigInteger.valueOf(2).pow(i-1).longValue();
+            final long maxValue = BigInteger.valueOf(2).pow(i-1).longValueExact();
             if ((maxValue + input) >= 0) {
                 return BigInteger.valueOf(input).add(BigInteger.valueOf(2*maxValue));
             }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -61,7 +61,7 @@ public class ElvisExpressionTest {
 
         assertNotNull(eval);
         assertEquals(1, eval.size);
-        assertThat(eval.head.get().asNumeric().intValue(), is(equalTo(1)));
+        assertThat(eval.head.get().asNumeric().intValueExact(), is(equalTo(1)));
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ElvisExpressionTest {
 
         assertNotNull(eval);
         assertEquals(1, eval.size);
-        assertThat(eval.head.get().asNumeric().intValue(), is(equalTo(2)));
+        assertThat(eval.head.get().asNumeric().intValueExact(), is(equalTo(2)));
     }
 
     @Test
@@ -89,8 +89,8 @@ public class ElvisExpressionTest {
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
         assertEquals(2, eval.size);
-        assertEquals(2, eval.head.get().asNumeric().intValue());
-        assertEquals(1, eval.tail.head.get().asNumeric().intValue());
+        assertEquals(2, eval.head.get().asNumeric().intValueExact());
+        assertEquals(1, eval.tail.head.get().asNumeric().intValueExact());
     }
 
     @Test
@@ -100,8 +100,8 @@ public class ElvisExpressionTest {
         final ValueExpression elvis = elvis(ref("c"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
         assertEquals(2, eval.size);
-        assertEquals(4, eval.head.get().asNumeric().intValue());
-        assertEquals(3, eval.tail.head.get().asNumeric().intValue());
+        assertEquals(4, eval.head.get().asNumeric().intValueExact());
+        assertEquals(3, eval.tail.head.get().asNumeric().intValueExact());
     }
 
     @Test
@@ -111,9 +111,9 @@ public class ElvisExpressionTest {
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
         assertEquals(3, eval.size);
-        assertEquals(2, eval.head.get().asNumeric().intValue());
-        assertEquals(1, eval.tail.head.get().asNumeric().intValue());
-        assertEquals(3, eval.tail.tail.head.get().asNumeric().intValue());
+        assertEquals(2, eval.head.get().asNumeric().intValueExact());
+        assertEquals(1, eval.tail.head.get().asNumeric().intValueExact());
+        assertEquals(3, eval.tail.tail.head.get().asNumeric().intValueExact());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class ElvisExpressionTest {
         final ValueExpression elvis = elvis(div(con(1), con(0)), con(1));
         final ImmutableList<Optional<Value>> eval = elvis.eval(stream(0).order, enc());
         assertEquals(1, eval.size);
-        assertEquals(1, eval.head.get().asNumeric().intValue());
+        assertEquals(1, eval.head.get().asNumeric().intValueExact());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -80,7 +80,7 @@ public class ExpandTest {
         assertEquals(SIZE, result.size);
         for (int i = 0; i < SIZE; i++) {
             assertTrue(result.head.isPresent());
-            assertEquals(VALUE_1, result.head.get().asNumeric().intValue());
+            assertEquals(VALUE_1, result.head.get().asNumeric().intValueExact());
             result = result.tail;
         }
     }
@@ -91,10 +91,10 @@ public class ExpandTest {
         assertEquals(2 * SIZE, result.size);
         for (int i = 0; i < SIZE; i++) {
             assertTrue(result.head.isPresent());
-            assertEquals(VALUE_1, result.head.get().asNumeric().intValue());
+            assertEquals(VALUE_1, result.head.get().asNumeric().intValueExact());
             result = result.tail;
             assertTrue(result.head.isPresent());
-            assertEquals(VALUE_2, result.head.get().asNumeric().intValue());
+            assertEquals(VALUE_2, result.head.get().asNumeric().intValueExact());
             result = result.tail;
         }
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
@@ -96,34 +96,34 @@ public class NthExpressionTest {
     public void testSingleIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [0], result = [1]
         final ImmutableList<Optional<Value>> values = makeList(stream(5, 1, 2, 3, 4, 5, 1, 0), 1);
-        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(1)));
+        assertThat(values.head.get().asNumeric().intValueExact(), is(equalTo(1)));
     }
 
     @Test
     public void testMultipleIndices() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 2 indices = [0, 2], result = [1, 3]
         final ImmutableList<Optional<Value>> values = makeList(stream(5, 1, 2, 3, 4, 5, 2, 0, 2), 2);
-        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(3)));
-        assertThat(values.tail.head.get().asNumeric().intValue(), is(equalTo(1)));
+        assertThat(values.head.get().asNumeric().intValueExact(), is(equalTo(3)));
+        assertThat(values.tail.head.get().asNumeric().intValueExact(), is(equalTo(1)));
     }
 
     @Test
     public void testMultipleIndicesMixedOrder() throws IOException {
         // 5 values = [5, 6, 7, 8, 9], 4 indices = [3, 2, 0, 4], result = [8, 7, 5, 9]
         final ImmutableList<Optional<Value>> values = makeList(stream(5, 5, 6, 7, 8, 9, 4, 3, 2, 0, 4), 4);
-        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(9)));
-        assertThat(values.tail.head.get().asNumeric().intValue(), is(equalTo(5)));
-        assertThat(values.tail.tail.head.get().asNumeric().intValue(), is(equalTo(7)));
-        assertThat(values.tail.tail.tail.head.get().asNumeric().intValue(), is(equalTo(8)));
+        assertThat(values.head.get().asNumeric().intValueExact(), is(equalTo(9)));
+        assertThat(values.tail.head.get().asNumeric().intValueExact(), is(equalTo(5)));
+        assertThat(values.tail.tail.head.get().asNumeric().intValueExact(), is(equalTo(7)));
+        assertThat(values.tail.tail.tail.head.get().asNumeric().intValueExact(), is(equalTo(8)));
     }
 
     @Test
     public void testMixedExistingNonExistingIndices() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 3 indices = [0, 42, 2], result = [1, Nan, 3]
         final ImmutableList<Optional<Value>> values = makeList(stream(5, 1, 2, 3, 4, 5, 3, 0, 42, 2), 3);
-        assertThat(values.head.get().asNumeric().intValue(), is(equalTo(3)));
+        assertThat(values.head.get().asNumeric().intValueExact(), is(equalTo(3)));
         assertThat(values.tail.head.isPresent(), is(equalTo(false)));
-        assertThat(values.tail.tail.head.get().asNumeric().intValue(), is(equalTo(1)));
+        assertThat(values.tail.tail.head.get().asNumeric().intValueExact(), is(equalTo(1)));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
@@ -24,7 +24,7 @@ public class OffsetTest {
         assertFalse(offsetCon.isEmpty());
         assertEquals(1, offsetCon.size);
         assertTrue(offsetCon.head.isPresent());
-        assertEquals(0, offsetCon.head.get().asNumeric().intValue());
+        assertEquals(0, offsetCon.head.get().asNumeric().intValueExact());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -37,12 +37,12 @@ public class DefTest {
 
     @Test
     public void scopeWithoutEncoding() throws IOException {
-        assertEquals(1, getValue(def("a", 1).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValue());
+        assertEquals(1, getValue(def("a", 1).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValueExact());
     }
 
     @Test
     public void scopeWithEncoding() throws IOException {
-        assertEquals(1, getValue(def("a", 1, signed()).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValue());
+        assertEquals(1, getValue(def("a", 1, signed()).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValueExact());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/PostTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PostTest.java
@@ -50,7 +50,7 @@ public class PostTest {
 
         // token parses and postcondition is true
         assertThat(result.isPresent(), is(true));
-        assertThat(result.get().offset.longValue(), is(2L));
+        assertThat(result.get().offset.longValueExact(), is(2L));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/PostTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PostTest.java
@@ -50,7 +50,7 @@ public class PostTest {
 
         // token parses and postcondition is true
         assertThat(result.isPresent(), is(true));
-        assertThat(result.get().offset, is(2L));
+        assertThat(result.get().offset.longValue(), is(2L));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/PreTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PreTest.java
@@ -46,7 +46,7 @@ public class PreTest {
         final Optional<Environment> result = SEQUENCE.parse(stream(1, 1), enc());
 
         // precondition is true, token is parsed
-        assertThat(result.get().offset, is(2L));
+        assertThat(result.get().offset.longValue(), is(2L));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/PreTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PreTest.java
@@ -46,7 +46,7 @@ public class PreTest {
         final Optional<Environment> result = SEQUENCE.parse(stream(1, 1), enc());
 
         // precondition is true, token is parsed
-        assertThat(result.get().offset.longValue(), is(2L));
+        assertThat(result.get().offset.longValueExact(), is(2L));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/TieTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TieTest.java
@@ -77,7 +77,7 @@ public class TieTest {
     @Test
     public void smallContainer() throws IOException {
         final Optional<Environment> result = parseContainer();
-        assertEquals(5, result.get().offset.intValue());
+        assertEquals(5, result.get().offset.intValueExact());
         assertEquals(6, getAllValues(result.get().order, "value").size);
     }
 
@@ -96,7 +96,7 @@ public class TieTest {
     private Optional<Environment> checkFullParse(Token token, byte[] data) throws IOException {
         final Optional<Environment> result = token.parse(new Environment(new InMemoryByteStream(data)), enc());
         assertTrue(result.isPresent());
-        assertEquals(data.length, result.get().offset.intValue());
+        assertEquals(data.length, result.get().offset.intValueExact());
         return result;
     }
 
@@ -131,7 +131,7 @@ public class TieTest {
                 def("data", last(ref("size"))),
                 tie(l2Token, inflate(last(ref("data")))));
         final Optional<Environment> result = checkFullParse(l1Token, l1Data);
-        assertEquals(80, result.get().order.head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asValue().asNumeric().intValue());
+        assertEquals(80, result.get().order.head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asValue().asNumeric().intValueExact());
     }
 
     private byte[] flipBlocks(byte[] input, int blockSize) {

--- a/core/src/test/java/io/parsingdata/metal/token/TieTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TieTest.java
@@ -77,7 +77,7 @@ public class TieTest {
     @Test
     public void smallContainer() throws IOException {
         final Optional<Environment> result = parseContainer();
-        assertEquals(5, result.get().offset);
+        assertEquals(5, result.get().offset.intValue());
         assertEquals(6, getAllValues(result.get().order, "value").size);
     }
 
@@ -96,7 +96,7 @@ public class TieTest {
     private Optional<Environment> checkFullParse(Token token, byte[] data) throws IOException {
         final Optional<Environment> result = token.parse(new Environment(new InMemoryByteStream(data)), enc());
         assertTrue(result.isPresent());
-        assertEquals(data.length, result.get().offset);
+        assertEquals(data.length, result.get().offset.intValue());
         return result;
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -53,7 +53,7 @@ public class WhileTest {
         // the while stops because the second 'value' is >= 1
         final Optional<Environment> result = WHILE.parse(stream(0, 9, 1, 10, 2, 11), enc());
 
-        assertThat(result.get().offset.longValue(), is(4L));
+        assertThat(result.get().offset.longValueExact(), is(4L));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -53,7 +53,7 @@ public class WhileTest {
         // the while stops because the second 'value' is >= 1
         final Optional<Environment> result = WHILE.parse(stream(0, 9, 1, 10, 2, 11), enc());
 
-        assertThat(result.get().offset, is(4L));
+        assertThat(result.get().offset.longValue(), is(4L));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -36,13 +36,13 @@ public class InMemoryByteStream implements ByteStream {
     public byte[] read(final BigInteger offset, final int length) throws IOException {
         if (!isAvailable(offset, length)) { throw new IOException("Data to read is not available."); }
         byte[] data = new byte[length];
-        System.arraycopy(this.data, offset.intValue(), data, 0, length);
+        System.arraycopy(this.data, offset.intValueExact(), data, 0, length);
         return data;
     }
 
     @Override
     public boolean isAvailable(final BigInteger offset, final int length) {
-        return offset.intValue() + length <= data.length;
+        return offset.intValueExact() + length <= data.length;
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal.util;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -32,16 +33,16 @@ public class InMemoryByteStream implements ByteStream {
     }
 
     @Override
-    public byte[] read(final long offset, final int length) throws IOException {
+    public byte[] read(final BigInteger offset, final int length) throws IOException {
         if (!isAvailable(offset, length)) { throw new IOException("Data to read is not available."); }
         byte[] data = new byte[length];
-        System.arraycopy(this.data, (int)offset, data, 0, length);
+        System.arraycopy(this.data, offset.intValue(), data, 0, length);
         return data;
     }
 
     @Override
-    public boolean isAvailable(final long offset, final int length) {
-        return offset + length <= data.length;
+    public boolean isAvailable(final BigInteger offset, final int length) {
+        return offset.intValue() + length <= data.length;
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
@@ -40,7 +40,7 @@ public class ReadTrackingByteStream implements ByteStream {
 
     @Override
     public byte[] read(final BigInteger offset, final int length) throws IOException {
-        for (long i = offset.longValue(); i < offset.longValue()+length; i++) {
+        for (long i = offset.longValueExact(); i < offset.longValueExact()+length; i++) {
             read.add(i);
         }
         return byteStream.read(offset, length);

--- a/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
@@ -20,6 +20,7 @@ import static io.parsingdata.metal.Util.checkNotNull;
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -38,8 +39,8 @@ public class ReadTrackingByteStream implements ByteStream {
     }
 
     @Override
-    public byte[] read(final long offset, final int length) throws IOException {
-        for (long i = offset; i < offset+length; i++) {
+    public byte[] read(final BigInteger offset, final int length) throws IOException {
+        for (long i = offset.longValue(); i < offset.longValue()+length; i++) {
             read.add(i);
         }
         return byteStream.read(offset, length);
@@ -57,7 +58,7 @@ public class ReadTrackingByteStream implements ByteStream {
     }
 
     @Override
-    public boolean isAvailable(final long offset, final int length) {
+    public boolean isAvailable(final BigInteger offset, final int length) {
         return byteStream.isAvailable(offset, length);
     }
 


### PR DESCRIPTION
Resolves #16.

The only places where we still use `long` or `int` are the following:

1. The `size` field of `ImmutableList` and `ParseGraph`.
2. When dealing with `byte[]`, which means there is a hard limit on what fits in an `int` anyway. For example: the `length` argument on methods of the `ByteStream` interface. Since `getData()` returns a `byte[]` anyway, there's no point in changing this now.
3. Many internal values that will remain within `long` scope I think (such as calculated result of `RepN`, result of `Count`, etc.) These values can be `BigInteger` and they are converted when necessary, but I don't think it actually makes sense to convert them now.