### PR TITLE
Minor issues and gardening for upcoming 7.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script: mvn clean verify
 
 jdk:
   - oraclejdk8
+  - oraclejdk9
 
 before_install:
     - pip install --user codecov

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,10 +16,6 @@
     <url>https://github.com/parsingdata/metal.git</url>
   </scm>
 
-  <properties>
-    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/core/src/main/java/io/parsingdata/metal/Trampoline.java
+++ b/core/src/main/java/io/parsingdata/metal/Trampoline.java
@@ -37,23 +37,37 @@ public interface Trampoline<T> {
         return current.result();
     }
 
-    static <T> Trampoline<T> complete(final CompletedTrampoline<T> completedTrampoline) { return completedTrampoline; }
+    static <T> Trampoline<T> complete(final CompletedTrampoline<T> completedTrampoline) {
+        return completedTrampoline;
+    }
 
     @FunctionalInterface
     interface CompletedTrampoline<T> extends Trampoline<T> {
 
-        default boolean hasNext() { return false; }
-        default Trampoline<T> next() { throw new UnsupportedOperationException("A CompletedTrampoline does not have a next computation."); }
+        default boolean hasNext() {
+            return false;
+        }
+
+        default Trampoline<T> next() {
+            throw new UnsupportedOperationException("A CompletedTrampoline does not have a next computation.");
+        }
 
     }
 
