### PR TITLE
Handle error cases caused by negative offsets

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -16,7 +16,10 @@
 
 package io.parsingdata.metal;
 
+import static java.math.BigInteger.ZERO;
+
 import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
 import java.util.Optional;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -56,6 +59,11 @@ public final class Util {
     public static boolean notNullAndSameClass(final Object object, final Object other) {
         return other != null
             && object.getClass() == other.getClass();
+    }
+
+    public static BigInteger checkNotNegative(final BigInteger argument, final String name) {
+        if (checkNotNull(argument, name).compareTo(ZERO) < 0) { throw new IllegalArgumentException("Argument " + name + " may not be negative."); }
+        return argument;
     }
 
     public static String bytesToHexString(final byte[] bytes) {

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ZERO;
+
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.io.IOException;
@@ -35,7 +37,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (offset.compareTo(ZERO) < 0 || !isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         try {
             return input.read(offset, length.intValueExact());
         } catch (final IOException exception) {

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal.data;
 
 import static java.math.BigInteger.ZERO;
 
+import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.io.IOException;
@@ -37,7 +38,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (offset.compareTo(ZERO) < 0 || !isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (!isAvailable(checkNotNegative(offset, "offset"), length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         try {
             return input.read(offset, length.intValueExact());
         } catch (final IOException exception) {

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ZERO;
+
 import static io.parsingdata.metal.Util.bytesToHexString;
 import static io.parsingdata.metal.Util.checkNotNull;
 
@@ -35,7 +37,7 @@ public class ConstantSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (offset.compareTo(ZERO) < 0 || !isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         final byte[] outputData = new byte[length.intValueExact()];
         System.arraycopy(data, offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.data;
 import static java.math.BigInteger.ZERO;
 
 import static io.parsingdata.metal.Util.bytesToHexString;
+import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.math.BigInteger;
@@ -37,7 +38,7 @@ public class ConstantSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (offset.compareTo(ZERO) < 0 || !isAvailable(offset, length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (!isAvailable(checkNotNegative(offset, "offset"), length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         final byte[] outputData = new byte[length.intValueExact()];
         System.arraycopy(data, offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -20,6 +20,7 @@ import static java.math.BigInteger.ZERO;
 
 import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
+import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.math.BigInteger;
@@ -48,8 +49,9 @@ public class DataExpressionSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
+        checkNotNegative(offset, "offset");
         final Value inputValue = getValue();
-        if (offset.compareTo(ZERO) < 0 || length.add(offset).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (length.add(offset).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         final byte[] outputData = new byte[length.intValueExact()];
         System.arraycopy(inputValue.getValue(), offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.data;
 
+import static java.math.BigInteger.ZERO;
+
 import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNull;
@@ -47,7 +49,7 @@ public class DataExpressionSource extends Source {
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
         final Value inputValue = getValue();
-        if (length.add(offset).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (offset.compareTo(ZERO) < 0 || length.add(offset).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
         final byte[] outputData = new byte[length.intValueExact()];
         System.arraycopy(inputValue.getValue(), offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;

--- a/core/src/main/java/io/parsingdata/metal/data/Environment.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Environment.java
@@ -75,8 +75,8 @@ public class Environment {
         return new Environment(order.add(parseReference), source, offset, callbacks);
     }
 
-    public Environment seek(final BigInteger newOffset) {
-        return new Environment(order, source, newOffset, callbacks);
+    public Optional<Environment> seek(final BigInteger newOffset) {
+        return newOffset.compareTo(ZERO) >= 0 ? Optional.of(new Environment(order, source, newOffset, callbacks)) : Optional.empty();
     }
 
     public Environment source(final ValueExpression dataExpression, final int index, final Environment environment, final Encoding encoding) {

--- a/core/src/main/java/io/parsingdata/metal/data/Environment.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Environment.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal.data;
 
 import static java.math.BigInteger.ZERO;
 
+import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
@@ -39,7 +40,7 @@ public class Environment {
     public Environment(final ParseGraph order, final Source source, final BigInteger offset, final Callbacks callbacks) {
         this.order = checkNotNull(order, "order");
         this.source = checkNotNull(source, "source");
-        this.offset = checkNotNull(offset, "offset");
+        this.offset = checkNotNegative(offset, "offset");
         this.callbacks = checkNotNull(callbacks, "callbacks");
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -39,7 +39,9 @@ public class Slice {
     }
 
     public static Optional<Slice> createFromSource(final Source source, final BigInteger offset, final BigInteger length) {
-        if (checkNotNull(length, "length").compareTo(ZERO) < 0 || !checkNotNull(source, "source").isAvailable(offset, length)) { return Optional.empty(); }
+        if (offset.compareTo(ZERO) < 0 ||
+            checkNotNull(length, "length").compareTo(ZERO) < 0 ||
+            !checkNotNull(source, "source").isAvailable(offset, length)) { return Optional.empty(); }
         return Optional.of(new Slice(source, offset, length));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -66,7 +66,7 @@ public class Def extends Token {
         }
         return environment
             .slice(dataSize)
-            .map(slice -> success(environment.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(environment.offset))))
+            .map(slice -> environment.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(environment.offset)))
             .orElse(failure());
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -68,7 +68,7 @@ public class Sub extends Token {
             return failure();
         }
         return iterate(scope, addresses, environment.addBranch(this), encoding).computeResult()
-            .flatMap(nextEnvironment -> success(nextEnvironment.seek(environment.offset)));
+            .flatMap(nextEnvironment -> nextEnvironment.seek(environment.offset));
     }
 
     private Trampoline<Optional<Environment>> iterate(final String scope, final ImmutableList<Optional<Value>> addresses, final Environment environment, final Encoding encoding) {
@@ -87,7 +87,10 @@ public class Sub extends Token {
         if (hasRootAtOffset(environment.order, token.getCanonical(environment), offset, environment.source)) {
             return success(environment.add(new ParseReference(offset, environment.source, token.getCanonical(environment))));
         }
-        return token.parse(scope, environment.seek(offset), encoding);
+        return environment
+            .seek(offset)
+            .map(newEnvironment -> token.parse(scope, newEnvironment, encoding))
+            .orElse(failure());
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal;
 
 import static org.junit.Assert.assertFalse;
 
+import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -80,10 +81,7 @@ public class ErrorsTest {
     public void environmentWithNegativeOffset() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument offset may not be negative.");
-        new Environment(new ByteStream() {
-            @Override public byte[] read(BigInteger offset, int length) throws IOException { return new byte[0]; }
-            @Override public boolean isAvailable(BigInteger offset, int length) { return false; }
-        }, BigInteger.valueOf(-1));
+        new Environment(DUMMY_STREAM, BigInteger.valueOf(-1));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -31,12 +31,14 @@ import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Optional;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.token.Token;
 
@@ -71,7 +73,17 @@ public class ErrorsTest {
                 repn(dummy, ref("b"))
             );
        Optional<Environment> result = multiRepN.parse(stream(2, 2, 2, 2), enc());
-        assertFalse(result.isPresent());
+       assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void environmentWithNegativeOffset() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Argument offset may not be negative.");
+        new Environment(new ByteStream() {
+            @Override public byte[] read(BigInteger offset, int length) throws IOException { return new byte[0]; }
+            @Override public boolean isAvailable(BigInteger offset, int length) { return false; }
+        }, BigInteger.valueOf(-1));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -31,6 +31,7 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_VE;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Optional;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.parsingdata.metal.data.Environment;
@@ -98,7 +100,7 @@ public class SubStructTest {
     }
 
     private ParseGraph startCycle(final int offset) throws IOException {
-        final Environment environment = stream(0, 4, 1, 21, 0, 0, 1).seek(BigInteger.valueOf(offset));
+        final Environment environment = stream(0, 4, 1, 21, 0, 0, 1).seek(BigInteger.valueOf(offset)).get();
         final Optional<Environment> result = LINKED_LIST.parse(environment, enc());
         assertTrue(result.isPresent());
         assertEquals(1, getReferences(result.get().order).size);
@@ -157,8 +159,13 @@ public class SubStructTest {
     }
 
     @Test
-    public void errorEmptyAddressInList() throws IOException {
-        assertFalse(sub(any("a"), cat(con(0), EMPTY_VE)).parse(stream(1, 2, 3, 4), enc()).isPresent());
+    public void errorEmptyAddress() throws IOException {
+        assertFalse(sub(any("a"), EMPTY_VE).parse(stream(1, 2, 3, 4), enc()).isPresent());
+    }
+
+    @Test
+    public void errorNegativeAddress() {
+        assertFalse(sub(any("a"), con(-1, signed())).parse(stream(1, 2, 3, 4), enc()).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -111,4 +111,15 @@ public class SourceAndSliceTest {
         assertFalse(Slice.createFromSource(source, BigInteger.valueOf(5), ZERO).isPresent());
     }
 
+    @Test
+    public void startReadAtNegativeOffsetSource() {
+        thrown.expect(IllegalStateException.class);
+        source.getData(BigInteger.valueOf(-1L), ONE);
+    }
+
+    @Test
+    public void startReadAtNegativeOffsetSlice() {
+        assertFalse(Slice.createFromSource(source, BigInteger.valueOf(-1L), ONE).isPresent());
+    }
+
 }

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -113,7 +113,7 @@ public class SourceAndSliceTest {
 
     @Test
     public void startReadAtNegativeOffsetSource() {
-        thrown.expect(IllegalStateException.class);
+        thrown.expect(IllegalArgumentException.class);
         source.getData(BigInteger.valueOf(-1L), ONE);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -17,7 +17,9 @@
 package io.parsingdata.metal.token;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
+import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
@@ -46,10 +48,15 @@ public class DefTest {
     }
 
     @Test
-    public void emptyName() {
+    public void errorEmptyName() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument name may not be empty.");
         def("", 1);
+    }
+
+    @Test
+    public void errorNegativeSize() {
+        assertFalse(def("negativeSize", con(-1, signed())).parse(stream(1), enc()).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.token;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
@@ -33,6 +34,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 
 import java.io.IOException;
@@ -77,6 +79,11 @@ public class UntilTest {
     @Test
     public void allDefaultValueExpressions() throws IOException {
         assertTrue(until("value", def("terminator", 1, eq(con(0)))).parse(stream(1, 2, 3, 0), enc()).isPresent());
+    }
+
+    @Test
+    public void errorNegativeSize() {
+        assertFalse(until("value", con(-1, signed()), def("terminator", 1, eq(con(0)))).parse(stream(1, 2, 3, 0), enc()).isPresent());
     }
 
     private Token createToken(final ValueExpression initialSize, final Token terminator) {


### PR DESCRIPTION
Resolves #207.

This PR solves two different problems both related to the handling of negative offsets.

First is preventing the creation of an `Environment` with an `offset` field that holds a negative value. Some code reading revealed that this could occur through a call to the `.seek()` method or through invoking the top-level constructor, both by passing in a negative `offset` argument. Both cases have been fixed. This involved some tweaking of `Def`, `Sub` and `Until` to make them correctly handle error cases (instead of causing an exception to be thrown).

One issue to consider is that the `Environment` constructor now throws an exception while the `.seek()` method returns an `Optional.empty()`. I believe this is warranted because the former is a constructor. However, we can still fix this by changing the `Environment` class to have a private constructor and then handle creation of `Environment` objects through (a) factory method(s).

Second is no longer allowing a negative `offset` argument to the implementations of `Source.getData()`, as well as not allowing the creation of a `Slice` that starts at a negative offset.