-    static <T> Trampoline<T> intermediate(final IntermediateTrampoline<T> intermediateTrampoline) { return intermediateTrampoline; }
+    static <T> Trampoline<T> intermediate(final IntermediateTrampoline<T> intermediateTrampoline) {
+        return intermediateTrampoline;
+    }
 
     @FunctionalInterface
     interface IntermediateTrampoline<T> extends Trampoline<T> {
 
-        default T result() { throw new UnsupportedOperationException("An IntermediateTrampoline does not have a result."); }
-        default boolean hasNext() { return true; }
+        default T result() {
+            throw new UnsupportedOperationException("An IntermediateTrampoline does not have a result.");
+        }
+
+        default boolean hasNext() {
+            return true;
+        }
 
     }
 

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -39,20 +39,26 @@ public final class Util {
     final private static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray(); // Private because array content is mutable.
 
     public static <T>T checkNotNull(final T argument, final String name) {
-        if (argument == null) { throw new IllegalArgumentException("Argument " + name + " may not be null."); }
+        if (argument == null) {
+            throw new IllegalArgumentException("Argument " + name + " may not be null.");
+        }
         return argument;
     }
 
     public static <T>T[] checkContainsNoNulls(final T[] arguments, final String name) {
         checkNotNull(arguments, name);
         for (final T argument : arguments) {
-            if (argument == null) { throw new IllegalArgumentException("Value in array " + name + " may not be null."); }
+            if (argument == null) {
+                throw new IllegalArgumentException("Value in array " + name + " may not be null.");
+            }
         }
         return arguments;
     }
 
     public static String checkNotEmpty(final String argument, final String name) {
-        if (checkNotNull(argument, name).isEmpty()) { throw new IllegalArgumentException("Argument " + name + " may not be empty."); }
+        if (checkNotNull(argument, name).isEmpty()) {
+            throw new IllegalArgumentException("Argument " + name + " may not be empty.");
+        }
         return argument;
     }
 
@@ -62,7 +68,9 @@ public final class Util {
     }
 
     public static BigInteger checkNotNegative(final BigInteger argument, final String name) {
-        if (checkNotNull(argument, name).compareTo(ZERO) < 0) { throw new IllegalArgumentException("Argument " + name + " may not be negative."); }
+        if (checkNotNull(argument, name).compareTo(ZERO) < 0) {
+            throw new IllegalArgumentException("Argument " + name + " may not be negative.");
+        }
         return argument;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -16,8 +16,6 @@
 
 package io.parsingdata.metal.data;
 
-import static java.math.BigInteger.ZERO;
-
 import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
 
@@ -38,7 +36,9 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(checkNotNegative(offset, "offset"), length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (!isAvailable(checkNotNegative(offset, "offset"), length)) {
+            throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
+        }
         try {
             return input.read(offset, length.intValueExact());
         } catch (final IOException exception) {

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -16,8 +16,6 @@
 
 package io.parsingdata.metal.data;
 
-import static java.math.BigInteger.ZERO;
-
 import static io.parsingdata.metal.Util.bytesToHexString;
 import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
@@ -38,7 +36,9 @@ public class ConstantSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(checkNotNegative(offset, "offset"), length)) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (!isAvailable(checkNotNegative(offset, "offset"), length)) {
+            throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
+        }
         final byte[] outputData = new byte[length.intValueExact()];
         System.arraycopy(data, offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -16,8 +16,6 @@
 
 package io.parsingdata.metal.data;
 
-import static java.math.BigInteger.ZERO;
-
 import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNegative;
@@ -51,7 +49,9 @@ public class DataExpressionSource extends Source {
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
         checkNotNegative(offset, "offset");
         final Value inputValue = getValue();
-        if (length.add(offset).compareTo(inputValue.slice.length) > 0) { throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ")."); }
+        if (length.add(offset).compareTo(inputValue.slice.length) > 0) {
+            throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
+        }
         final byte[] outputData = new byte[length.intValueExact()];
         System.arraycopy(inputValue.getValue(), offset.intValueExact(), outputData, 0, outputData.length);
         return outputData;
@@ -64,12 +64,18 @@ public class DataExpressionSource extends Source {
 
     private Value getValue() {
         final ImmutableList<Optional<Value>> results = dataExpression.eval(graph, encoding);
-        if (results.size <= index) { throw new IllegalStateException("ValueExpression dataExpression yields " + results.size + " result(s) (expected at least " + (index + 1) + ")."); }
-        return getValueAtIndex(results, index, 0).computeResult().orElseThrow(() -> new IllegalStateException("ValueExpression dataExpression yields empty Value at index " + index + "."));
+        if (results.size <= index) {
+            throw new IllegalStateException("ValueExpression dataExpression yields " + results.size + " result(s) (expected at least " + (index + 1) + ").");
+        }
+        return getValueAtIndex(results, index, 0)
+            .computeResult()
+            .orElseThrow(() -> new IllegalStateException("ValueExpression dataExpression yields empty Value at index " + index + "."));
     }
 
     private Trampoline<Optional<Value>> getValueAtIndex(final ImmutableList<Optional<Value>> results, final int index, final int current) {
-        if (index == current) { return complete(() -> results.head); }
+        if (index == current) {
+            return complete(() -> results.head);
+        }
         return intermediate(() -> getValueAtIndex(results.tail, index, current + 1));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/data/ImmutableList.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ImmutableList.java
@@ -53,7 +53,9 @@ public class ImmutableList<T> {
     }
 
     private static <T> Trampoline<ImmutableList<T>> createFromArray(final ImmutableList<T> list, final T[] array, final int index) {
-        if (index < 0) { return complete(() -> list); }
+        if (index < 0) {
+            return complete(() -> list);
+        }
         return intermediate(() -> createFromArray(list.add(array[index]), array, index - 1));
     }
 
@@ -63,16 +65,22 @@ public class ImmutableList<T> {
 
     public ImmutableList<T> add(final ImmutableList<T> list) {
         checkNotNull(list, "list");
-        if (isEmpty()) { return list; }
+        if (isEmpty()) {
+            return list;
+        }
         return addRecursive(reverse(list)).computeResult();
     }
 
     private Trampoline<ImmutableList<T>> addRecursive(final ImmutableList<T> list) {
-        if (list.isEmpty()) { return complete(() -> this); }
+        if (list.isEmpty()) {
+            return complete(() -> this);
+        }
         return intermediate(() -> add(list.head).addRecursive(list.tail));
     }
 
-    public boolean isEmpty() { return size == 0; }
+    public boolean isEmpty() {
+        return size == 0;
+    }
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -85,7 +85,9 @@ public class ParseGraph implements ParseItem {
     }
 
     ParseGraph closeBranch() {
-        if (!branched) { throw new IllegalStateException("Cannot close branch that is not open."); }
+        if (!branched) {
+            throw new IllegalStateException("Cannot close branch that is not open.");
+        }
         if (head.asGraph().branched) {
             return new ParseGraph(head.asGraph().closeBranch(), tail, definition, true);
         }
@@ -102,9 +104,13 @@ public class ParseGraph implements ParseItem {
     }
 
     private Trampoline<Optional<ParseValue>> current(final ImmutableList<ParseItem> items) {
-        if (items.isEmpty()) { return complete(Optional::empty); }
+        if (items.isEmpty()) {
+            return complete(Optional::empty);
+        }
         final ParseItem item = items.head;
-        if (item.isValue()) { return complete(() -> Optional.of(item.asValue())); }
+        if (item.isValue()) {
+            return complete(() -> Optional.of(item.asValue()));
+        }
         if (item.isGraph() && !item.asGraph().isEmpty()) {
             return intermediate(() -> current(items.tail.add(item.asGraph().tail)
                                                         .add(item.asGraph().head)));
@@ -118,7 +124,9 @@ public class ParseGraph implements ParseItem {
 
     @Override
     public String toString() {
-        if (this == EMPTY) { return "pg(EMPTY)"; }
+        if (this == EMPTY) {
+            return "pg(EMPTY)";
+        }
         if (head == null) {
             return "pg(terminator:" + definition.getClass().getSimpleName() + ")";
         }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -63,14 +63,14 @@ public class ParseGraph implements ParseItem {
         this(head, tail, definition, false);
     }
 
-    public ParseGraph add(final ParseValue head) {
+    ParseGraph add(final ParseValue head) {
         if (branched) {
             return new ParseGraph(this.head.asGraph().add(head), tail, definition, true);
         }
         return new ParseGraph(head, this, definition);
     }
 
-    public ParseGraph add(final ParseReference parseReference) {
+    ParseGraph add(final ParseReference parseReference) {
         if (branched) {
             return new ParseGraph(head.asGraph().add(parseReference), tail, definition, true);
         }

--- a/core/src/main/java/io/parsingdata/metal/data/Selection.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Selection.java
@@ -40,12 +40,18 @@ public final class Selection {
     public static Trampoline<Optional<ParseItem>> findItemAtOffset(final ImmutableList<ParseItem> items, final BigInteger offset, final Source source) {
         checkNotNull(items, "items");
         checkNotNull(source, "source");
-        if (items.isEmpty()) { return complete(Optional::empty); }
+        if (items.isEmpty()) {
+            return complete(Optional::empty);
+        }
         final ParseItem head = items.head;
-        if (head.isValue() && matchesLocation(head.asValue(), offset, source)) { return complete(() -> Optional.of(head)); }
+        if (head.isValue() && matchesLocation(head.asValue(), offset, source)) {
+            return complete(() -> Optional.of(head));
+        }
         if (head.isGraph()) {
             final ParseValue value = getLowestOffsetValue(ImmutableList.create(head.asGraph()), null).computeResult();
-            if (value != null && matchesLocation(value, offset, source)) { return complete(() -> Optional.of(head)); }
+            if (value != null && matchesLocation(value, offset, source)) {
+                return complete(() -> Optional.of(head));
+            }
         }
         return intermediate(() -> findItemAtOffset(items.tail, offset, source));
     }
@@ -55,7 +61,9 @@ public final class Selection {
     }
 
     private static Trampoline<ParseValue> getLowestOffsetValue(final ImmutableList<ParseGraph> graphList, final ParseValue lowest) {
-        if (graphList.isEmpty()) { return complete(() -> lowest); }
+        if (graphList.isEmpty()) {
+            return complete(() -> lowest);
+        }
         final ParseGraph graph = graphList.head;
         if (graph.isEmpty() || !graph.getDefinition().isLocal()) {
             return intermediate(() -> getLowestOffsetValue(graphList.tail, lowest));
@@ -85,7 +93,9 @@ public final class Selection {
     }
 
     private static Trampoline<ImmutableList<ParseValue>> getAllValues(final ImmutableList<ParseGraph> graphList, final ImmutableList<ParseValue> valueList, final Predicate<ParseValue> predicate, final int limit) {
-        if (graphList.isEmpty() || valueList.size == limit) { return complete(() -> valueList); }
+        if (graphList.isEmpty() || valueList.size == limit) {
+            return complete(() -> valueList);
+        }
         final ParseGraph graph = graphList.head;
         if (graph.isEmpty()) {
             return intermediate(() -> getAllValues(graphList.tail, valueList, predicate, limit));
@@ -97,17 +107,23 @@ public final class Selection {
     }
 
     private static ImmutableList<ParseValue> addIfMatchingValue(final ImmutableList<ParseValue> valueList, final ParseItem item, final Predicate<ParseValue> predicate) {
-        if (item.isValue() && predicate.test(item.asValue())) { return valueList.add(item.asValue()); }
+        if (item.isValue() && predicate.test(item.asValue())) {
+            return valueList.add(item.asValue());
+        }
         return valueList;
     }
 
     public static <T> ImmutableList<T> reverse(final ImmutableList<T> list) {
-        if (list.isEmpty()) { return list; }
+        if (list.isEmpty()) {
+            return list;
+        }
         return reverse(list.tail, ImmutableList.create(list.head)).computeResult();
     }
 
     private static <T> Trampoline<ImmutableList<T>> reverse(final ImmutableList<T> oldList, final ImmutableList<T> newList) {
-        if (oldList.isEmpty()) { return complete(() -> newList); }
+        if (oldList.isEmpty()) {
+            return complete(() -> newList);
+        }
         return intermediate(() -> reverse(oldList.tail, newList.add(oldList.head)));
     }
 
@@ -116,7 +132,9 @@ public final class Selection {
     }
 
     private static Trampoline<ImmutableList<ParseItem>> getAllRootsRecursive(final ImmutableList<Pair> backlog, final Token definition, final ImmutableList<ParseItem> rootList) {
-        if (backlog.isEmpty()) { return complete(() -> rootList); }
+        if (backlog.isEmpty()) {
+            return complete(() -> rootList);
+        }
         final ParseItem item = backlog.head.item;
         final ParseGraph parent = backlog.head.parent;
         final ImmutableList<ParseItem> nextResult = item.getDefinition().equals(definition) && (parent == null || !parent.getDefinition().equals(definition)) ? rootList.add(item) : rootList;

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -41,7 +41,9 @@ public class Slice {
     public static Optional<Slice> createFromSource(final Source source, final BigInteger offset, final BigInteger length) {
         if (offset.compareTo(ZERO) < 0 ||
             checkNotNull(length, "length").compareTo(ZERO) < 0 ||
-            !checkNotNull(source, "source").isAvailable(offset, length)) { return Optional.empty(); }
+            !checkNotNull(source, "source").isAvailable(offset, length)) {
+            return Optional.empty();
+        }
         return Optional.of(new Slice(source, offset, length));
     }
 
@@ -54,7 +56,9 @@ public class Slice {
     }
 
     public byte[] getData(final BigInteger limit) {
-        if (limit.compareTo(ZERO) < 0) { throw new IllegalArgumentException("Argument limit may not be negative."); }
+        if (limit.compareTo(ZERO) < 0) {
+            throw new IllegalArgumentException("Argument limit may not be negative.");
+        }
         final BigInteger calculatedLength = limit.compareTo(length) > 0 ? length : limit;
         return source.getData(offset, calculatedLength);
     }

--- a/core/src/main/java/io/parsingdata/metal/data/callback/Callbacks.java
+++ b/core/src/main/java/io/parsingdata/metal/data/callback/Callbacks.java
@@ -39,7 +39,9 @@ public class Callbacks {
         this.tokenCallbacks = checkNotNull(tokenCallbacks, "tokenCallbacks");
     }
 
-    public static Callbacks create() { return NONE; }
+    public static Callbacks create() {
+        return NONE;
+    }
 
     public Callbacks add(final Callback genericCallback) {
         return new Callbacks(genericCallback, tokenCallbacks);
@@ -57,7 +59,9 @@ public class Callbacks {
     }
 
     private Trampoline<Void> handleCallbacks(final ImmutableList<TokenCallback> callbacks, final Token token, final Environment before, final Optional<Environment> after) {
-        if (callbacks.isEmpty()) { return complete(() -> null); }
+        if (callbacks.isEmpty()) {
+            return complete(() -> null);
+        }
         if (callbacks.head.token.equals(token)) {
             callbacks.head.callback.handle(token, before, after);
         }

--- a/core/src/main/java/io/parsingdata/metal/expression/True.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/True.java
@@ -27,7 +27,9 @@ import io.parsingdata.metal.encoding.Encoding;
 public class True implements Expression {
 
     @Override
-    public boolean eval(final ParseGraph graph, final Encoding encoding) { return true; }
+    public boolean eval(final ParseGraph graph, final Encoding encoding) {
+        return true;
+    }
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -60,16 +60,24 @@ public abstract class ComparisonExpression implements Expression {
     @Override
     public boolean eval(final ParseGraph graph, final Encoding encoding) {
         final ImmutableList<Optional<Value>> values = value == null ? ImmutableList.create(graph.current().map(identity())) : value.eval(graph, encoding);
-        if (values.isEmpty()) { return false; }
+        if (values.isEmpty()) {
+            return false;
+        }
         final ImmutableList<Optional<Value>> predicates = predicate.eval(graph, encoding);
-        if (values.size != predicates.size) { return false; }
+        if (values.size != predicates.size) {
+            return false;
+        }
         return compare(values, predicates).computeResult();
     }
 
     private Trampoline<Boolean> compare(final ImmutableList<Optional<Value>> currents, final ImmutableList<Optional<Value>> predicates) {
-        if (!currents.head.isPresent() || !predicates.head.isPresent()) { return complete(() -> false); }
+        if (!currents.head.isPresent() || !predicates.head.isPresent()) {
+            return complete(() -> false);
+        }
         final boolean headResult = compare(currents.head.get(), predicates.head.get());
-        if (!headResult || currents.tail.isEmpty()) { return complete(() -> headResult); }
+        if (!headResult || currents.tail.isEmpty()) {
+            return complete(() -> headResult);
+        }
         return intermediate(() -> compare(currents.tail, predicates.tail));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
@@ -40,9 +40,13 @@ public class Eq extends ComparisonExpression {
     public boolean compare(final Value left, final Value right) {
         final byte[] leftBytes = left.getValue();
         final byte[] rightBytes = right.getValue();
-        if (leftBytes.length != rightBytes.length) { return false; }
+        if (leftBytes.length != rightBytes.length) {
+            return false;
+        }
         for (int i = 0; i < leftBytes.length; i++) {
-            if (leftBytes[i] != rightBytes[i]) { return false; }
+            if (leftBytes[i] != rightBytes[i]) {
+                return false;
+            }
         }
         return true;
     }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/Eq.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.comparison;
 
+import java.util.Arrays;
+
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -38,17 +40,8 @@ public class Eq extends ComparisonExpression {
 
     @Override
     public boolean compare(final Value left, final Value right) {
-        final byte[] leftBytes = left.getValue();
-        final byte[] rightBytes = right.getValue();
-        if (leftBytes.length != rightBytes.length) {
-            return false;
-        }
-        for (int i = 0; i < leftBytes.length; i++) {
-            if (leftBytes[i] != rightBytes[i]) {
-                return false;
-            }
-        }
-        return true;
+        return left.slice.length.compareTo(right.slice.length) == 0
+            && Arrays.equals(left.getValue(), right.getValue());
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -74,7 +74,7 @@ public abstract class BinaryValueExpression implements ValueExpression {
         if (leftValues.isEmpty() || rightValues.isEmpty()) {
             return complete(() -> result);
         }
-        return intermediate(() -> evalLists(leftValues.tail, rightValues.tail, graph, encoding, result.add(eval(leftValues.head, rightValues.head, graph, encoding))));
+        return intermediate(() -> evalLists(leftValues.tail, rightValues.tail, graph, encoding, result.add(leftValues.head.flatMap(left -> rightValues.head.flatMap(right -> eval(left, right, graph, encoding))))));
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> padList(final ImmutableList<Optional<Value>> list, final long size) {
@@ -82,13 +82,6 @@ public abstract class BinaryValueExpression implements ValueExpression {
             return complete(() -> list);
         }
         return intermediate(() -> padList(list.add(Optional.empty()), size - 1));
-    }
-
-    private Optional<Value> eval(final Optional<Value> left, final Optional<Value> right, final ParseGraph graph, final Encoding encoding) {
-        if (!left.isPresent() || !right.isPresent()) {
-            return Optional.empty();
-        }
-        return eval(left.get(), right.get(), graph, encoding);
     }
 
     public abstract Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -71,17 +71,23 @@ public abstract class BinaryValueExpression implements ValueExpression {
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> evalLists(final ImmutableList<Optional<Value>> leftValues, final ImmutableList<Optional<Value>> rightValues, final ParseGraph graph, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
-        if (leftValues.isEmpty() || rightValues.isEmpty()) { return complete(() -> result); }
+        if (leftValues.isEmpty() || rightValues.isEmpty()) {
+            return complete(() -> result);
+        }
         return intermediate(() -> evalLists(leftValues.tail, rightValues.tail, graph, encoding, result.add(eval(leftValues.head, rightValues.head, graph, encoding))));
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> padList(final ImmutableList<Optional<Value>> list, final long size) {
-        if (size <= 0) { return complete(() -> list); }
+        if (size <= 0) {
+            return complete(() -> list);
+        }
         return intermediate(() -> padList(list.add(Optional.empty()), size - 1));
     }
 
     private Optional<Value> eval(final Optional<Value> left, final Optional<Value> right, final ParseGraph graph, final Encoding encoding) {
-        if (!left.isPresent() || !right.isPresent()) { return Optional.empty(); }
+        if (!left.isPresent() || !right.isPresent()) {
+            return Optional.empty();
+        }
         return eval(left.get(), right.get(), graph, encoding);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -55,7 +55,9 @@ public class Bytes implements ValueExpression {
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
         final ImmutableList<Optional<Value>> input = operand.eval(graph, encoding);
-        if (input.isEmpty()) { return input; }
+        if (input.isEmpty()) {
+            return input;
+        }
         return toBytes(new ImmutableList<>(), input.head, input.tail, encoding).computeResult();
     }
 
@@ -67,7 +69,9 @@ public class Bytes implements ValueExpression {
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> bytesToValues(final ImmutableList<Optional<Value>> output, final byte[] value, final int i, final Encoding encoding) {
-        if (i >= value.length) { return complete(() -> output); }
+        if (i >= value.length) {
+            return complete(() -> output);
+        }
         return intermediate(() -> bytesToValues(output.add(Optional.of(new Value(createFromBytes(new byte[] { value[i] }), encoding))), value, i + 1, encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ConstantFactory.java
@@ -56,8 +56,9 @@ public final class ConstantFactory {
     }
 
     private static byte[] compact(final byte[] data, final boolean signed) {
-        if (signed) { return data; }
-        if (data.length < 2) { return data; }
+        if (signed || data.length < 2) {
+            return data;
+        }
         // Strip possible leading zero byte.
         if (data[0] == 0) {
             final byte[] outBytes = new byte[data.length - 1];

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -58,8 +58,12 @@ public class Elvis implements ValueExpression {
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> result, final ImmutableList<Optional<Value>> leftValues, final ImmutableList<Optional<Value>> rightValues) {
-        if (leftValues.isEmpty()) { return complete(() -> result.add(reverse(rightValues))); }
-        if (rightValues.isEmpty()) { return complete(() -> result.add(reverse(leftValues))); }
+        if (leftValues.isEmpty()) {
+            return complete(() -> result.add(reverse(rightValues)));
+        }
+        if (rightValues.isEmpty()) {
+            return complete(() -> result.add(reverse(leftValues)));
+        }
         return intermediate(() -> eval(result.add(leftValues.head.isPresent() ? leftValues.head : rightValues.head), leftValues.tail, rightValues.tail));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -53,14 +53,20 @@ public class Expand implements ValueExpression {
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
         final ImmutableList<Optional<Value>> base = this.base.eval(graph, encoding);
-        if (base.isEmpty()) { return base; }
+        if (base.isEmpty()) {
+            return base;
+        }
         final ImmutableList<Optional<Value>> count = this.count.eval(graph, encoding);
-        if (count.size != 1 || !count.head.isPresent()) { throw new IllegalArgumentException("Count must evaluate to a single non-empty value."); }
+        if (count.size != 1 || !count.head.isPresent()) {
+            throw new IllegalArgumentException("Count must evaluate to a single non-empty value.");
+        }
         return expand(base, count.head.get().asNumeric().intValueExact(), new ImmutableList<>()).computeResult();
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> expand(final ImmutableList<Optional<Value>> base, final int count, final ImmutableList<Optional<Value>> aggregate) {
-        if (count < 1) { return complete(() -> aggregate); }
+        if (count < 1) {
+            return complete(() -> aggregate);
+        }
         return intermediate(() -> expand(base, count - 1, aggregate.add(base)));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -59,9 +59,13 @@ public abstract class Fold implements ValueExpression {
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
         final ImmutableList<Optional<Value>> initial = this.initial != null ? this.initial.eval(graph, encoding) : new ImmutableList<>();
-        if (initial.size > 1) { return new ImmutableList<>(); }
+        if (initial.size > 1) {
+            return new ImmutableList<>();
+        }
         final ImmutableList<Optional<Value>> values = prepareValues(this.values.eval(graph, encoding));
-        if (values.isEmpty() || containsEmpty(values).computeResult()) { return initial; }
+        if (values.isEmpty() || containsEmpty(values).computeResult()) {
+            return initial;
+        }
         if (!initial.isEmpty()) {
             return ImmutableList.create(fold(graph, encoding, reducer, initial.head, values).computeResult());
         }
@@ -69,15 +73,23 @@ public abstract class Fold implements ValueExpression {
     }
 
     private Trampoline<Optional<Value>> fold(final ParseGraph graph, final Encoding encoding, final BinaryOperator<ValueExpression> reducer, final Optional<Value> head, final ImmutableList<Optional<Value>> tail) {
-        if (!head.isPresent() || tail.isEmpty()) { return complete(() -> head); }
+        if (!head.isPresent() || tail.isEmpty()) {
+            return complete(() -> head);
+        }
         final ImmutableList<Optional<Value>> reducedValue = reduce(reducer, head.get(), tail.head.get()).eval(graph, encoding);
-        if (reducedValue.size != 1) { throw new IllegalArgumentException("Reducer must evaluate to a single value."); }
+        if (reducedValue.size != 1) {
+            throw new IllegalArgumentException("Reducer must evaluate to a single value.");
+        }
         return intermediate(() -> fold(graph, encoding, reducer, reducedValue.head, tail.tail));
     }
 
     private Trampoline<Boolean> containsEmpty(final ImmutableList<Optional<Value>> list) {
-        if (list.isEmpty()) { return complete(() -> false); }
-        if (!list.head.isPresent()) { return complete(() -> true); }
+        if (list.isEmpty()) {
+            return complete(() -> false);
+        }
+        if (!list.head.isPresent()) {
+            return complete(() -> true);
+        }
         return intermediate(() -> containsEmpty(list.tail));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -59,7 +59,9 @@ public abstract class UnaryValueExpression implements ValueExpression {
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ParseGraph graph, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
-        if (values.isEmpty()) { return complete(() -> result); }
+        if (values.isEmpty()) {
+            return complete(() -> result);
+        }
         return intermediate(() -> eval(values.tail, graph, encoding, result.add(values.head.flatMap(value -> eval(value, graph, encoding)))));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -63,7 +63,9 @@ public class Nth implements ValueExpression {
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ImmutableList<Optional<Value>> indices, final ImmutableList<Optional<Value>> result) {
-        if (indices.isEmpty()) { return complete(() -> result); }
+        if (indices.isEmpty()) {
+            return complete(() -> result);
+        }
         if (indices.head.isPresent()) {
             final BigInteger index = indices.head.get().asNumeric();
             final BigInteger valueCount = BigInteger.valueOf(values.size);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -66,14 +66,11 @@ public class Nth implements ValueExpression {
         if (indices.isEmpty()) {
             return complete(() -> result);
         }
-        if (indices.head.isPresent()) {
-            final BigInteger index = indices.head.get().asNumeric();
-            final BigInteger valueCount = BigInteger.valueOf(values.size);
-            if (index.compareTo(valueCount) < 0 && index.compareTo(ZERO) >= 0) {
-                return intermediate(() -> eval(values, indices.tail, result.add(nth(values, valueCount.subtract(index).subtract(ONE)).computeResult())));
-            }
-        }
-        return intermediate(() -> eval(values, indices.tail, result.add(Optional.empty())));
+        final BigInteger valueCount = BigInteger.valueOf(values.size);
+        final Optional<Value> nextResult = indices.head
+            .filter(index -> index.asNumeric().compareTo(valueCount) < 0 && index.asNumeric().compareTo(ZERO) >= 0)
+            .flatMap(index -> nth(values, valueCount.subtract(index.asNumeric()).subtract(ONE)).computeResult());
+        return intermediate(() -> eval(values, indices.tail, result.add(nextResult)));
     }
 
     private Trampoline<Optional<Value>> nth(final ImmutableList<Optional<Value>> values, final BigInteger index) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -69,9 +69,13 @@ public class Ref<T> implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        if (limit == null) { return evalImpl(graph, NO_LIMIT); }
+        if (limit == null) {
+            return evalImpl(graph, NO_LIMIT);
+        }
         ImmutableList<Optional<Value>> evaluatedLimit = limit.eval(graph, encoding);
-        if (evaluatedLimit.size != 1 || !evaluatedLimit.head.isPresent()) { throw new IllegalArgumentException("Limit must evaluate to a single non-empty value."); }
+        if (evaluatedLimit.size != 1 || !evaluatedLimit.head.isPresent()) {
+            throw new IllegalArgumentException("Limit must evaluate to a single non-empty value.");
+        }
         return evalImpl(graph, evaluatedLimit.head.get().asNumeric().intValueExact());
     }
 
@@ -80,7 +84,9 @@ public class Ref<T> implements ValueExpression {
     }
 
     private static <T, U extends T> Trampoline<ImmutableList<Optional<T>>> wrap(final ImmutableList<U> input, final ImmutableList<Optional<T>> output) {
-        if (input.isEmpty()) { return complete(() -> output); }
+        if (input.isEmpty()) {
+            return complete(() -> output);
+        }
         return intermediate(() -> wrap(input.tail, output.add(Optional.of(input.head))));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -59,7 +59,8 @@ public class Cho extends Token {
         if (list.isEmpty()) {
             return complete(Util::failure);
         }
-        return list.head.parse(scope, environment, encoding)
+        return list.head
+            .parse(scope, environment, encoding)
             .map(result -> complete(() -> success(result.closeBranch())))
             .orElseGet(() -> intermediate(() -> iterate(scope, environment, encoding, list.tail)));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -61,10 +61,13 @@ public class Def extends Token {
         if (sizes.size != 1 || !sizes.head.isPresent()) {
             return failure();
         }
-        final BigInteger dataSize = sizes.head.get().asNumeric();
-        if (dataSize.compareTo(ZERO) == 0) {
-            return success(environment);
-        }
+        return sizes.head
+            .filter(dataSize -> dataSize.asNumeric().compareTo(ZERO) != 0)
+            .map(dataSize -> slice(scope, environment, encoding, dataSize.asNumeric()))
+            .orElseGet(() -> success(environment));
+    }
+
+    private Optional<Environment> slice(final String scope, final Environment environment, final Encoding encoding, final BigInteger dataSize) {
         return environment
             .slice(dataSize)
             .map(slice -> environment.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(environment.offset)))

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -27,6 +27,7 @@ import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
@@ -67,7 +68,7 @@ public class Def extends Token {
         return environment
             .slice(dataSize)
             .map(slice -> environment.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(environment.offset)))
-            .orElse(failure());
+            .orElseGet(Util::failure);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Post.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Post.java
@@ -52,7 +52,8 @@ public class Post extends Token {
 
     @Override
     protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
-        return token.parse(scope, environment.addBranch(this), encoding)
+        return token
+            .parse(scope, environment.addBranch(this), encoding)
             .map(nextEnvironment -> predicate.eval(nextEnvironment.order, encoding) ? success(nextEnvironment.closeBranch()) : failure())
             .orElseGet(Util::failure);
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -56,7 +56,8 @@ public class Pre extends Token {
         if (!predicate.eval(environment.order, encoding)) {
             return failure();
         }
-        return token.parse(scope, environment.addBranch(this), encoding)
+        return token
+            .parse(scope, environment.addBranch(this), encoding)
             .map(resultEnvironment -> success(resultEnvironment.closeBranch()))
             .orElseGet(Util::failure);
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Rep.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Rep.java
@@ -52,7 +52,8 @@ public class Rep extends Token {
     }
 
     private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding) {
-        return token.parse(scope, environment, encoding)
+        return token
+            .parse(scope, environment, encoding)
             .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding)))
             .orElseGet(() -> complete(() -> success(environment.closeBranch())));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -69,7 +69,8 @@ public class RepN extends Token {
         if (count <= 0) {
             return complete(() -> success(environment.closeBranch()));
         }
-        return token.parse(scope, environment, encoding)
+        return token
+            .parse(scope, environment, encoding)
             .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding, count - 1)))
             .orElseGet(() -> complete(Util::failure));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -59,7 +59,8 @@ public class Seq extends Token {
         if (list.isEmpty()) {
             return complete(() -> success(environment.closeBranch()));
         }
-        return list.head.parse(scope, environment, encoding)
+        return list.head
+            .parse(scope, environment, encoding)
             .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding, list.tail)))
             .orElseGet(() -> complete(Util::failure));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -90,7 +90,7 @@ public class Sub extends Token {
         return environment
             .seek(offset)
             .map(newEnvironment -> token.parse(scope, newEnvironment, encoding))
-            .orElse(failure());
+            .orElseGet(Util::failure);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -76,10 +76,8 @@ public class Sub extends Token {
         if (addresses.isEmpty()) {
             return complete(() -> success(environment.closeBranch()));
         }
-        if (!addresses.head.isPresent()) {
-            return complete(Util::failure);
-        }
-        return parse(scope, addresses.head.get().asNumeric(), environment, encoding)
+        return addresses.head
+            .flatMap(address -> parse(scope, address.asNumeric(), environment, encoding))
             .map(nextEnvironment -> intermediate(() -> iterate(scope, addresses.tail, nextEnvironment, encoding)))
             .orElseGet(() -> complete(Util::failure));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -67,7 +67,8 @@ public class Sub extends Token {
         if (addresses.isEmpty()) {
             return failure();
         }
-        return iterate(scope, addresses, environment.addBranch(this), encoding).computeResult()
+        return iterate(scope, addresses, environment.addBranch(this), encoding)
+            .computeResult()
             .flatMap(nextEnvironment -> nextEnvironment.seek(environment.offset));
     }
 
@@ -94,7 +95,9 @@ public class Sub extends Token {
     }
 
     @Override
-    public boolean isLocal() { return false; }
+    public boolean isLocal() {
+        return false;
+    }
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/token/Tie.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Tie.java
@@ -74,7 +74,8 @@ public class Tie extends Token {
         if (!values.head.isPresent()) {
             return complete(Util::failure);
         }
-        return token.parse(scope, environment.source(dataExpression, index, environment, encoding), encoding)
+        return token
+            .parse(scope, environment.source(dataExpression, index, environment, encoding), encoding)
             .map(nextEnvironment -> intermediate(() -> iterate(scope, values.tail, index + 1, returnEnvironment, nextEnvironment, encoding)))
             .orElseGet(() -> complete(Util::failure));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -78,9 +78,13 @@ public abstract class Token {
         return scope + (scope.isEmpty() || name.isEmpty() ? NO_NAME : SEPARATOR) + name;
     }
 
-    public boolean isLocal() { return true; }
+    public boolean isLocal() {
+        return true;
+    }
 
-    public Token getCanonical(final Environment environment) { return this; }
+    public Token getCanonical(final Environment environment) {
+        return this;
+    }
 
     protected String makeNameFragment() {
         return name.isEmpty() ? NO_NAME : name + ",";

--- a/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
@@ -55,7 +55,9 @@ public class TokenRef extends Token {
     public TokenRef(final String name, final String referenceName, final Encoding encoding) {
         super(name, encoding);
         this.referenceName = checkNotNull(referenceName, "referenceName");
-        if (referenceName.isEmpty()) { throw new IllegalArgumentException("Argument referenceName may not be empty."); }
+        if (referenceName.isEmpty()) {
+            throw new IllegalArgumentException("Argument referenceName may not be empty.");
+        }
     }
 
     @Override
@@ -64,9 +66,13 @@ public class TokenRef extends Token {
     }
 
     private Trampoline<Token> lookup(final ImmutableList<ParseItem> items, final String referenceName) {
-        if (items.isEmpty()) { return complete(() -> LOOKUP_FAILED); }
+        if (items.isEmpty()) {
+            return complete(() -> LOOKUP_FAILED);
+        }
         final ParseItem item = items.head;
-        if (item.getDefinition().name.equals(referenceName)) { return complete(item::getDefinition); }
+        if (item.getDefinition().name.equals(referenceName)) {
+            return complete(item::getDefinition);
+        }
         if (item.isGraph() && !item.asGraph().isEmpty()) {
             return intermediate(() -> lookup(items.tail.add(item.asGraph().tail).add(item.asGraph().head), referenceName));
         }

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -103,13 +103,13 @@ public class Until extends Token {
         return environment
             .slice(currentSize)
             .map(slice -> parseSlice(scope, environment, currentSize, stepSize, maxSize, encoding, slice))
-            .orElse(complete(Util::failure));
+            .orElseGet(() -> complete(Util::failure));
     }
 
     private Trampoline<Optional<Environment>> parseSlice(String scope, Environment environment, BigInteger currentSize, BigInteger stepSize, BigInteger maxSize, Encoding encoding, Slice slice) {
         return (currentSize.compareTo(ZERO) == 0 ? Optional.of(environment) : environment.add(new ParseValue(name, this, slice, encoding)).seek(environment.offset.add(currentSize)))
             .map(preparedEnvironment -> terminator.parse(scope, preparedEnvironment, encoding))
-            .orElse(failure())
+            .orElseGet(Util::failure)
             .map(parsedEnvironment -> complete(() -> success(parsedEnvironment)))
             .orElseGet(() -> intermediate(() -> iterate(scope, environment, currentSize.add(stepSize), stepSize, maxSize, encoding)));
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -23,7 +23,6 @@ import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotEmpty;
 import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.Util.failure;
 import static io.parsingdata.metal.Util.success;
 
 import java.math.BigInteger;
@@ -90,8 +89,11 @@ public class Until extends Token {
     }
 
     private Trampoline<Optional<Environment>> handleInterval(final String scope, final Environment environment, final ImmutableList<Optional<Value>> initialSizes, final ImmutableList<Optional<Value>> stepSizes, final ImmutableList<Optional<Value>> maxSizes, final Encoding encoding) {
-        if (checkNotValidList(initialSizes) || checkNotValidList(stepSizes) || checkNotValidList(maxSizes)) { return complete(Util::failure); }
-        return iterate(scope, environment, getNumeric(initialSizes), getNumeric(stepSizes), getNumeric(maxSizes), encoding).computeResult()
+        if (checkNotValidList(initialSizes) || checkNotValidList(stepSizes) || checkNotValidList(maxSizes)) {
+            return complete(Util::failure);
+        }
+        return iterate(scope, environment, getNumeric(initialSizes), getNumeric(stepSizes), getNumeric(maxSizes), encoding)
+            .computeResult()
             .map(nextEnvironment -> complete(() -> success(nextEnvironment)))
             .orElseGet(() -> intermediate(() -> handleInterval(scope, environment, initialSizes.tail, stepSizes.tail, maxSizes.tail, encoding)));
     }
@@ -99,7 +101,9 @@ public class Until extends Token {
     private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final BigInteger currentSize, final BigInteger stepSize, final BigInteger maxSize, final Encoding encoding) {
         if (stepSize.compareTo(ZERO) == 0 ||
             stepSize.compareTo(ZERO) > 0 && currentSize.compareTo(maxSize) > 0 ||
-            stepSize.compareTo(ZERO) < 0 && currentSize.compareTo(maxSize) < 0) { return complete(Util::failure); }
+            stepSize.compareTo(ZERO) < 0 && currentSize.compareTo(maxSize) < 0) {
+            return complete(Util::failure);
+        }
         return environment
             .slice(currentSize)
             .map(slice -> parseSlice(scope, environment, currentSize, stepSize, maxSize, encoding, slice))

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -62,7 +62,8 @@ public class While extends Token {
 
     private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding) {
         if (predicate.eval(environment.order, encoding)) {
-            return token.parse(scope, environment, encoding)
+            return token
+                .parse(scope, environment, encoding)
                 .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding)))
                 .orElseGet(() -> complete(Util::failure));
         }

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -124,7 +124,7 @@ public class AutoEqualityTest {
     };
 
     private static final ParseValue PARSEVALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-    private static final ParseGraph GRAPH_WITH_REFERENCE = ParseGraph.EMPTY.add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a")));
+    private static final ParseGraph GRAPH_WITH_REFERENCE = new Environment(DUMMY_STREAM).add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a"))).order;
     private static final ParseGraph BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).order;
     private static final ParseGraph CLOSED_BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
 
@@ -136,13 +136,13 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()));
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
-    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, ParseGraph.EMPTY.add(PARSEVALUE).add(PARSEVALUE), enc()), ZERO, BigInteger.valueOf(2)).get());
+    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, new Environment(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, enc()), ZERO, BigInteger.valueOf(2)).get());
     private static final List<Supplier<Object>> BYTE_ARRAYS = Arrays.asList(() -> new byte[] { 0 }, () -> new byte[] { 1, 2 }, () -> new byte[] {});
-    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, ParseGraph.EMPTY.add(PARSEVALUE), signed()));
+    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, new Environment(DUMMY_STREAM).add(PARSEVALUE).order, signed()));
     private static final List<Supplier<Object>> LONGS = Arrays.asList(() -> 0L, () -> 1L, () -> 31L, () -> 100000L);
     private static final List<Supplier<Object>> INTEGERS = Arrays.asList(() -> 0, () -> 1, () -> 17, () -> 21212121);
     private static final List<Supplier<Object>> PARSEGRAPHS = Arrays.asList(() -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE);
-    private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> ParseGraph.EMPTY.add(PARSEVALUE), () -> ParseGraph.EMPTY.add(PARSEVALUE).add(PARSEVALUE), () -> BRANCHED_GRAPH);
+    private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> new Environment(DUMMY_STREAM).add(PARSEVALUE).order, () -> new Environment(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, () -> BRANCHED_GRAPH);
     private static final List<Supplier<Object>> BYTESTREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
     private static final List<Supplier<Object>> BIGINTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
     private static final Map<Class, List<Supplier<Object>>> mapping = new HashMap<Class, List<Supplier<Object>>>() {{

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -167,7 +167,7 @@ public class EqualityTest {
     @Test
     public void parseGraph() {
         final ParseValue value = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-        final ParseGraph object = ParseGraph.EMPTY.add(value);
+        final ParseGraph object = new Environment(DUMMY_STREAM).add(value).order;
         assertFalse(object.equals(null));
         assertFalse(object.equals("a"));
         final Environment environment = new Environment(DUMMY_STREAM);

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.TRUE;
 import static io.parsingdata.metal.Shorthand.and;
 import static io.parsingdata.metal.Shorthand.cho;
@@ -199,7 +200,7 @@ public class ShorthandsTest {
         assertEquals(DEFB, seq.tokens.tail.head);
     }
 
-    final ParseGraph PARSEGRAPH = ParseGraph.EMPTY.add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42));
+    final ParseGraph PARSEGRAPH = new Environment(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42)).order;
 
     @Test
     public void mapLeftWithSub() {

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -116,7 +116,9 @@ public class ToStringTest {
         return prefix + count++;
     }
 
-    private Token t() { return any("a"); }
+    private Token t() {
+        return any("a");
+    }
 
     private ValueExpression v() {
         return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(last(ref(n())), first(nth(exp(ref(n()), con(1)), con(1)))), con(1)), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));

--- a/core/src/test/java/io/parsingdata/metal/TrampolineTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TrampolineTest.java
@@ -59,7 +59,9 @@ public class TrampolineTest {
     }
 
     private Trampoline<BigInteger> fibonacci(final BigInteger l, final BigInteger r, final long count) {
-        if (count == 0) { return complete(() -> l); }
+        if (count == 0) {
+            return complete(() -> l);
+        }
         return intermediate(() -> fibonacci(r, l.add(r), count-1));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -152,9 +152,15 @@ public class TreeTest {
     }
 
     private boolean contains(final ImmutableList<ParseValue> nrs, final int i) {
-        if (nrs.isEmpty()) { return false; }
-        if (nrs.head.asNumeric().intValueExact() == i) { return true; }
-        if (nrs.tail != null) { return contains(nrs.tail, i); }
+        if (nrs.isEmpty()) {
+            return false;
+        }
+        if (nrs.head.asNumeric().intValueExact() == i) {
+            return true;
+        }
+        if (nrs.tail != null) {
+            return contains(nrs.tail, i);
+        }
         return false;
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -84,7 +84,9 @@ public class SourceAndSliceTest {
 
     private boolean compareDataSlices(byte[] data, int offset) {
         for(int i = 0; i < data.length; i++) {
-            if (data[i] != DATA[offset+i]) { return false; }
+            if (data[i] != DATA[offset+i]) {
+                return false;
+            }
         }
         return true;
     }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByName.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByName.java
@@ -49,19 +49,27 @@ public final class ByName {
     }
 
     public static ParseValue get(final ImmutableList<ParseValue> list, final String name) {
-        if (list.isEmpty()) { return null; }
-        if (list.head.matches(name)) { return list.head; }
+        if (list.isEmpty()) {
+            return null;
+        }
+        if (list.head.matches(name)) {
+            return list.head;
+        }
         else {
             return get(list.tail, name);
         }
     }
 
     public static ImmutableList<ParseValue> getAll(final ImmutableList<ParseValue> list, final String name) {
-        if (list.isEmpty()) { return list; }
+        if (list.isEmpty()) {
+            return list;
+        }
         final ImmutableList<ParseValue> tailList = getAll(list.tail, name);
         if (list.head.matches(name)) {
             return tailList.add(list.head);
-        } else { return tailList; }
+        } else {
+            return tailList;
+        }
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByToken.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByToken.java
@@ -30,13 +30,21 @@ public final class ByToken {
     public static ParseItem get(final ParseGraph graph, final Token definition) {
         checkNotNull(graph, "graph");
         checkNotNull(definition, "definition");
-        if (graph.definition.equals(definition)) { return graph; }
-        if (graph.isEmpty()) { return null; }
+        if (graph.definition.equals(definition)) {
+            return graph;
+        }
+        if (graph.isEmpty()) {
+            return null;
+        }
         final ParseItem head = graph.head;
-        if (head.isValue() && head.asValue().definition.equals(definition)) { return head; }
+        if (head.isValue() && head.asValue().definition.equals(definition)) {
+            return head;
+        }
         if (head.isGraph()) {
             final ParseItem item = get(head.asGraph(), definition);
-            if (item != null) { return item; }
+            if (item != null) {
+                return item;
+            }
         }
         return get(graph.tail, definition);
     }
@@ -48,7 +56,9 @@ public final class ByToken {
     }
 
     private static ImmutableList<ParseItem> getAllRecursive(final ParseGraph graph, final Token definition) {
-        if (graph.isEmpty()) { return new ImmutableList<>(); }
+        if (graph.isEmpty()) {
+            return new ImmutableList<>();
+        }
         final ImmutableList<ParseItem> tailResults = getAllRecursive(graph.tail, definition);
         final ImmutableList<ParseItem> results = graph.definition.equals(definition) ? tailResults.add(graph) : tailResults;
         final ParseItem head = graph.head;

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByType.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByType.java
@@ -34,7 +34,9 @@ public final class ByType {
     }
 
     private static ImmutableList<Optional<ParseItem>> getReferences(final ParseGraph graph, final ParseGraph root) {
-        if (graph.isEmpty()) { return new ImmutableList<>(); }
+        if (graph.isEmpty()) {
+            return new ImmutableList<>();
+        }
         final ParseItem head = graph.head;
         if (head.isReference() && !head.asReference().resolve(root).isPresent()) { throw new IllegalStateException("A ParseReference must point to an existing graph."); }
         return getReferences(graph.tail, root).add(head.isGraph() ? getReferences(head.asGraph(), root) : (head.isReference() ? ImmutableList.create(head.asReference().resolve(root)) : new ImmutableList<>()));

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -18,17 +18,17 @@ package io.parsingdata.metal.data.selection;
 
 import static java.math.BigInteger.ZERO;
 
-import static io.parsingdata.metal.data.ParseGraph.EMPTY;
+import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 
-import java.io.IOException;
 import java.math.BigInteger;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseReference;
 import io.parsingdata.metal.data.Source;
 
@@ -46,7 +46,7 @@ public class ByTypeTest {
     public void unresolvableRef() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("A ParseReference must point to an existing graph.");
-        getReferences(EMPTY.add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)));
+        getReferences(new Environment(DUMMY_STREAM).add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).order);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.exp;
@@ -33,6 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseValue;
@@ -65,7 +67,7 @@ public class ExpandTest {
     public void expandListTimes() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Count must evaluate to a single non-empty value.");
-        exp(con(1), ref("a")).eval(ParseGraph.EMPTY.add(PARSEVALUE_1).add(PARSEVALUE_2), enc());
+        exp(con(1), ref("a")).eval(new Environment(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2).order, enc());
     }
 
     @Test
@@ -87,7 +89,7 @@ public class ExpandTest {
 
     @Test
     public void expandList() {
-        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(ParseGraph.EMPTY.add(PARSEVALUE_2).add(PARSEVALUE_1), enc());
+        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(new Environment(DUMMY_STREAM).add(PARSEVALUE_2).add(PARSEVALUE_1).order, enc());
         assertEquals(2 * SIZE, result.size);
         for (int i = 0; i < SIZE; i++) {
             assertTrue(result.head.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
@@ -16,8 +16,9 @@
 
 package io.parsingdata.metal.util;
 
-import static io.parsingdata.metal.Util.checkNotNull;
 import static java.util.stream.Collectors.toList;
+
+import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -52,7 +53,9 @@ public class ReadTrackingByteStream implements ByteStream {
 
     public boolean containsNone(final long... values) {
         for (final long v : LongStream.of(values).boxed().collect(toList())) {
-            if (read.contains(v)) { return false; }
+            if (read.contains(v)) {
+                return false;
+            }
         }
         return true;
     }

--- a/formats/src/main/java/io/parsingdata/metal/format/VarInt.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/VarInt.java
@@ -37,15 +37,18 @@ public final class VarInt {
 
     private VarInt() {}
 
-    public static Token varInt(final String name) { return
+    public static Token varInt(final String name) {
+        return
         until(name, con(1), post(EMPTY, eq(and(last(bytes(last(ref(name)))), con(128)), con(0))));
     }
 
-    public static ValueExpression decodeVarInt(final ValueExpression expression) { return
+    public static ValueExpression decodeVarInt(final ValueExpression expression) {
+        return
         foldLeft(rev(bytes(expression)), VarInt::varIntReducer);
     }
 
-    private static ValueExpression varIntReducer(final ValueExpression left, final ValueExpression right) { return
+    private static ValueExpression varIntReducer(final ValueExpression left, final ValueExpression right) {
+        return
         or(shl(left, con(7)), and(right, con(127)));
     }
 

--- a/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
@@ -42,7 +42,11 @@ public class FormatTest extends ParameterizedParse {
     }
 
     private static Environment env(final String path) throws URISyntaxException, IOException {
-        return stream(FormatTest.class.getClass().getResource(path).toURI());
+        return stream(FormatTest
+            .class
+            .getClass()
+            .getResource(path)
+            .toURI());
     }
 
 }

--- a/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
@@ -42,11 +42,7 @@ public class FormatTest extends ParameterizedParse {
     }
 
     private static Environment env(final String path) throws URISyntaxException, IOException {
-        return stream(FormatTest
-            .class
-            .getClass()
-            .getResource(path)
-            .toURI());
+        return stream(FormatTest.class.getResource(path).toURI());
     }
 
 }

--- a/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
@@ -52,7 +52,8 @@ public class VarIntTest extends ParameterizedParse {
         });
     }
 
-    public static final Token varIntAndValue(final int size) { return
+    public static final Token varIntAndValue(final int size) {
+        return
         seq(varInt("vint_name"), post(def("full_name", con(size)), eqNum(decodeVarInt(last(ref("vint_name"))))));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <gpg-plugin.version>1.6</gpg-plugin.version>
     <source-plugin.version>3.0.1</source-plugin.version>
     <pitest-maven.version>1.2.4</pitest-maven.version>
+    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -56,16 +56,16 @@
 
     <junit.version>4.12</junit.version>
 
-    <jacoco-plugin.version>0.7.8</jacoco-plugin.version>
+    <jacoco-plugin.version>0.7.9</jacoco-plugin.version>
     <reports-plugin.version>2.9</reports-plugin.version>
-    <findbugs-plugin.version>3.0.4</findbugs-plugin.version>
-    <pmd-plugin.version>3.7</pmd-plugin.version>
+    <findbugs-plugin.version>3.0.5</findbugs-plugin.version>
+    <pmd-plugin.version>3.8</pmd-plugin.version>
     <jxr-plugin.version>2.5</jxr-plugin.version>
-    <javadoc-plugin.version>2.10.4</javadoc-plugin.version>
-    <nexus-staging-plugin.version>1.6.7</nexus-staging-plugin.version>
+    <javadoc-plugin.version>3.0.0-M1</javadoc-plugin.version>
+    <nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
     <gpg-plugin.version>1.6</gpg-plugin.version>
     <source-plugin.version>3.0.1</source-plugin.version>
-    <pitest-maven.version>1.1.11</pitest-maven.version>
+    <pitest-maven.version>1.2.4</pitest-maven.version>
   </properties>
 
   <profiles>
@@ -234,6 +234,7 @@
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>
+          <omitVisitors>DumbMethods</omitVisitors>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Resolves #212: Added OracleJDK9 to Travis build configuration for building and testing. Fixed an issue with retrieving resources on JDK9.
Resolves #158: FindBugs now excludes equals()-check that reports incorrect error.
Resolves #209: The `add(ParseValue)` and `add(ParseReference)` methods on `ParseGraph` are now package-private.
Minor refactoring to pom, updated versions of all dependencies to current releases.
Migrated use of `orElse()` to `orElseGet()`.
Improved formatting by moving all `return` statements to their own line.
