### PR TITLE
Improve abstraction of parse state

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -61,6 +61,7 @@ import io.parsingdata.metal.expression.value.arithmetic.Sub;
 import io.parsingdata.metal.expression.value.bitwise.ShiftLeft;
 import io.parsingdata.metal.expression.value.bitwise.ShiftRight;
 import io.parsingdata.metal.expression.value.reference.Count;
+import io.parsingdata.metal.expression.value.reference.CurrentOffset;
 import io.parsingdata.metal.expression.value.reference.First;
 import io.parsingdata.metal.expression.value.reference.Last;
 import io.parsingdata.metal.expression.value.reference.Len;
@@ -86,7 +87,7 @@ public final class Shorthand {
 
     public static final Token EMPTY = def(EMPTY_NAME, 0L);
     public static final ValueExpression SELF = new Self();
-    public static final ValueExpression CURRENT_OFFSET = elvis(add(offset(SELF), len(SELF)), con(0));
+    public static final ValueExpression CURRENT_OFFSET = new CurrentOffset();
     public static final Expression TRUE = new True();
 
     private Shorthand() {}

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.Slice;
 import io.parsingdata.metal.encoding.Encoding;
@@ -106,11 +106,11 @@ public final class Util {
         };
     }
 
-    public static Optional<Environment> success(final Environment environment) {
-        return Optional.of(environment);
+    public static Optional<ParseState> success(final ParseState parseState) {
+        return Optional.of(parseState);
     }
 
-    public static Optional<Environment> failure() {
+    public static Optional<ParseState> failure() {
         return Optional.empty();
     }
 

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -88,7 +88,7 @@ public final class Util {
     public static ValueExpression inflate(final ValueExpression target) {
         return new UnaryValueExpression(target) {
             @Override
-            public Optional<Value> eval(final Value value, final ParseGraph graph, final Encoding encoding) {
+            public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
                 final Inflater inf = new Inflater(true);
                 inf.setInput(value.getValue());
                 final byte[] dataReceiver = new byte[512];

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -64,7 +64,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), input);
+        return Objects.hash(getClass(), input);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -62,7 +62,7 @@ public class ConstantSource extends Source {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), Arrays.hashCode(data));
+        return Objects.hash(getClass(), Arrays.hashCode(data));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -35,13 +35,13 @@ public class DataExpressionSource extends Source {
 
     public final ValueExpression dataExpression;
     public final int index;
-    public final ParseGraph graph;
+    public final ParseState parseState;
     public final Encoding encoding;
 
-    public DataExpressionSource(final ValueExpression dataExpression, final int index, final ParseGraph graph, final Encoding encoding) {
+    public DataExpressionSource(final ValueExpression dataExpression, final int index, final ParseState parseState, final Encoding encoding) {
         this.dataExpression = checkNotNull(dataExpression, "dataExpression");
         this.index = index;
-        this.graph = checkNotNull(graph, "graph");
+        this.parseState = checkNotNull(parseState, "parseState");
         this.encoding = checkNotNull(encoding, "encoding");
     }
 
@@ -63,7 +63,7 @@ public class DataExpressionSource extends Source {
     }
 
     private Value getValue() {
-        final ImmutableList<Optional<Value>> results = dataExpression.eval(graph, encoding);
+        final ImmutableList<Optional<Value>> results = dataExpression.eval(parseState, encoding);
         if (results.size <= index) {
             throw new IllegalStateException("ValueExpression dataExpression yields " + results.size + " result(s) (expected at least " + (index + 1) + ").");
         }
@@ -81,7 +81,7 @@ public class DataExpressionSource extends Source {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + dataExpression.toString() + "[" + index + "](" + graph + "," + encoding + "))";
+        return getClass().getSimpleName() + "(" + dataExpression.toString() + "[" + index + "](" + parseState + "," + encoding + "))";
     }
 
     @Override
@@ -89,13 +89,13 @@ public class DataExpressionSource extends Source {
         return Util.notNullAndSameClass(this, obj)
             && Objects.equals(dataExpression, ((DataExpressionSource)obj).dataExpression)
             && Objects.equals(index, ((DataExpressionSource)obj).index)
-            && Objects.equals(graph, ((DataExpressionSource)obj).graph)
+            && Objects.equals(parseState, ((DataExpressionSource)obj).parseState)
             && Objects.equals(encoding, ((DataExpressionSource)obj).encoding);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), dataExpression, index, graph, encoding);
+        return Objects.hash(getClass().hashCode(), dataExpression, index, parseState, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -95,7 +95,7 @@ public class DataExpressionSource extends Source {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), dataExpression, index, parseState, encoding);
+        return Objects.hash(getClass(), dataExpression, index, parseState, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/Environment.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Environment.java
@@ -25,7 +25,6 @@ import static io.parsingdata.metal.data.Slice.createFromSource;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
@@ -35,25 +34,15 @@ public class Environment {
     public final ParseGraph order;
     public final BigInteger offset;
     public final Source source;
-    public final Callbacks callbacks;
 
-    public Environment(final ParseGraph order, final Source source, final BigInteger offset, final Callbacks callbacks) {
+    public Environment(final ParseGraph order, final Source source, final BigInteger offset) {
         this.order = checkNotNull(order, "order");
         this.source = checkNotNull(source, "source");
         this.offset = checkNotNegative(offset, "offset");
-        this.callbacks = checkNotNull(callbacks, "callbacks");
-    }
-
-    public Environment(final ByteStream input, final BigInteger offset, final Callbacks callbacks) {
-        this(ParseGraph.EMPTY, new ByteStreamSource(input), offset, callbacks);
     }
 
     public Environment(final ByteStream input, final BigInteger offset) {
-        this(input, offset, Callbacks.NONE);
-    }
-
-    public Environment(final ByteStream input, final Callbacks callbacks) {
-        this(input, ZERO, callbacks);
+        this(ParseGraph.EMPTY, new ByteStreamSource(input), offset);
     }
 
     public Environment(final ByteStream input) {
@@ -61,27 +50,27 @@ public class Environment {
     }
 
     public Environment addBranch(final Token token) {
-        return new Environment(order.addBranch(token), source, offset, callbacks);
+        return new Environment(order.addBranch(token), source, offset);
     }
 
     public Environment closeBranch() {
-        return new Environment(order.closeBranch(), source, offset, callbacks);
+        return new Environment(order.closeBranch(), source, offset);
     }
 
     public Environment add(final ParseValue parseValue) {
-        return new Environment(order.add(parseValue), source, offset, callbacks);
+        return new Environment(order.add(parseValue), source, offset);
     }
 
     public Environment add(final ParseReference parseReference) {
-        return new Environment(order.add(parseReference), source, offset, callbacks);
+        return new Environment(order.add(parseReference), source, offset);
     }
 
     public Optional<Environment> seek(final BigInteger newOffset) {
-        return newOffset.compareTo(ZERO) >= 0 ? Optional.of(new Environment(order, source, newOffset, callbacks)) : Optional.empty();
+        return newOffset.compareTo(ZERO) >= 0 ? Optional.of(new Environment(order, source, newOffset)) : Optional.empty();
     }
 
     public Environment source(final ValueExpression dataExpression, final int index, final Environment environment, final Encoding encoding) {
-        return new Environment(order, new DataExpressionSource(dataExpression, index, environment.order, encoding), ZERO, callbacks);
+        return new Environment(order, new DataExpressionSource(dataExpression, index, environment.order, encoding), ZERO);
     }
 
     public Optional<Slice> slice(final BigInteger length) {
@@ -90,7 +79,7 @@ public class Environment {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(source:" + source + ";offset:" + offset + ";order:" + order + ";callbacks:" + callbacks + ")";
+        return getClass().getSimpleName() + "(source:" + source + ";offset:" + offset + ";order:" + order + ")";
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/Environment.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Environment.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.data;
+
+import static io.parsingdata.metal.Util.checkNotNull;
+import static io.parsingdata.metal.token.Token.NO_NAME;
+import static io.parsingdata.metal.token.Token.SEPARATOR;
+
+import io.parsingdata.metal.data.callback.Callbacks;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.token.Token;
+
+public class Environment {
+
+    public final String scope;
+    public final ParseState parseState;
+    public final Callbacks callbacks;
+    public final Encoding encoding;
+
+    public Environment(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        this.scope = checkNotNull(scope, "scope");
+        this.parseState = checkNotNull(parseState, "parseState");
+        this.callbacks = checkNotNull(callbacks, "callbacks");
+        this.encoding = checkNotNull(encoding, "encoding");
+    }
+
+    public Environment(final String scope, final ParseState parseState, final Encoding encoding) {
+        this(scope, parseState, Callbacks.NONE, encoding);
+    }
+
+    public Environment(final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        this(NO_NAME, parseState, callbacks, encoding);
+    }
+
+    public Environment(final ParseState parseState, final Encoding encoding) {
+        this(parseState, Callbacks.NONE, encoding);
+    }
+
+    public Environment withParseState(final ParseState parseState) {
+        return new Environment(scope, parseState, callbacks, encoding);
+    }
+
+    public Environment withEncoding(final Encoding encoding) {
+        return new Environment(scope, parseState, callbacks, encoding);
+    }
+
+    public Environment addBranch(final Token token) {
+        return withParseState(parseState.addBranch(token));
+    }
+
+    public Environment extendScope(final String name) {
+        return new Environment(scope + (scope.isEmpty() || name.isEmpty() ? NO_NAME : SEPARATOR) + name, parseState, callbacks, encoding);
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/data/ImmutableList.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ImmutableList.java
@@ -97,7 +97,7 @@ public class ImmutableList<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), head, tail);
+        return Objects.hash(getClass(), head, tail);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -38,7 +38,7 @@ public class ParseGraph implements ParseItem {
     public final long size;
 
     public static final Token NONE = new Token("NONE", null) {
-        @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) { throw new IllegalStateException("This placeholder may not be invoked."); }
+        @Override protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) { throw new IllegalStateException("This placeholder may not be invoked."); }
         @Override public String toString() { return "None"; }
     };
 

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -144,7 +144,7 @@ public class ParseGraph implements ParseItem {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), head, tail, branched, definition);
+        return Objects.hash(getClass(), head, tail, branched, definition);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 
@@ -37,7 +38,7 @@ public class ParseGraph implements ParseItem {
     public final long size;
 
     public static final Token NONE = new Token("NONE", null) {
-        @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) { throw new IllegalStateException("This placeholder may not be invoked."); }
+        @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) { throw new IllegalStateException("This placeholder may not be invoked."); }
         @Override public String toString() { return "None"; }
     };
 

--- a/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseGraph.java
@@ -25,8 +25,6 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.callback.Callbacks;
-import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 
 public class ParseGraph implements ParseItem {
@@ -38,7 +36,7 @@ public class ParseGraph implements ParseItem {
     public final long size;
 
     public static final Token NONE = new Token("NONE", null) {
-        @Override protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) { throw new IllegalStateException("This placeholder may not be invoked."); }
+        @Override protected Optional<ParseState> parseImpl(final Environment environment) { throw new IllegalStateException("This placeholder may not be invoked."); }
         @Override public String toString() { return "None"; }
     };
 

--- a/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseReference.java
@@ -62,7 +62,7 @@ public class ParseReference implements ParseItem {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), location, source, definition);
+        return Objects.hash(getClass(), location, source, definition);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseState.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseState.java
@@ -41,12 +41,12 @@ public class ParseState {
         this.offset = checkNotNegative(offset, "offset");
     }
 
-    public ParseState(final ByteStream input, final BigInteger offset) {
-        this(ParseGraph.EMPTY, new ByteStreamSource(input), offset);
+    public static ParseState createFromByteStream(final ByteStream input, final BigInteger offset) {
+        return new ParseState(ParseGraph.EMPTY, new ByteStreamSource(input), offset);
     }
 
-    public ParseState(final ByteStream input) {
-        this(input, ZERO);
+    public static ParseState createFromByteStream(final ByteStream input) {
+        return createFromByteStream(input, ZERO);
     }
 
     public ParseState addBranch(final Token token) {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseState.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseState.java
@@ -72,7 +72,7 @@ public class ParseState {
     }
 
     public ParseState source(final ValueExpression dataExpression, final int index, final ParseState parseState, final Encoding encoding) {
-        return new ParseState(order, new DataExpressionSource(dataExpression, index, parseState.order, encoding), ZERO);
+        return new ParseState(order, new DataExpressionSource(dataExpression, index, parseState, encoding), ZERO);
     }
 
     public Optional<Slice> slice(final BigInteger length) {

--- a/core/src/main/java/io/parsingdata/metal/data/ParseState.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseState.java
@@ -23,8 +23,10 @@ import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
 import java.math.BigInteger;
+import java.util.Objects;
 import java.util.Optional;
 
+import io.parsingdata.metal.Util;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
@@ -80,6 +82,19 @@ public class ParseState {
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(source:" + source + ";offset:" + offset + ";order:" + order + ")";
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return Util.notNullAndSameClass(this, obj)
+            && Objects.equals(order, ((ParseState)obj).order)
+            && Objects.equals(offset, ((ParseState)obj).offset)
+            && Objects.equals(source, ((ParseState)obj).source);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass().hashCode(), order, offset, source);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseState.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseState.java
@@ -94,7 +94,7 @@ public class ParseState {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), order, offset, source);
+        return Objects.hash(getClass(), order, offset, source);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ParseState.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ParseState.java
@@ -29,48 +29,48 @@ import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 
-public class Environment {
+public class ParseState {
 
     public final ParseGraph order;
     public final BigInteger offset;
     public final Source source;
 
-    public Environment(final ParseGraph order, final Source source, final BigInteger offset) {
+    public ParseState(final ParseGraph order, final Source source, final BigInteger offset) {
         this.order = checkNotNull(order, "order");
         this.source = checkNotNull(source, "source");
         this.offset = checkNotNegative(offset, "offset");
     }
 
-    public Environment(final ByteStream input, final BigInteger offset) {
+    public ParseState(final ByteStream input, final BigInteger offset) {
         this(ParseGraph.EMPTY, new ByteStreamSource(input), offset);
     }
 
-    public Environment(final ByteStream input) {
+    public ParseState(final ByteStream input) {
         this(input, ZERO);
     }
 
-    public Environment addBranch(final Token token) {
-        return new Environment(order.addBranch(token), source, offset);
+    public ParseState addBranch(final Token token) {
+        return new ParseState(order.addBranch(token), source, offset);
     }
 
-    public Environment closeBranch() {
-        return new Environment(order.closeBranch(), source, offset);
+    public ParseState closeBranch() {
+        return new ParseState(order.closeBranch(), source, offset);
     }
 
-    public Environment add(final ParseValue parseValue) {
-        return new Environment(order.add(parseValue), source, offset);
+    public ParseState add(final ParseValue parseValue) {
+        return new ParseState(order.add(parseValue), source, offset);
     }
 
-    public Environment add(final ParseReference parseReference) {
-        return new Environment(order.add(parseReference), source, offset);
+    public ParseState add(final ParseReference parseReference) {
+        return new ParseState(order.add(parseReference), source, offset);
     }
 
-    public Optional<Environment> seek(final BigInteger newOffset) {
-        return newOffset.compareTo(ZERO) >= 0 ? Optional.of(new Environment(order, source, newOffset)) : Optional.empty();
+    public Optional<ParseState> seek(final BigInteger newOffset) {
+        return newOffset.compareTo(ZERO) >= 0 ? Optional.of(new ParseState(order, source, newOffset)) : Optional.empty();
     }
 
-    public Environment source(final ValueExpression dataExpression, final int index, final Environment environment, final Encoding encoding) {
-        return new Environment(order, new DataExpressionSource(dataExpression, index, environment.order, encoding), ZERO);
+    public ParseState source(final ValueExpression dataExpression, final int index, final ParseState parseState, final Encoding encoding) {
+        return new ParseState(order, new DataExpressionSource(dataExpression, index, parseState.order, encoding), ZERO);
     }
 
     public Optional<Slice> slice(final BigInteger length) {

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -78,7 +78,7 @@ public class Slice {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), source, offset, length);
+        return Objects.hash(getClass(), source, offset, length);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/callback/Callback.java
+++ b/core/src/main/java/io/parsingdata/metal/data/callback/Callback.java
@@ -16,12 +16,12 @@
 
 package io.parsingdata.metal.data.callback;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.token.Token;
 
 public interface Callback {
 
-    void handleSuccess(Token token, Environment before, Environment after);
-    void handleFailure(Token token, Environment before);
+    void handleSuccess(Token token, ParseState before, ParseState after);
+    void handleFailure(Token token, ParseState before);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/callback/Callbacks.java
+++ b/core/src/main/java/io/parsingdata/metal/data/callback/Callbacks.java
@@ -23,7 +23,7 @@ import static io.parsingdata.metal.Util.checkNotNull;
 import java.util.function.Consumer;
 
 import io.parsingdata.metal.Trampoline;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.token.Token;
 
@@ -51,11 +51,11 @@ public class Callbacks {
         return new Callbacks(genericCallback, tokenCallbacks.add(new TokenCallback(token, callback)));
     }
 
-    public static Consumer<Callback> success(final Token token, final Environment before, final Environment after) {
+    public static Consumer<Callback> success(final Token token, final ParseState before, final ParseState after) {
         return callback -> callback.handleSuccess(token, before, after);
     }
 
-    public static Consumer<Callback> failure(final Token token, final Environment before) {
+    public static Consumer<Callback> failure(final Token token, final ParseState before) {
         return callback -> callback.handleFailure(token, before);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
@@ -71,7 +71,7 @@ public class Encoding {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), sign, charset, byteOrder);
+        return Objects.hash(getClass(), sign, charset, byteOrder);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
+++ b/core/src/main/java/io/parsingdata/metal/encoding/Encoding.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.encoding;
 
+import static io.parsingdata.metal.Util.checkNotNull;
+
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -49,9 +51,9 @@ public class Encoding {
     }
 
     public Encoding(final Sign sign, final Charset charset, final ByteOrder byteOrder) {
-        this.sign = sign;
-        this.charset = charset;
-        this.byteOrder = byteOrder;
+        this.sign = checkNotNull(sign, "sign");
+        this.charset = checkNotNull(charset, "charset");
+        this.byteOrder = checkNotNull(byteOrder, "byteOrder");
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/Expression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/Expression.java
@@ -24,9 +24,9 @@ import io.parsingdata.metal.encoding.Encoding;
  * Interface for all Expression implementations.
  * <p>
  * An Expression is evaluated by calling the
- * {@link #eval(ParseGraph, Encoding)} method. Given an {@link ParseState}
- * and an {@link Encoding}, the evaluation either succeeds or fails. Main use
- * of expressions is to define predicates that are evaluated during parsing.
+ * {@link #eval(ParseState, Encoding)} method. Given a {@link ParseState} and
+ * an {@link Encoding}, the evaluation either succeeds or fails. Main use of
+ * expressions is to define predicates that are evaluated during parsing.
  *
  * @see io.parsingdata.metal.token.Def
  * @see io.parsingdata.metal.token.Pre
@@ -35,6 +35,6 @@ import io.parsingdata.metal.encoding.Encoding;
 @FunctionalInterface
 public interface Expression {
 
-    boolean eval(ParseGraph graph, Encoding encoding);
+    boolean eval(ParseState parseState, Encoding encoding);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/Expression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/Expression.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.expression;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.encoding.Encoding;
 
@@ -24,7 +24,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * Interface for all Expression implementations.
  * <p>
  * An Expression is evaluated by calling the
- * {@link #eval(ParseGraph, Encoding)} method. Given an {@link Environment}
+ * {@link #eval(ParseGraph, Encoding)} method. Given an {@link ParseState}
  * and an {@link Encoding}, the evaluation either succeeds or fails. Main use
  * of expressions is to define predicates that are evaluated during parsing.
  *

--- a/core/src/main/java/io/parsingdata/metal/expression/True.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/True.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal.expression;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -27,7 +28,7 @@ import io.parsingdata.metal.encoding.Encoding;
 public class True implements Expression {
 
     @Override
-    public boolean eval(final ParseGraph graph, final Encoding encoding) {
+    public boolean eval(final ParseState parseState, final Encoding encoding) {
         return true;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -97,7 +97,7 @@ public abstract class ComparisonExpression implements Expression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), value, predicate);
+        return Objects.hash(getClass(), value, predicate);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -58,12 +58,12 @@ public abstract class ComparisonExpression implements Expression {
     }
 
     @Override
-    public boolean eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> values = value == null ? ImmutableList.create(graph.current().map(identity())) : value.eval(graph, encoding);
+    public boolean eval(final ParseState parseState, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> values = value == null ? ImmutableList.create(parseState.order.current().map(identity())) : value.eval(parseState, encoding);
         if (values.isEmpty()) {
             return false;
         }
-        final ImmutableList<Optional<Value>> predicates = predicate.eval(graph, encoding);
+        final ImmutableList<Optional<Value>> predicates = predicate.eval(parseState, encoding);
         if (values.size != predicates.size) {
             return false;
         }

--- a/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/comparison/ComparisonExpression.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.encoding.Encoding;
@@ -45,7 +45,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * <p>
  * The {@link #value} argument may be <code>null</code>, in which case it is
  * not evaluated and the output value is substituted with a list containing
- * only the {@link Value} most recently added to the {@link Environment}.
+ * only the {@link Value} most recently added to the {@link ParseState}.
  */
 public abstract class ComparisonExpression implements Expression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/And.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal.expression.logical;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -30,8 +31,8 @@ public class And extends BinaryLogicalExpression {
     }
 
     @Override
-    public boolean eval(final ParseGraph graph, final Encoding encoding) {
-        return left.eval(graph, encoding) && right.eval(graph, encoding);
+    public boolean eval(final ParseState parseState, final Encoding encoding) {
+        return left.eval(parseState, encoding) && right.eval(parseState, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/BinaryLogicalExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/BinaryLogicalExpression.java
@@ -55,7 +55,7 @@ public abstract class BinaryLogicalExpression implements LogicalExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), left, right);
+        return Objects.hash(getClass(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/Not.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal.expression.logical;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -30,8 +31,8 @@ public class Not extends UnaryLogicalExpression {
     }
 
     @Override
-    public boolean eval(final ParseGraph graph, final Encoding encoding) {
-        return !operand.eval(graph, encoding);
+    public boolean eval(final ParseState parseState, final Encoding encoding) {
+        return !operand.eval(parseState, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/Or.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal.expression.logical;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -30,8 +31,8 @@ public class Or extends BinaryLogicalExpression {
     }
 
     @Override
-    public boolean eval(final ParseGraph graph, final Encoding encoding) {
-        return left.eval(graph, encoding) || right.eval(graph, encoding);
+    public boolean eval(final ParseState parseState, final Encoding encoding) {
+        return left.eval(parseState, encoding) || right.eval(parseState, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/logical/UnaryLogicalExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/logical/UnaryLogicalExpression.java
@@ -52,7 +52,7 @@ public abstract class UnaryLogicalExpression implements LogicalExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), operand);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -101,7 +101,7 @@ public abstract class BinaryValueExpression implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), left, right);
+        return Objects.hash(getClass(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -89,7 +89,7 @@ public class Bytes implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), operand);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -28,6 +28,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -53,8 +54,8 @@ public class Bytes implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> input = operand.eval(graph, encoding);
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> input = operand.eval(parseState, encoding);
         if (input.isEmpty()) {
             return input;
         }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -21,6 +21,7 @@ import static io.parsingdata.metal.data.Slice.createFromBytes;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -33,7 +34,7 @@ public class Cat extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         final byte[] leftBytes = left.getValue();
         final byte[] rightBytes = right.getValue();
         final byte[] concatenatedBytes = new byte[leftBytes.length + rightBytes.length];

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -57,7 +57,7 @@ public class Const implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), value);
+        return Objects.hash(getClass(), value);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -39,7 +40,7 @@ public class Const implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
         return ImmutableList.create(Optional.of(value));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -28,6 +28,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -53,8 +54,8 @@ public class Elvis implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return reverse(eval(new ImmutableList<>(), left.eval(graph, encoding), right.eval(graph, encoding)).computeResult());
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        return reverse(eval(new ImmutableList<>(), left.eval(parseState, encoding), right.eval(parseState, encoding)).computeResult());
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> result, final ImmutableList<Optional<Value>> leftValues, final ImmutableList<Optional<Value>> rightValues) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -82,7 +82,7 @@ public class Elvis implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), left, right);
+        return Objects.hash(getClass(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -27,6 +27,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -51,12 +52,12 @@ public class Expand implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> base = this.base.eval(graph, encoding);
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> base = this.base.eval(parseState, encoding);
         if (base.isEmpty()) {
             return base;
         }
-        final ImmutableList<Optional<Value>> count = this.count.eval(graph, encoding);
+        final ImmutableList<Optional<Value>> count = this.count.eval(parseState, encoding);
         if (count.size != 1 || !count.head.isPresent()) {
             throw new IllegalArgumentException("Count must evaluate to a single non-empty value.");
         }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -85,7 +85,7 @@ public class Expand implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), base, count);
+        return Objects.hash(getClass(), base, count);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -28,6 +28,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -57,30 +58,30 @@ public abstract class Fold implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> initial = this.initial != null ? this.initial.eval(graph, encoding) : new ImmutableList<>();
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> initial = this.initial != null ? this.initial.eval(parseState, encoding) : new ImmutableList<>();
         if (initial.size > 1) {
             return new ImmutableList<>();
         }
-        final ImmutableList<Optional<Value>> values = prepareValues(this.values.eval(graph, encoding));
+        final ImmutableList<Optional<Value>> values = prepareValues(this.values.eval(parseState, encoding));
         if (values.isEmpty() || containsEmpty(values).computeResult()) {
             return initial;
         }
         if (!initial.isEmpty()) {
-            return ImmutableList.create(fold(graph, encoding, reducer, initial.head, values).computeResult());
+            return ImmutableList.create(fold(parseState, encoding, reducer, initial.head, values).computeResult());
         }
-        return ImmutableList.create(fold(graph, encoding, reducer, values.head, values.tail).computeResult());
+        return ImmutableList.create(fold(parseState, encoding, reducer, values.head, values.tail).computeResult());
     }
 
-    private Trampoline<Optional<Value>> fold(final ParseGraph graph, final Encoding encoding, final BinaryOperator<ValueExpression> reducer, final Optional<Value> head, final ImmutableList<Optional<Value>> tail) {
+    private Trampoline<Optional<Value>> fold(final ParseState parseState, final Encoding encoding, final BinaryOperator<ValueExpression> reducer, final Optional<Value> head, final ImmutableList<Optional<Value>> tail) {
         if (!head.isPresent() || tail.isEmpty()) {
             return complete(() -> head);
         }
-        final ImmutableList<Optional<Value>> reducedValue = reduce(reducer, head.get(), tail.head.get()).eval(graph, encoding);
+        final ImmutableList<Optional<Value>> reducedValue = reduce(reducer, head.get(), tail.head.get()).eval(parseState, encoding);
         if (reducedValue.size != 1) {
             throw new IllegalArgumentException("Reducer must evaluate to a single value.");
         }
-        return intermediate(() -> fold(graph, encoding, reducer, reducedValue.head, tail.tail));
+        return intermediate(() -> fold(parseState, encoding, reducer, reducedValue.head, tail.tail));
     }
 
     private Trampoline<Boolean> containsEmpty(final ImmutableList<Optional<Value>> list) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -113,7 +113,7 @@ public abstract class Fold implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), values, reducer, initial);
+        return Objects.hash(getClass(), values, reducer, initial);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
@@ -60,7 +60,7 @@ public class Reverse implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), values);
+        return Objects.hash(getClass(), values);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -42,8 +43,8 @@ public class Reverse implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return reverse(values.eval(graph, encoding));
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        return reverse(values.eval(parseState, encoding));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -28,6 +28,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -39,7 +40,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * ValueExpression itself will be that as well.
  * <p>
  * To implement a UnaryValueExpression, only the
- * {@link #eval(Value, ParseGraph, Encoding)} must be implemented, handling
+ * {@link #eval(Value, ParseState, Encoding)} must be implemented, handling
  * the case of evaluating one value. This base class takes care of evaluating
  * the operand and handling list semantics.
  *
@@ -54,18 +55,18 @@ public abstract class UnaryValueExpression implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return reverse(eval(operand.eval(graph, encoding), graph, encoding, new ImmutableList<>()).computeResult());
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        return reverse(eval(operand.eval(parseState, encoding), parseState, encoding, new ImmutableList<>()).computeResult());
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ParseGraph graph, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
+    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ParseState parseState, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
         if (values.isEmpty()) {
             return complete(() -> result);
         }
-        return intermediate(() -> eval(values.tail, graph, encoding, result.add(values.head.flatMap(value -> eval(value, graph, encoding)))));
+        return intermediate(() -> eval(values.tail, parseState, encoding, result.add(values.head.flatMap(value -> eval(value, parseState, encoding)))));
     }
 
-    public abstract Optional<Value> eval(final Value value, final ParseGraph graph, final Encoding encoding);
+    public abstract Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding);
 
     @Override
     public String toString() {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -81,7 +81,7 @@ public abstract class UnaryValueExpression implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), operand);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Value.java
@@ -76,7 +76,7 @@ public class Value {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), slice, encoding);
+        return Objects.hash(getClass(), slice, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
@@ -20,23 +20,23 @@ import java.util.Optional;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
  * Interface for all ValueExpression implementations.
  * <p>
  * A ValueExpression is an expression that is evaluated by executing its
- * {@link #eval(ParseGraph, Encoding)} method. It yields a list of
+ * {@link #eval(ParseState, Encoding)} method. It yields a list of
  * {@link Value} objects encapsulated in {@link Optional} objects (to guard
  * against <code>null</code>s).
  * <p>
- * As context, it receives the current <code>graph</code> object that
- * describes the parse state as well as the current <code>encoding</code>
- * object that describes the encoding to use when reading data from the input.
+ * As context, it receives the current <code>parseState</code> object that as
+ * well as the current <code>encoding</code> object.
  */
 @FunctionalInterface
 public interface ValueExpression {
 
-    ImmutableList<Optional<Value>> eval(ParseGraph graph, Encoding encoding);
+    ImmutableList<Optional<Value>> eval(ParseState parseState, Encoding encoding);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value.arithmetic;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -35,7 +36,7 @@ public class Add extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().add(right.asNumeric()), encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -41,7 +42,7 @@ public class Div extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         if (right.asNumeric().equals(ZERO)) {
             return Optional.empty();
         }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -41,7 +42,7 @@ public class Mod extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         if (right.asNumeric().compareTo(ZERO) <= 0) {
             return Optional.empty();
         }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value.arithmetic;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -35,7 +36,7 @@ public class Mul extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().multiply(right.asNumeric()), encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value.arithmetic;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
@@ -35,7 +36,7 @@ public class Neg extends UnaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value value, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
         return Optional.of(ConstantFactory.createFromNumeric(value.asNumeric().negate(), encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value.arithmetic;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -35,7 +36,7 @@ public class Sub extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().subtract(right.asNumeric()), encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
@@ -20,6 +20,7 @@ import java.util.BitSet;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -36,7 +37,7 @@ public class And extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         final BitSet leftBits = left.asBitSet();
         leftBits.and(right.asBitSet());
         return Optional.of(ConstantFactory.createFromBitSet(leftBits, left.getValue().length, encoding));

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
@@ -20,6 +20,7 @@ import java.util.BitSet;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
@@ -36,7 +37,7 @@ public class Not extends UnaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value value, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
         final BitSet bits = value.asBitSet();
         bits.flip(0, value.getValue().length * 8);
         return Optional.of(ConstantFactory.createFromBitSet(bits, value.getValue().length, encoding));

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
@@ -20,6 +20,7 @@ import java.util.BitSet;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -36,7 +37,7 @@ public class Or extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         final BitSet leftBits = left.asBitSet();
         leftBits.or(right.asBitSet());
         final int minSize = Math.max(left.getValue().length, right.getValue().length);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
@@ -20,6 +20,7 @@ import java.util.BitSet;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -37,7 +38,7 @@ public class ShiftLeft extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value operand, final Value positions, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value operand, final Value positions, final ParseState parseState, final Encoding encoding) {
         final BitSet leftBits = operand.asBitSet();
         final int shiftLeft = positions.asNumeric().intValueExact();
         final int bitCount = leftBits.length() + shiftLeft;

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
@@ -20,6 +20,7 @@ import java.util.BitSet;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -37,7 +38,7 @@ public class ShiftRight extends BinaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value operand, final Value positions, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value operand, final Value positions, final ParseState parseState, final Encoding encoding) {
         final BitSet leftBits = operand.asBitSet();
         final int shift = positions.asNumeric().intValueExact();
         return Optional.of(ConstantFactory.createFromBitSet(leftBits.get(shift, Math.max(shift, leftBits.length())), operand.getValue().length, encoding));

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -66,7 +66,7 @@ public class Count implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), operand);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.encoding.Sign;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -43,8 +44,8 @@ public class Count implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> values = operand.eval(graph, encoding);
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> values = operand.eval(parseState, encoding);
         return ImmutableList.create(Optional.of(fromNumeric(values.size)));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value.reference;
+
+import static io.parsingdata.metal.expression.value.ConstantFactory.createFromNumeric;
+
+import java.util.Optional;
+
+import io.parsingdata.metal.Util;
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
+
+/**
+ * A {@link ValueExpression} that represents the current offset in the
+ * {@link ParseState}.
+ */
+public class CurrentOffset implements ValueExpression {
+
+    @Override
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        return ImmutableList.create(Optional.of(createFromNumeric(parseState.offset, new Encoding())));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return Util.notNullAndSameClass(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -67,7 +67,7 @@ public class First implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), operand);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -27,6 +27,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -44,8 +45,8 @@ public class First implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operand.eval(graph, encoding);
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
         return list.isEmpty() ? list : ImmutableList.create(getFirst(list).computeResult());
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -60,7 +60,7 @@ public class Last implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), operand);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -41,8 +42,8 @@ public class Last implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operand.eval(graph, encoding);
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
         return list.isEmpty() ? list : ImmutableList.create(list.head);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.encoding.Sign;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -38,7 +39,7 @@ public class Len extends UnaryValueExpression {
     }
 
     @Override
-    public Optional<Value> eval(final Value value, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
         return Optional.of(fromNumeric(value.getLength()));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -32,6 +32,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -58,8 +59,8 @@ public class Nth implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return reverse(eval(values.eval(graph, encoding), indices.eval(graph, encoding), new ImmutableList<>()).computeResult());
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        return reverse(eval(values.eval(parseState, encoding), indices.eval(parseState, encoding), new ImmutableList<>()).computeResult());
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ImmutableList<Optional<Value>> indices, final ImmutableList<Optional<Value>> result) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -95,7 +95,7 @@ public class Nth implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), values, indices);
+        return Objects.hash(getClass(), values, indices);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -19,6 +19,7 @@ package io.parsingdata.metal.expression.value.reference;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ConstantFactory;
@@ -39,7 +40,7 @@ public class Offset extends UnaryValueExpression {
     public Offset(final ValueExpression operand) { super(operand); }
 
     @Override
-    public Optional<Value> eval(final Value value, final ParseGraph graph, final Encoding encoding) {
+    public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
         return Optional.of(ConstantFactory.createFromNumeric(value.slice.offset, value.encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -105,7 +105,7 @@ public class Ref<T> implements ValueExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), reference, limit);
+        return Objects.hash(getClass(), reference, limit);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -30,6 +30,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
@@ -68,19 +69,19 @@ public class Ref<T> implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
         if (limit == null) {
-            return evalImpl(graph, NO_LIMIT);
+            return evalImpl(parseState, NO_LIMIT);
         }
-        ImmutableList<Optional<Value>> evaluatedLimit = limit.eval(graph, encoding);
+        ImmutableList<Optional<Value>> evaluatedLimit = limit.eval(parseState, encoding);
         if (evaluatedLimit.size != 1 || !evaluatedLimit.head.isPresent()) {
             throw new IllegalArgumentException("Limit must evaluate to a single non-empty value.");
         }
-        return evalImpl(graph, evaluatedLimit.head.get().asNumeric().intValueExact());
+        return evalImpl(parseState, evaluatedLimit.head.get().asNumeric().intValueExact());
     }
 
-    private ImmutableList<Optional<Value>> evalImpl(final ParseGraph graph, final int limit) {
-        return wrap(getAllValues(graph, predicate, limit), new ImmutableList<Optional<Value>>()).computeResult();
+    private ImmutableList<Optional<Value>> evalImpl(final ParseState parseState, final int limit) {
+        return wrap(getAllValues(parseState.order, predicate, limit), new ImmutableList<Optional<Value>>()).computeResult();
     }
 
     private static <T, U extends T> Trampoline<ImmutableList<Optional<T>>> wrap(final ImmutableList<U> input, final ImmutableList<Optional<T>> output) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -35,8 +36,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 public class Self implements ValueExpression {
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
-        return ImmutableList.create(graph.current().map(identity()));
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
+        return ImmutableList.create(parseState.order.current().map(identity()));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -30,6 +30,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -51,18 +52,18 @@ public class Cho extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), encoding, tokens).computeResult();
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, environment.addBranch(this), callbacks, encoding, tokens).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding, final ImmutableList<Token> list) {
+    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
         if (list.isEmpty()) {
             return complete(Util::failure);
         }
         return list.head
-            .parse(scope, environment, encoding)
+            .parse(scope, environment, callbacks, encoding)
             .map(result -> complete(() -> success(result.closeBranch())))
-            .orElseGet(() -> intermediate(() -> iterate(scope, environment, encoding, list.tail)));
+            .orElseGet(() -> intermediate(() -> iterate(scope, environment, callbacks, encoding, list.tail)));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
@@ -52,18 +52,18 @@ public class Cho extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), callbacks, encoding, tokens).computeResult();
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, parseState.addBranch(this), callbacks, encoding, tokens).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
+    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
         if (list.isEmpty()) {
             return complete(Util::failure);
         }
         return list.head
-            .parse(scope, environment, callbacks, encoding)
+            .parse(scope, parseState, callbacks, encoding)
             .map(result -> complete(() -> success(result.closeBranch())))
-            .orElseGet(() -> intermediate(() -> iterate(scope, environment, callbacks, encoding, list.tail)));
+            .orElseGet(() -> intermediate(() -> iterate(scope, parseState, callbacks, encoding, list.tail)));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Cho.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Cho.java
@@ -28,9 +28,9 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.callback.Callbacks;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -52,18 +52,18 @@ public class Cho extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, parseState.addBranch(this), callbacks, encoding, tokens).computeResult();
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        return iterate(environment.addBranch(this), tokens).computeResult();
     }
 
-    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
+    private Trampoline<Optional<ParseState>> iterate(final Environment environment, final ImmutableList<Token> list) {
         if (list.isEmpty()) {
             return complete(Util::failure);
         }
         return list.head
-            .parse(scope, parseState, callbacks, encoding)
+            .parse(environment)
             .map(result -> complete(() -> success(result.closeBranch())))
-            .orElseGet(() -> intermediate(() -> iterate(scope, parseState, callbacks, encoding, list.tail)));
+            .orElseGet(() -> intermediate(() -> iterate(environment, list.tail)));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -28,10 +28,10 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
-import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -57,21 +57,21 @@ public class Def extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> sizes = size.eval(parseState, encoding);
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        final ImmutableList<Optional<Value>> sizes = size.eval(environment.parseState, environment.encoding);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
             return failure();
         }
         return sizes.head
             .filter(dataSize -> dataSize.asNumeric().compareTo(ZERO) != 0)
-            .map(dataSize -> slice(scope, parseState, encoding, dataSize.asNumeric()))
-            .orElseGet(() -> success(parseState));
+            .map(dataSize -> slice(environment, dataSize.asNumeric()))
+            .orElseGet(() -> success(environment.parseState));
     }
 
-    private Optional<ParseState> slice(final String scope, final ParseState parseState, final Encoding encoding, final BigInteger dataSize) {
-        return parseState
+    private Optional<ParseState> slice(final Environment environment, final BigInteger dataSize) {
+        return environment.parseState
             .slice(dataSize)
-            .map(slice -> parseState.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(parseState.offset)))
+            .map(slice -> environment.parseState.add(new ParseValue(environment.scope, this, slice, environment.encoding)).seek(dataSize.add(environment.parseState.offset)))
             .orElseGet(Util::failure);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -58,7 +58,7 @@ public class Def extends Token {
 
     @Override
     protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> sizes = size.eval(parseState.order, encoding);
+        final ImmutableList<Optional<Value>> sizes = size.eval(parseState, encoding);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
             return failure();
         }

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.callback.Callbacks;
@@ -57,21 +57,21 @@ public class Def extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> sizes = size.eval(environment.order, encoding);
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> sizes = size.eval(parseState.order, encoding);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
             return failure();
         }
         return sizes.head
             .filter(dataSize -> dataSize.asNumeric().compareTo(ZERO) != 0)
-            .map(dataSize -> slice(scope, environment, encoding, dataSize.asNumeric()))
-            .orElseGet(() -> success(environment));
+            .map(dataSize -> slice(scope, parseState, encoding, dataSize.asNumeric()))
+            .orElseGet(() -> success(parseState));
     }
 
-    private Optional<Environment> slice(final String scope, final Environment environment, final Encoding encoding, final BigInteger dataSize) {
-        return environment
+    private Optional<ParseState> slice(final String scope, final ParseState parseState, final Encoding encoding, final BigInteger dataSize) {
+        return parseState
             .slice(dataSize)
-            .map(slice -> environment.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(environment.offset)))
+            .map(slice -> parseState.add(new ParseValue(scope, this, slice, encoding)).seek(dataSize.add(parseState.offset)))
             .orElseGet(Util::failure);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -31,6 +31,7 @@ import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -56,7 +57,7 @@ public class Def extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         final ImmutableList<Optional<Value>> sizes = size.eval(environment.order, encoding);
         if (sizes.size != 1 || !sizes.head.isPresent()) {
             return failure();

--- a/core/src/main/java/io/parsingdata/metal/token/Post.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Post.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
@@ -52,10 +52,10 @@ public class Post extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
         return token
-            .parse(scope, environment.addBranch(this), callbacks, encoding)
-            .map(nextEnvironment -> predicate.eval(nextEnvironment.order, encoding) ? success(nextEnvironment.closeBranch()) : failure())
+            .parse(scope, parseState.addBranch(this), callbacks, encoding)
+            .map(nextParseState -> predicate.eval(nextParseState.order, encoding) ? success(nextParseState.closeBranch()) : failure())
             .orElseGet(Util::failure);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Post.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Post.java
@@ -55,7 +55,7 @@ public class Post extends Token {
     protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
         return token
             .parse(scope, parseState.addBranch(this), callbacks, encoding)
-            .map(nextParseState -> predicate.eval(nextParseState.order, encoding) ? success(nextParseState.closeBranch()) : failure())
+            .map(nextParseState -> predicate.eval(nextParseState, encoding) ? success(nextParseState.closeBranch()) : failure())
             .orElseGet(Util::failure);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Post.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Post.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -51,9 +52,9 @@ public class Post extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         return token
-            .parse(scope, environment.addBranch(this), encoding)
+            .parse(scope, environment.addBranch(this), callbacks, encoding)
             .map(nextEnvironment -> predicate.eval(nextEnvironment.order, encoding) ? success(nextEnvironment.closeBranch()) : failure())
             .orElseGet(Util::failure);
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Post.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Post.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -52,10 +52,10 @@ public class Post extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+    protected Optional<ParseState> parseImpl(final Environment environment) {
         return token
-            .parse(scope, parseState.addBranch(this), callbacks, encoding)
-            .map(nextParseState -> predicate.eval(nextParseState, encoding) ? success(nextParseState.closeBranch()) : failure())
+            .parse(environment.addBranch(this))
+            .map(nextParseState -> predicate.eval(nextParseState, environment.encoding) ? success(nextParseState.closeBranch()) : failure())
             .orElseGet(Util::failure);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -53,12 +53,12 @@ public class Pre extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        if (!predicate.eval(parseState, encoding)) {
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        if (!predicate.eval(environment.parseState, environment.encoding)) {
             return failure();
         }
         return token
-            .parse(scope, parseState.addBranch(this), callbacks, encoding)
+            .parse(environment.addBranch(this))
             .map(resultParseState -> success(resultParseState.closeBranch()))
             .orElseGet(Util::failure);
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
@@ -53,13 +53,13 @@ public class Pre extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        if (!predicate.eval(environment.order, encoding)) {
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        if (!predicate.eval(parseState.order, encoding)) {
             return failure();
         }
         return token
-            .parse(scope, environment.addBranch(this), callbacks, encoding)
-            .map(resultEnvironment -> success(resultEnvironment.closeBranch()))
+            .parse(scope, parseState.addBranch(this), callbacks, encoding)
+            .map(resultParseState -> success(resultParseState.closeBranch()))
             .orElseGet(Util::failure);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -52,12 +53,12 @@ public class Pre extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         if (!predicate.eval(environment.order, encoding)) {
             return failure();
         }
         return token
-            .parse(scope, environment.addBranch(this), encoding)
+            .parse(scope, environment.addBranch(this), callbacks, encoding)
             .map(resultEnvironment -> success(resultEnvironment.closeBranch()))
             .orElseGet(Util::failure);
     }

--- a/core/src/main/java/io/parsingdata/metal/token/Pre.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Pre.java
@@ -54,7 +54,7 @@ public class Pre extends Token {
 
     @Override
     protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        if (!predicate.eval(parseState.order, encoding)) {
+        if (!predicate.eval(parseState, encoding)) {
             return failure();
         }
         return token

--- a/core/src/main/java/io/parsingdata/metal/token/Rep.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Rep.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
@@ -48,15 +48,15 @@ public class Rep extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), callbacks, encoding).computeResult();
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, parseState.addBranch(this), callbacks, encoding).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
         return token
-            .parse(scope, environment, callbacks, encoding)
-            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding)))
-            .orElseGet(() -> complete(() -> success(environment.closeBranch())));
+            .parse(scope, parseState, callbacks, encoding)
+            .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding)))
+            .orElseGet(() -> complete(() -> success(parseState.closeBranch())));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Rep.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Rep.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -47,14 +48,14 @@ public class Rep extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), encoding).computeResult();
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, environment.addBranch(this), callbacks, encoding).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding) {
+    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         return token
-            .parse(scope, environment, encoding)
-            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding)))
+            .parse(scope, environment, callbacks, encoding)
+            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding)))
             .orElseGet(() -> complete(() -> success(environment.closeBranch())));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Rep.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Rep.java
@@ -25,8 +25,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -48,15 +48,15 @@ public class Rep extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, parseState.addBranch(this), callbacks, encoding).computeResult();
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        return iterate(environment.addBranch(this)).computeResult();
     }
 
-    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+    private Trampoline<Optional<ParseState>> iterate(final Environment environment) {
         return token
-            .parse(scope, parseState, callbacks, encoding)
-            .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding)))
-            .orElseGet(() -> complete(() -> success(parseState.closeBranch())));
+            .parse(environment)
+            .map(nextParseState -> intermediate(() -> iterate(environment.withParseState(nextParseState))))
+            .orElseGet(() -> complete(() -> success(environment.parseState.closeBranch())));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -29,6 +29,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -57,21 +58,21 @@ public class RepN extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         final ImmutableList<Optional<Value>> counts = n.eval(environment.order, encoding);
         if (counts.size != 1 || !counts.head.isPresent()) {
             return failure();
         }
-        return iterate(scope, environment.addBranch(this), encoding, counts.head.get().asNumeric().longValueExact()).computeResult();
+        return iterate(scope, environment.addBranch(this), callbacks, encoding, counts.head.get().asNumeric().longValueExact()).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding, final long count) {
+    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding, final long count) {
         if (count <= 0) {
             return complete(() -> success(environment.closeBranch()));
         }
         return token
-            .parse(scope, environment, encoding)
-            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding, count - 1)))
+            .parse(scope, environment, callbacks, encoding)
+            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding, count - 1)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
@@ -58,21 +58,21 @@ public class RepN extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> counts = n.eval(environment.order, encoding);
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        final ImmutableList<Optional<Value>> counts = n.eval(parseState.order, encoding);
         if (counts.size != 1 || !counts.head.isPresent()) {
             return failure();
         }
-        return iterate(scope, environment.addBranch(this), callbacks, encoding, counts.head.get().asNumeric().longValueExact()).computeResult();
+        return iterate(scope, parseState.addBranch(this), callbacks, encoding, counts.head.get().asNumeric().longValueExact()).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding, final long count) {
+    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding, final long count) {
         if (count <= 0) {
-            return complete(() -> success(environment.closeBranch()));
+            return complete(() -> success(parseState.closeBranch()));
         }
         return token
-            .parse(scope, environment, callbacks, encoding)
-            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding, count - 1)))
+            .parse(scope, parseState, callbacks, encoding)
+            .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding, count - 1)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -27,9 +27,9 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.callback.Callbacks;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -58,21 +58,21 @@ public class RepN extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> counts = n.eval(parseState, encoding);
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        final ImmutableList<Optional<Value>> counts = n.eval(environment.parseState, environment.encoding);
         if (counts.size != 1 || !counts.head.isPresent()) {
             return failure();
         }
-        return iterate(scope, parseState.addBranch(this), callbacks, encoding, counts.head.get().asNumeric().longValueExact()).computeResult();
+        return iterate(environment.addBranch(this), counts.head.get().asNumeric().longValueExact()).computeResult();
     }
 
-    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding, final long count) {
+    private Trampoline<Optional<ParseState>> iterate(final Environment environment, final long count) {
         if (count <= 0) {
-            return complete(() -> success(parseState.closeBranch()));
+            return complete(() -> success(environment.parseState.closeBranch()));
         }
         return token
-            .parse(scope, parseState, callbacks, encoding)
-            .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding, count - 1)))
+            .parse(environment)
+            .map(nextParseState -> intermediate(() -> iterate(environment.withParseState(nextParseState), count - 1)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -59,7 +59,7 @@ public class RepN extends Token {
 
     @Override
     protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> counts = n.eval(parseState.order, encoding);
+        final ImmutableList<Optional<Value>> counts = n.eval(parseState, encoding);
         if (counts.size != 1 || !counts.head.isPresent()) {
             return failure();
         }

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -30,6 +30,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -51,17 +52,17 @@ public class Seq extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), encoding, tokens).computeResult();
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, environment.addBranch(this), callbacks, encoding, tokens).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding, final ImmutableList<Token> list) {
+    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
         if (list.isEmpty()) {
             return complete(() -> success(environment.closeBranch()));
         }
         return list.head
-            .parse(scope, environment, encoding)
-            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding, list.tail)))
+            .parse(scope, environment, callbacks, encoding)
+            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding, list.tail)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
@@ -52,17 +52,17 @@ public class Seq extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), callbacks, encoding, tokens).computeResult();
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, parseState.addBranch(this), callbacks, encoding, tokens).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
+    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
         if (list.isEmpty()) {
-            return complete(() -> success(environment.closeBranch()));
+            return complete(() -> success(parseState.closeBranch()));
         }
         return list.head
-            .parse(scope, environment, callbacks, encoding)
-            .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding, list.tail)))
+            .parse(scope, parseState, callbacks, encoding)
+            .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding, list.tail)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Seq.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Seq.java
@@ -28,9 +28,9 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.callback.Callbacks;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -52,17 +52,17 @@ public class Seq extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, parseState.addBranch(this), callbacks, encoding, tokens).computeResult();
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        return iterate(environment.addBranch(this), tokens).computeResult();
     }
 
-    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding, final ImmutableList<Token> list) {
+    private Trampoline<Optional<ParseState>> iterate(final Environment environment, final ImmutableList<Token> list) {
         if (list.isEmpty()) {
-            return complete(() -> success(parseState.closeBranch()));
+            return complete(() -> success(environment.parseState.closeBranch()));
         }
         return list.head
-            .parse(scope, parseState, callbacks, encoding)
-            .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding, list.tail)))
+            .parse(environment)
+            .map(nextParseState -> intermediate(() -> iterate(environment.withParseState(nextParseState), list.tail)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -64,7 +64,7 @@ public class Sub extends Token {
 
     @Override
     protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> addresses = address.eval(parseState.order, encoding);
+        final ImmutableList<Optional<Value>> addresses = address.eval(parseState, encoding);
         if (addresses.isEmpty()) {
             return failure();
         }

--- a/core/src/main/java/io/parsingdata/metal/token/Tie.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Tie.java
@@ -27,9 +27,9 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.callback.Callbacks;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -60,24 +60,24 @@ public class Tie extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> dataResult = dataExpression.eval(parseState, encoding);
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        final ImmutableList<Optional<Value>> dataResult = dataExpression.eval(environment.parseState, environment.encoding);
         if (dataResult.isEmpty()) {
             return failure();
         }
-        return iterate(scope, dataResult, 0, parseState, parseState.addBranch(this), callbacks, encoding).computeResult();
+        return iterate(environment.addBranch(this), dataResult, 0, environment.parseState).computeResult();
     }
 
-    private Trampoline<Optional<ParseState>> iterate(final String scope, final ImmutableList<Optional<Value>> values, final int index, final ParseState returnParseState, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+    private Trampoline<Optional<ParseState>> iterate(final Environment environment, final ImmutableList<Optional<Value>> values, final int index, final ParseState returnParseState) {
         if (values.isEmpty()) {
-            return complete(() -> success(new ParseState(parseState.closeBranch().order, returnParseState.source, returnParseState.offset)));
+            return complete(() -> success(new ParseState(environment.parseState.closeBranch().order, returnParseState.source, returnParseState.offset)));
         }
         if (!values.head.isPresent()) {
             return complete(Util::failure);
         }
         return token
-            .parse(scope, parseState.source(dataExpression, index, parseState, encoding), callbacks, encoding)
-            .map(nextParseState -> intermediate(() -> iterate(scope, values.tail, index + 1, returnParseState, nextParseState, callbacks, encoding)))
+            .parse(environment.withParseState(environment.parseState.source(dataExpression, index, environment.parseState, environment.encoding)))
+            .map(nextParseState -> intermediate(() -> iterate(environment.withParseState(nextParseState), values.tail, index + 1, returnParseState)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Tie.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Tie.java
@@ -61,7 +61,7 @@ public class Tie extends Token {
 
     @Override
     protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> dataResult = dataExpression.eval(parseState.order, encoding);
+        final ImmutableList<Optional<Value>> dataResult = dataExpression.eval(parseState, encoding);
         if (dataResult.isEmpty()) {
             return failure();
         }

--- a/core/src/main/java/io/parsingdata/metal/token/Tie.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Tie.java
@@ -29,6 +29,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -59,24 +60,24 @@ public class Tie extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         final ImmutableList<Optional<Value>> dataResult = dataExpression.eval(environment.order, encoding);
         if (dataResult.isEmpty()) {
             return failure();
         }
-        return iterate(scope, dataResult, 0, environment, environment.addBranch(this), encoding).computeResult();
+        return iterate(scope, dataResult, 0, environment, environment.addBranch(this), callbacks, encoding).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final ImmutableList<Optional<Value>> values, final int index, final Environment returnEnvironment, final Environment environment, final Encoding encoding) {
+    private Trampoline<Optional<Environment>> iterate(final String scope, final ImmutableList<Optional<Value>> values, final int index, final Environment returnEnvironment, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         if (values.isEmpty()) {
-            return complete(() -> success(new Environment(environment.closeBranch().order, returnEnvironment.source, returnEnvironment.offset, returnEnvironment.callbacks)));
+            return complete(() -> success(new Environment(environment.closeBranch().order, returnEnvironment.source, returnEnvironment.offset)));
         }
         if (!values.head.isPresent()) {
             return complete(Util::failure);
         }
         return token
-            .parse(scope, environment.source(dataExpression, index, environment, encoding), encoding)
-            .map(nextEnvironment -> intermediate(() -> iterate(scope, values.tail, index + 1, returnEnvironment, nextEnvironment, encoding)))
+            .parse(scope, environment.source(dataExpression, index, environment, encoding), callbacks, encoding)
+            .map(nextEnvironment -> intermediate(() -> iterate(scope, values.tail, index + 1, returnEnvironment, nextEnvironment, callbacks, encoding)))
             .orElseGet(() -> complete(Util::failure));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -63,20 +64,28 @@ public abstract class Token {
         this.encoding = encoding;
     }
 
-    public Optional<Environment> parse(final String scope, final Environment environment, final Encoding encoding) {
+    public Optional<Environment> parse(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         final Encoding activeEncoding = this.encoding != null ? this.encoding : encoding;
-        final Optional<Environment> result = parseImpl(makeScope(checkNotNull(scope, "scope")), checkNotNull(environment, "environment"), activeEncoding);
-        environment.callbacks.handle(this, result
+        final Optional<Environment> result = parseImpl(makeScope(checkNotNull(scope, "scope")), checkNotNull(environment, "environment"), callbacks, activeEncoding);
+        callbacks.handle(this, result
             .map(after -> success(this, environment, after))
             .orElseGet(() -> failure(this, environment)));
         return result;
     }
 
-    public Optional<Environment> parse(final Environment environment, final Encoding encoding) {
-        return parse(NO_NAME, environment, encoding);
+    public Optional<Environment> parse(final String scope, final Environment environment, final Encoding encoding) {
+        return parse(scope, environment, Callbacks.NONE, encoding);
     }
 
-    protected abstract Optional<Environment> parseImpl(String scope, Environment environment, Encoding encoding);
+    public Optional<Environment> parse(final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        return parse(NO_NAME, environment, callbacks, encoding);
+    }
+
+    public Optional<Environment> parse(final Environment environment, final Encoding encoding) {
+        return parse(environment, Callbacks.NONE, encoding);
+    }
+
+    protected abstract Optional<Environment> parseImpl(String scope, Environment environment, Callbacks callbacks, Encoding encoding);
 
     private String makeScope(final String scope) {
         return scope + (scope.isEmpty() || name.isEmpty() ? NO_NAME : SEPARATOR) + name;

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -96,7 +96,7 @@ public abstract class Token {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), name, encoding);
+        return Objects.hash(getClass(), name, encoding);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
@@ -37,7 +37,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * Specifies the two fields that all tokens share: <code>name</code> (a
  * String) and <code>encoding</code> (an {@link Encoding}). A Token is parsed
  * by calling one of the <code>parse</code> methods. Parsing a Token succeeds
- * if the returned {@link Optional} contains an {@link Environment}, otherwise
+ * if the returned {@link Optional} contains an {@link ParseState}, otherwise
  * parsing has failed.
  * <p>
  * The <code>name</code> field is used during parsing to construct a scope, by
@@ -64,28 +64,28 @@ public abstract class Token {
         this.encoding = encoding;
     }
 
-    public Optional<Environment> parse(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+    public Optional<ParseState> parse(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
         final Encoding activeEncoding = this.encoding != null ? this.encoding : encoding;
-        final Optional<Environment> result = parseImpl(makeScope(checkNotNull(scope, "scope")), checkNotNull(environment, "environment"), callbacks, activeEncoding);
+        final Optional<ParseState> result = parseImpl(makeScope(checkNotNull(scope, "scope")), checkNotNull(parseState, "parseState"), callbacks, activeEncoding);
         callbacks.handle(this, result
-            .map(after -> success(this, environment, after))
-            .orElseGet(() -> failure(this, environment)));
+            .map(after -> success(this, parseState, after))
+            .orElseGet(() -> failure(this, parseState)));
         return result;
     }
 
-    public Optional<Environment> parse(final String scope, final Environment environment, final Encoding encoding) {
-        return parse(scope, environment, Callbacks.NONE, encoding);
+    public Optional<ParseState> parse(final String scope, final ParseState parseState, final Encoding encoding) {
+        return parse(scope, parseState, Callbacks.NONE, encoding);
     }
 
-    public Optional<Environment> parse(final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        return parse(NO_NAME, environment, callbacks, encoding);
+    public Optional<ParseState> parse(final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        return parse(NO_NAME, parseState, callbacks, encoding);
     }
 
-    public Optional<Environment> parse(final Environment environment, final Encoding encoding) {
-        return parse(environment, Callbacks.NONE, encoding);
+    public Optional<ParseState> parse(final ParseState parseState, final Encoding encoding) {
+        return parse(parseState, Callbacks.NONE, encoding);
     }
 
-    protected abstract Optional<Environment> parseImpl(String scope, Environment environment, Callbacks callbacks, Encoding encoding);
+    protected abstract Optional<ParseState> parseImpl(String scope, ParseState parseState, Callbacks callbacks, Encoding encoding);
 
     private String makeScope(final String scope) {
         return scope + (scope.isEmpty() || name.isEmpty() ? NO_NAME : SEPARATOR) + name;
@@ -95,7 +95,7 @@ public abstract class Token {
         return true;
     }
 
-    public Token getCanonical(final Environment environment) {
+    public Token getCanonical(final ParseState parseState) {
         return this;
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/Token.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Token.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -64,32 +64,16 @@ public abstract class Token {
         this.encoding = encoding;
     }
 
-    public Optional<ParseState> parse(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        final Encoding activeEncoding = this.encoding != null ? this.encoding : encoding;
-        final Optional<ParseState> result = parseImpl(makeScope(checkNotNull(scope, "scope")), checkNotNull(parseState, "parseState"), callbacks, activeEncoding);
-        callbacks.handle(this, result
-            .map(after -> success(this, parseState, after))
-            .orElseGet(() -> failure(this, parseState)));
+    public Optional<ParseState> parse(final Environment environment) {
+        final Environment activeEnvironment = this.encoding != null ? environment.withEncoding(this.encoding) : environment;
+        final Optional<ParseState> result = parseImpl(activeEnvironment.extendScope(name));
+        environment.callbacks.handle(this, result
+            .map(after -> success(this, environment.parseState, after))
+            .orElseGet(() -> failure(this, environment.parseState)));
         return result;
     }
 
-    public Optional<ParseState> parse(final String scope, final ParseState parseState, final Encoding encoding) {
-        return parse(scope, parseState, Callbacks.NONE, encoding);
-    }
-
-    public Optional<ParseState> parse(final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        return parse(NO_NAME, parseState, callbacks, encoding);
-    }
-
-    public Optional<ParseState> parse(final ParseState parseState, final Encoding encoding) {
-        return parse(parseState, Callbacks.NONE, encoding);
-    }
-
-    protected abstract Optional<ParseState> parseImpl(String scope, ParseState parseState, Callbacks callbacks, Encoding encoding);
-
-    private String makeScope(final String scope) {
-        return scope + (scope.isEmpty() || name.isEmpty() ? NO_NAME : SEPARATOR) + name;
-    }
+    protected abstract Optional<ParseState> parseImpl(final Environment environment);
 
     public boolean isLocal() {
         return true;

--- a/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
@@ -25,10 +25,10 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseItem;
-import io.parsingdata.metal.data.callback.Callbacks;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -46,7 +46,7 @@ public class TokenRef extends Token {
 
     private static final Token LOOKUP_FAILED = new Token("LOOKUP_FAILED", null) {
         @Override
-        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        protected Optional<ParseState> parseImpl(final Environment environment) {
             return failure();
         }
     };
@@ -62,8 +62,8 @@ public class TokenRef extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        return lookup(ImmutableList.create(parseState.order), referenceName).computeResult().parse(scope, parseState, callbacks, encoding);
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        return lookup(ImmutableList.create(environment.parseState.order), referenceName).computeResult().parse(environment);
     }
 
     private Trampoline<Token> lookup(final ImmutableList<ParseItem> items, final String referenceName) {

--- a/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.callback.Callbacks;
@@ -46,7 +46,7 @@ public class TokenRef extends Token {
 
     private static final Token LOOKUP_FAILED = new Token("LOOKUP_FAILED", null) {
         @Override
-        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
             return failure();
         }
     };
@@ -62,8 +62,8 @@ public class TokenRef extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        return lookup(ImmutableList.create(environment.order), referenceName).computeResult().parse(scope, environment, callbacks, encoding);
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        return lookup(ImmutableList.create(parseState.order), referenceName).computeResult().parse(scope, parseState, callbacks, encoding);
     }
 
     private Trampoline<Token> lookup(final ImmutableList<ParseItem> items, final String referenceName) {
@@ -81,8 +81,8 @@ public class TokenRef extends Token {
     }
 
     @Override
-    public Token getCanonical(final Environment environment) {
-        return lookup(ImmutableList.create(environment.order), referenceName).computeResult();
+    public Token getCanonical(final ParseState parseState) {
+        return lookup(ImmutableList.create(parseState.order), referenceName).computeResult();
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
+++ b/core/src/main/java/io/parsingdata/metal/token/TokenRef.java
@@ -28,6 +28,7 @@ import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseItem;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -45,7 +46,7 @@ public class TokenRef extends Token {
 
     private static final Token LOOKUP_FAILED = new Token("LOOKUP_FAILED", null) {
         @Override
-        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
             return failure();
         }
     };
@@ -61,8 +62,8 @@ public class TokenRef extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
-        return lookup(ImmutableList.create(environment.order), referenceName).computeResult().parse(scope, environment, encoding);
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        return lookup(ImmutableList.create(environment.order), referenceName).computeResult().parse(scope, environment, callbacks, encoding);
     }
 
     private Trampoline<Token> lookup(final ImmutableList<ParseItem> items, final String referenceName) {

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -86,7 +86,7 @@ public class Until extends Token {
 
     @Override
     protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        return handleInterval(scope, parseState, initialSize.eval(parseState.order, encoding), stepSize.eval(parseState.order, encoding), maxSize.eval(parseState.order, encoding), callbacks, encoding).computeResult();
+        return handleInterval(scope, parseState, initialSize.eval(parseState, encoding), stepSize.eval(parseState, encoding), maxSize.eval(parseState, encoding), callbacks, encoding).computeResult();
     }
 
     private Trampoline<Optional<ParseState>> handleInterval(final String scope, final ParseState parseState, final ImmutableList<Optional<Value>> initialSizes, final ImmutableList<Optional<Value>> stepSizes, final ImmutableList<Optional<Value>> maxSizes, final Callbacks callbacks, final Encoding encoding) {

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -56,15 +57,15 @@ public class While extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), encoding).computeResult();
+    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, environment.addBranch(this), callbacks, encoding).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Encoding encoding) {
+    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
         if (predicate.eval(environment.order, encoding)) {
             return token
-                .parse(scope, environment, encoding)
-                .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, encoding)))
+                .parse(scope, environment, callbacks, encoding)
+                .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding)))
                 .orElseGet(() -> complete(Util::failure));
         }
         return complete(() -> success(environment.closeBranch()));

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -62,7 +62,7 @@ public class While extends Token {
     }
 
     private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        if (predicate.eval(parseState.order, encoding)) {
+        if (predicate.eval(parseState, encoding)) {
             return token
                 .parse(scope, parseState, callbacks, encoding)
                 .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding)))

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 
@@ -57,18 +57,18 @@ public class While extends Token {
     }
 
     @Override
-    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, parseState.addBranch(this), callbacks, encoding).computeResult();
+    protected Optional<ParseState> parseImpl(final Environment environment) {
+        return iterate(environment.addBranch(this)).computeResult();
     }
 
-    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-        if (predicate.eval(parseState, encoding)) {
+    private Trampoline<Optional<ParseState>> iterate(final Environment environment) {
+        if (predicate.eval(environment.parseState, environment.encoding)) {
             return token
-                .parse(scope, parseState, callbacks, encoding)
-                .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding)))
+                .parse(environment)
+                .map(nextParseState -> intermediate(() -> iterate(environment.withParseState(nextParseState))))
                 .orElseGet(() -> complete(Util::failure));
         }
-        return complete(() -> success(parseState.closeBranch()));
+        return complete(() -> success(environment.parseState.closeBranch()));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/While.java
+++ b/core/src/main/java/io/parsingdata/metal/token/While.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
@@ -57,18 +57,18 @@ public class While extends Token {
     }
 
     @Override
-    protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        return iterate(scope, environment.addBranch(this), callbacks, encoding).computeResult();
+    protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        return iterate(scope, parseState.addBranch(this), callbacks, encoding).computeResult();
     }
 
-    private Trampoline<Optional<Environment>> iterate(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-        if (predicate.eval(environment.order, encoding)) {
+    private Trampoline<Optional<ParseState>> iterate(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        if (predicate.eval(parseState.order, encoding)) {
             return token
-                .parse(scope, environment, callbacks, encoding)
-                .map(nextEnvironment -> intermediate(() -> iterate(scope, nextEnvironment, callbacks, encoding)))
+                .parse(scope, parseState, callbacks, encoding)
+                .map(nextParseState -> intermediate(() -> iterate(scope, nextParseState, callbacks, encoding)))
                 .orElseGet(() -> complete(Util::failure));
         }
-        return complete(() -> success(environment.closeBranch()));
+        return complete(() -> success(parseState.closeBranch()));
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -35,6 +35,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.comparison.Eq;
@@ -78,7 +79,7 @@ public class ArgumentsTest {
     final private static ValueExpression VALID_VE = con(1);
     final private static BinaryOperator<ValueExpression> VALID_REDUCER = (left, right) -> null;
     final private static Expression VALID_E = (graph, encoding) -> false;
-    final private static Token VALID_T = new Token("", null) { @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) { return null; } };
+    final private static Token VALID_T = new Token("", null) { @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) { return null; } };
 
     private final Class<?> _class;
     private final Object[] _arguments;

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -34,9 +34,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.callback.Callbacks;
-import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.comparison.Eq;
 import io.parsingdata.metal.expression.comparison.EqNum;
@@ -78,8 +77,8 @@ public class ArgumentsTest {
     final private static String EMPTY_NAME = "";
     final private static ValueExpression VALID_VE = con(1);
     final private static BinaryOperator<ValueExpression> VALID_REDUCER = (left, right) -> null;
-    final private static Expression VALID_E = (graph, encoding) -> false;
-    final private static Token VALID_T = new Token("", null) { @Override protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) { return null; } };
+    final private static Expression VALID_E = (parseState, encoding) -> false;
+    final private static Token VALID_T = new Token("", null) { @Override protected Optional<ParseState> parseImpl(final Environment environment) { return null; } };
 
     private final Class<?> _class;
     private final Object[] _arguments;

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
@@ -79,7 +79,7 @@ public class ArgumentsTest {
     final private static ValueExpression VALID_VE = con(1);
     final private static BinaryOperator<ValueExpression> VALID_REDUCER = (left, right) -> null;
     final private static Expression VALID_E = (graph, encoding) -> false;
-    final private static Token VALID_T = new Token("", null) { @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) { return null; } };
+    final private static Token VALID_T = new Token("", null) { @Override protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) { return null; } };
 
     private final Class<?> _class;
     private final Object[] _arguments;

--- a/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
@@ -30,7 +30,7 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -57,7 +57,7 @@ import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.ByteStreamSource;
 import io.parsingdata.metal.data.ConstantSource;
 import io.parsingdata.metal.data.DataExpressionSource;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseReference;
@@ -124,9 +124,9 @@ public class AutoEqualityTest {
     };
 
     private static final ParseValue PARSEVALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-    private static final ParseGraph GRAPH_WITH_REFERENCE = new Environment(DUMMY_STREAM).add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a"))).order;
-    private static final ParseGraph BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).order;
-    private static final ParseGraph CLOSED_BRANCHED_GRAPH = new Environment(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
+    private static final ParseGraph GRAPH_WITH_REFERENCE = new ParseState(DUMMY_STREAM).add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a"))).order;
+    private static final ParseGraph BRANCHED_GRAPH = new ParseState(DUMMY_STREAM).addBranch(any("a")).order;
+    private static final ParseGraph CLOSED_BRANCHED_GRAPH = new ParseState(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
 
     private static final List<Supplier<Object>> STRINGS = Arrays.asList(() -> "a", () -> "b");
     private static final List<Supplier<Object>> ENCODINGS = Arrays.asList(() -> enc(), () -> signed(), () -> le(), () -> new Encoding(Charset.forName("UTF-8")));
@@ -136,13 +136,13 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()));
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
-    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, new Environment(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, enc()), ZERO, BigInteger.valueOf(2)).get());
+    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, new ParseState(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, enc()), ZERO, BigInteger.valueOf(2)).get());
     private static final List<Supplier<Object>> BYTE_ARRAYS = Arrays.asList(() -> new byte[] { 0 }, () -> new byte[] { 1, 2 }, () -> new byte[] {});
-    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, new Environment(DUMMY_STREAM).add(PARSEVALUE).order, signed()));
+    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, new ParseState(DUMMY_STREAM).add(PARSEVALUE).order, signed()));
     private static final List<Supplier<Object>> LONGS = Arrays.asList(() -> 0L, () -> 1L, () -> 31L, () -> 100000L);
     private static final List<Supplier<Object>> INTEGERS = Arrays.asList(() -> 0, () -> 1, () -> 17, () -> 21212121);
     private static final List<Supplier<Object>> PARSEGRAPHS = Arrays.asList(() -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE);
-    private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> new Environment(DUMMY_STREAM).add(PARSEVALUE).order, () -> new Environment(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, () -> BRANCHED_GRAPH);
+    private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> new ParseState(DUMMY_STREAM).add(PARSEVALUE).order, () -> new ParseState(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, () -> BRANCHED_GRAPH);
     private static final List<Supplier<Object>> BYTESTREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
     private static final List<Supplier<Object>> BIGINTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
     private static final Map<Class, List<Supplier<Object>>> mapping = new HashMap<Class, List<Supplier<Object>>>() {{

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -61,6 +61,7 @@ import io.parsingdata.metal.data.DataExpressionSource;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseReference;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.Slice;
 import io.parsingdata.metal.data.Source;
@@ -113,6 +114,7 @@ import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
 import io.parsingdata.metal.token.Until;
 import io.parsingdata.metal.token.While;
+import io.parsingdata.metal.util.EncodingFactory;
 import io.parsingdata.metal.util.InMemoryByteStream;
 
 @RunWith(Parameterized.class)
@@ -129,7 +131,7 @@ public class AutoEqualityTest {
     private static final ParseGraph CLOSED_BRANCHED_GRAPH = createFromByteStream(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
 
     private static final List<Supplier<Object>> STRINGS = Arrays.asList(() -> "a", () -> "b");
-    private static final List<Supplier<Object>> ENCODINGS = Arrays.asList(() -> enc(), () -> signed(), () -> le(), () -> new Encoding(Charset.forName("UTF-8")));
+    private static final List<Supplier<Object>> ENCODINGS = Arrays.asList(EncodingFactory::enc, EncodingFactory::signed, EncodingFactory::le, () -> new Encoding(Charset.forName("UTF-8")));
     private static final List<Supplier<Object>> TOKENS = Arrays.asList(() -> any("a"), () -> any("b"));
     private static final List<Supplier<Object>> TOKEN_ARRAYS = Arrays.asList(() -> new Token[] { any("a"), any("b")}, () -> new Token[] { any("b"), any("c") }, () -> new Token[] { any("a"), any("b"), any("c") });
     private static final List<Supplier<Object>> VALUE_EXPRESSIONS = Arrays.asList(() -> con(1), () -> con(2));
@@ -144,7 +146,7 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> PARSEGRAPHS = Arrays.asList(() -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE);
     private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).order, () -> createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, () -> BRANCHED_GRAPH);
     private static final List<Supplier<Object>> BYTESTREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
-    private static final List<Supplier<Object>> BIGINTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
+    private static final List<Supplier<Object>> BIG_INTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
     private static final Map<Class, List<Supplier<Object>>> mapping = new HashMap<Class, List<Supplier<Object>>>() {{
         put(String.class, STRINGS);
         put(Encoding.class, ENCODINGS);
@@ -162,7 +164,7 @@ public class AutoEqualityTest {
         put(ParseGraph.class, PARSEGRAPHS);
         put(ParseItem.class, PARSEITEMS);
         put(ByteStream.class, BYTESTREAMS);
-        put(BigInteger.class, BIGINTEGERS);
+        put(BigInteger.class, BIG_INTEGERS);
     }};
 
     @Parameterized.Parameters(name="{0}")
@@ -181,7 +183,7 @@ public class AutoEqualityTest {
             io.parsingdata.metal.expression.logical.And.class, io.parsingdata.metal.expression.logical.Or.class,
             io.parsingdata.metal.expression.logical.Not.class,
             // Data structures
-            Value.class, ParseValue.class, ParseReference.class,
+            Value.class, ParseValue.class, ParseReference.class, ParseState.class,
             // Inputs
             ConstantSource.class, DataExpressionSource.class, ByteStreamSource.class
             );

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -97,6 +97,7 @@ import io.parsingdata.metal.expression.value.bitwise.Or;
 import io.parsingdata.metal.expression.value.bitwise.ShiftLeft;
 import io.parsingdata.metal.expression.value.bitwise.ShiftRight;
 import io.parsingdata.metal.expression.value.reference.Count;
+import io.parsingdata.metal.expression.value.reference.CurrentOffset;
 import io.parsingdata.metal.expression.value.reference.First;
 import io.parsingdata.metal.expression.value.reference.Last;
 import io.parsingdata.metal.expression.value.reference.Len;
@@ -180,7 +181,7 @@ public class AutoEqualityTest {
             Len.class, Offset.class, Neg.class, Not.class, Count.class, First.class, Last.class, Reverse.class,
             And.class, Or.class, ShiftLeft.class, ShiftRight.class, Add.class, Div.class, Mod.class, Mul.class,
             io.parsingdata.metal.expression.value.arithmetic.Sub.class, Cat.class, Nth.class, Elvis.class,
-            FoldLeft.class, FoldRight.class, Const.class, Expand.class, Bytes.class,
+            FoldLeft.class, FoldRight.class, Const.class, Expand.class, Bytes.class, CurrentOffset.class,
             // Expressions
             Eq.class, EqNum.class, EqStr.class, GtEqNum.class, GtNum.class, LtEqNum.class, LtNum.class,
             io.parsingdata.metal.expression.logical.And.class, io.parsingdata.metal.expression.logical.Or.class,

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -28,6 +28,7 @@ import static io.parsingdata.metal.Shorthand.TRUE;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
@@ -57,7 +58,6 @@ import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.ByteStreamSource;
 import io.parsingdata.metal.data.ConstantSource;
 import io.parsingdata.metal.data.DataExpressionSource;
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseReference;
@@ -124,9 +124,9 @@ public class AutoEqualityTest {
     };
 
     private static final ParseValue PARSEVALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-    private static final ParseGraph GRAPH_WITH_REFERENCE = new ParseState(DUMMY_STREAM).add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a"))).order;
-    private static final ParseGraph BRANCHED_GRAPH = new ParseState(DUMMY_STREAM).addBranch(any("a")).order;
-    private static final ParseGraph CLOSED_BRANCHED_GRAPH = new ParseState(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
+    private static final ParseGraph GRAPH_WITH_REFERENCE = createFromByteStream(DUMMY_STREAM).add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a"))).order;
+    private static final ParseGraph BRANCHED_GRAPH = createFromByteStream(DUMMY_STREAM).addBranch(any("a")).order;
+    private static final ParseGraph CLOSED_BRANCHED_GRAPH = createFromByteStream(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
 
     private static final List<Supplier<Object>> STRINGS = Arrays.asList(() -> "a", () -> "b");
     private static final List<Supplier<Object>> ENCODINGS = Arrays.asList(() -> enc(), () -> signed(), () -> le(), () -> new Encoding(Charset.forName("UTF-8")));
@@ -136,13 +136,13 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()));
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
-    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, new ParseState(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, enc()), ZERO, BigInteger.valueOf(2)).get());
+    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, enc()), ZERO, BigInteger.valueOf(2)).get());
     private static final List<Supplier<Object>> BYTE_ARRAYS = Arrays.asList(() -> new byte[] { 0 }, () -> new byte[] { 1, 2 }, () -> new byte[] {});
-    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, new ParseState(DUMMY_STREAM).add(PARSEVALUE).order, signed()));
+    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).order, signed()));
     private static final List<Supplier<Object>> LONGS = Arrays.asList(() -> 0L, () -> 1L, () -> 31L, () -> 100000L);
     private static final List<Supplier<Object>> INTEGERS = Arrays.asList(() -> 0, () -> 1, () -> 17, () -> 21212121);
     private static final List<Supplier<Object>> PARSEGRAPHS = Arrays.asList(() -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE);
-    private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> new ParseState(DUMMY_STREAM).add(PARSEVALUE).order, () -> new ParseState(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, () -> BRANCHED_GRAPH);
+    private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).order, () -> createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, () -> BRANCHED_GRAPH);
     private static final List<Supplier<Object>> BYTESTREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
     private static final List<Supplier<Object>> BIGINTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
     private static final Map<Class, List<Supplier<Object>>> mapping = new HashMap<Class, List<Supplier<Object>>>() {{

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal;
 
 import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
 
 import static org.junit.Assert.assertEquals;
@@ -28,10 +29,10 @@ import static io.parsingdata.metal.Shorthand.TRUE;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.data.ByteStreamSourceTest.DUMMY_BYTE_STREAM_SOURCE;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -125,7 +126,7 @@ public class AutoEqualityTest {
         @Override public boolean isAvailable(BigInteger offset, int length) { return false; }
     };
 
-    private static final ParseValue PARSEVALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
+    private static final ParseValue PARSE_VALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
     private static final ParseGraph GRAPH_WITH_REFERENCE = createFromByteStream(DUMMY_STREAM).add(new ParseReference(ZERO, new ConstantSource(new byte[]{1, 2}), any("a"))).order;
     private static final ParseGraph BRANCHED_GRAPH = createFromByteStream(DUMMY_STREAM).addBranch(any("a")).order;
     private static final ParseGraph CLOSED_BRANCHED_GRAPH = createFromByteStream(DUMMY_STREAM).addBranch(any("a")).closeBranch().order;
@@ -138,15 +139,16 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()));
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
-    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, enc()), ZERO, BigInteger.valueOf(2)).get());
+    private static final List<Supplier<Object>> SLICES = Arrays.asList(() -> createFromBytes(new byte[] { 1, 2 }), () -> Slice.createFromSource(new DataExpressionSource(ref("a"), 1, createFromByteStream(DUMMY_STREAM).add(PARSE_VALUE).add(PARSE_VALUE), enc()), ZERO, BigInteger.valueOf(2)).get());
     private static final List<Supplier<Object>> BYTE_ARRAYS = Arrays.asList(() -> new byte[] { 0 }, () -> new byte[] { 1, 2 }, () -> new byte[] {});
-    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).order, signed()));
+    private static final List<Supplier<Object>> SOURCES = Arrays.asList(() -> new ConstantSource(new byte[] {}), () -> new DataExpressionSource(ref("x"), 8, createFromByteStream(DUMMY_STREAM).add(PARSE_VALUE), signed()));
     private static final List<Supplier<Object>> LONGS = Arrays.asList(() -> 0L, () -> 1L, () -> 31L, () -> 100000L);
     private static final List<Supplier<Object>> INTEGERS = Arrays.asList(() -> 0, () -> 1, () -> 17, () -> 21212121);
-    private static final List<Supplier<Object>> PARSEGRAPHS = Arrays.asList(() -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE);
-    private static final List<Supplier<Object>> PARSEITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).order, () -> createFromByteStream(DUMMY_STREAM).add(PARSEVALUE).add(PARSEVALUE).order, () -> BRANCHED_GRAPH);
-    private static final List<Supplier<Object>> BYTESTREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
+    private static final List<Supplier<Object>> PARSE_GRAPHS = Arrays.asList(() -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE);
+    private static final List<Supplier<Object>> PARSE_ITEMS = Arrays.asList(() -> CLOSED_BRANCHED_GRAPH, () -> ParseGraph.EMPTY, () -> GRAPH_WITH_REFERENCE, () -> createFromByteStream(DUMMY_STREAM).add(PARSE_VALUE).order, () -> createFromByteStream(DUMMY_STREAM).add(PARSE_VALUE).add(PARSE_VALUE).order, () -> BRANCHED_GRAPH);
+    private static final List<Supplier<Object>> BYTE_STREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
     private static final List<Supplier<Object>> BIG_INTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
+    private static final List<Supplier<Object>> PARSE_STATES = Arrays.asList(() -> createFromByteStream(DUMMY_STREAM), () -> createFromByteStream(DUMMY_STREAM, ONE), () -> new ParseState(GRAPH_WITH_REFERENCE, DUMMY_BYTE_STREAM_SOURCE, TEN));
     private static final Map<Class, List<Supplier<Object>>> mapping = new HashMap<Class, List<Supplier<Object>>>() {{
         put(String.class, STRINGS);
         put(Encoding.class, ENCODINGS);
@@ -161,10 +163,11 @@ public class AutoEqualityTest {
         put(Source.class, SOURCES);
         put(long.class, LONGS);
         put(int.class, INTEGERS);
-        put(ParseGraph.class, PARSEGRAPHS);
-        put(ParseItem.class, PARSEITEMS);
-        put(ByteStream.class, BYTESTREAMS);
+        put(ParseGraph.class, PARSE_GRAPHS);
+        put(ParseItem.class, PARSE_ITEMS);
+        put(ByteStream.class, BYTE_STREAMS);
         put(BigInteger.class, BIG_INTEGERS);
+        put(ParseState.class, PARSE_STATES);
     }};
 
     @Parameterized.Parameters(name="{0}")

--- a/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
@@ -28,7 +28,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 import static io.parsingdata.metal.util.TokenDefinitions.eqRef;

--- a/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
@@ -28,6 +28,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
@@ -53,22 +54,22 @@ public class BackTrackNameBindTest {
 
     @Test
     public void choiceRefLeft() throws IOException {
-        assertTrue(_choiceRef.parse(stream(1, 2, 2), enc()).isPresent());
+        assertTrue(_choiceRef.parse(env(stream(1, 2, 2))).isPresent());
     }
 
     @Test
     public void choiceRefRight() throws IOException {
-        assertTrue(_choiceRef.parse(stream(1, 2, 3), enc()).isPresent());
+        assertTrue(_choiceRef.parse(env(stream(1, 2, 3))).isPresent());
     }
 
     @Test
     public void choiceRefNone() throws IOException {
-        assertFalse(_choiceRef.parse(stream(1, 1, 2), enc()).isPresent());
+        assertFalse(_choiceRef.parse(env(stream(1, 1, 2))).isPresent());
     }
 
     @Test
     public void repeatRef() throws IOException {
-        assertTrue(_repeatRef.parse(stream(42, 42, 42, 21, 21, 21), enc()).isPresent());
+        assertTrue(_repeatRef.parse(env(stream(42, 42, 42, 21, 21, 21))).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
@@ -23,6 +23,7 @@ import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
@@ -59,42 +60,42 @@ public class BackTrackOffsetTest {
 
     @Test
     public void choiceLeft() throws IOException {
-        assertTrue(_backTrackChoice.parse(stream(1, 2), enc()).isPresent());
+        assertTrue(_backTrackChoice.parse(env(stream(1, 2))).isPresent());
     }
 
     @Test
     public void choiceRight() throws IOException {
-        assertTrue(_backTrackChoice.parse(stream(1, 3), enc()).isPresent());
+        assertTrue(_backTrackChoice.parse(env(stream(1, 3))).isPresent());
     }
 
     @Test
     public void choiceNone() throws IOException {
-        assertFalse(_backTrackChoice.parse(stream(1, 4), enc()).isPresent());
+        assertFalse(_backTrackChoice.parse(env(stream(1, 4))).isPresent());
     }
 
     @Test
     public void repeatZero() throws IOException {
-        assertTrue(_backTrackRepeat.parse(stream(1, 3), enc()).isPresent());
+        assertTrue(_backTrackRepeat.parse(env(stream(1, 3))).isPresent());
     }
 
     @Test
     public void repeatOnce() throws IOException {
-        assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 3), enc()).isPresent());
+        assertTrue(_backTrackRepeat.parse(env(stream(1, 2, 1, 3))).isPresent());
     }
 
     @Test
     public void repeatTwice() throws IOException {
-        assertTrue(_backTrackRepeat.parse(stream(1, 2, 1, 2, 1, 3), enc()).isPresent());
+        assertTrue(_backTrackRepeat.parse(env(stream(1, 2, 1, 2, 1, 3))).isPresent());
     }
 
     @Test
     public void repeatNone() throws IOException {
-        assertFalse(_backTrackRepeat.parse(stream(1, 4), enc()).isPresent());
+        assertFalse(_backTrackRepeat.parse(env(stream(1, 4))).isPresent());
     }
 
     @Test
     public void deepMatch() throws IOException {
-        assertTrue(_backTrackDeep.parse(stream(1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 84), enc()).isPresent());
+        assertTrue(_backTrackDeep.parse(env(stream(1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 1, 2, 21, 1, 2, 42, 84))).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
@@ -23,7 +23,7 @@ import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 

--- a/core/src/test/java/io/parsingdata/metal/BitwiseValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BitwiseValueExpressionSemanticsTest.java
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.shl;
 import static io.parsingdata.metal.Shorthand.shr;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import org.junit.Test;
 
 import io.parsingdata.metal.data.ByteStream;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
@@ -65,8 +65,8 @@ public class ByteLengthTest {
         final byte[] text2 = "Metal".getBytes(UTF_8);
 
         final ByteStream stream = new InMemoryByteStream(concat(text1, text2));
-        final Environment environment = new Environment(stream);
-        final Optional<Environment> result = STRING.parse(environment, ENCODING);
+        final ParseState parseState = new ParseState(stream);
+        final Optional<ParseState> result = STRING.parse(parseState, ENCODING);
 
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
@@ -78,8 +78,8 @@ public class ByteLengthTest {
     @Test
     public void testLenNull() throws IOException {
         final ByteStream stream = new InMemoryByteStream(string("Joe"));
-        final Environment environment = new Environment(stream);
-        final Optional<Environment> result = NAME.parse(environment, ENCODING);
+        final ParseState parseState = new ParseState(stream);
+        final Optional<ParseState> result = NAME.parse(parseState, ENCODING);
         assertFalse(result.isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -28,6 +28,7 @@ import static io.parsingdata.metal.Shorthand.len;
 import static io.parsingdata.metal.Shorthand.ltNum;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.encoding.ByteOrder.LITTLE_ENDIAN;
 import static io.parsingdata.metal.encoding.Sign.UNSIGNED;
@@ -65,7 +66,7 @@ public class ByteLengthTest {
         final byte[] text2 = "Metal".getBytes(UTF_8);
 
         final ByteStream stream = new InMemoryByteStream(concat(text1, text2));
-        final ParseState parseState = new ParseState(stream);
+        final ParseState parseState = createFromByteStream(stream);
         final Optional<ParseState> result = STRING.parse(parseState, ENCODING);
 
         assertTrue(result.isPresent());
@@ -78,7 +79,7 @@ public class ByteLengthTest {
     @Test
     public void testLenNull() throws IOException {
         final ByteStream stream = new InMemoryByteStream(string("Joe"));
-        final ParseState parseState = new ParseState(stream);
+        final ParseState parseState = createFromByteStream(stream);
         final Optional<ParseState> result = NAME.parse(parseState, ENCODING);
         assertFalse(result.isPresent());
     }

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -32,6 +32,7 @@ import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.encoding.ByteOrder.LITTLE_ENDIAN;
 import static io.parsingdata.metal.encoding.Sign.UNSIGNED;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -67,7 +68,7 @@ public class ByteLengthTest {
 
         final ByteStream stream = new InMemoryByteStream(concat(text1, text2));
         final ParseState parseState = createFromByteStream(stream);
-        final Optional<ParseState> result = STRING.parse(parseState, ENCODING);
+        final Optional<ParseState> result = STRING.parse(env(parseState, ENCODING));
 
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
@@ -80,7 +81,7 @@ public class ByteLengthTest {
     public void testLenNull() throws IOException {
         final ByteStream stream = new InMemoryByteStream(string("Joe"));
         final ParseState parseState = createFromByteStream(stream);
-        final Optional<ParseState> result = NAME.parse(parseState, ENCODING);
+        final Optional<ParseState> result = NAME.parse(env(parseState, ENCODING));
         assertFalse(result.isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
@@ -33,7 +33,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.SELF;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;

--- a/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
@@ -31,7 +31,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;

--- a/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
@@ -23,7 +23,7 @@ import static io.parsingdata.metal.Shorthand.eqNum;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -50,7 +50,7 @@ public class CurrentOffsetTest {
         final Optional<ParseState> result = def("a", con(size)).parse(createFromByteStream(new InMemoryByteStream(data)), enc());
         assertTrue(result.isPresent());
 
-        final ImmutableList<Optional<Value>> offset = CURRENT_OFFSET.eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> offset = CURRENT_OFFSET.eval(result.get(), enc());
 
         assertNotNull(offset);
         assertEquals(1, offset.size);

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.encoding.Sign;
@@ -46,7 +46,7 @@ public class CurrentOffsetTest {
 
     private void checkCurrentOffset(final int size) throws IOException {
         final byte[] data = new byte[size];
-        final Optional<Environment> result = def("a", con(size)).parse(new Environment(new InMemoryByteStream(data)), enc());
+        final Optional<ParseState> result = def("a", con(size)).parse(new ParseState(new InMemoryByteStream(data)), enc());
         assertTrue(result.isPresent());
 
         final ImmutableList<Optional<Value>> offset = CURRENT_OFFSET.eval(result.get().order, enc());
@@ -73,12 +73,12 @@ public class CurrentOffsetTest {
         for (int i = 0; i < stream.length; i++) {
             stream[i] = (byte) i;
         }
-        final Environment environment = new Environment(new InMemoryByteStream(stream));
+        final ParseState parseState = new ParseState(new InMemoryByteStream(stream));
 
         // value - offset + 1 should be 0:
         final Token offsetValidation = rep(def("byte", con(1), eqNum(sub(SELF, sub(CURRENT_OFFSET, con(1))), con(0))));
 
-        final Optional<Environment> result = offsetValidation.parse(environment, new Encoding(Sign.UNSIGNED));
+        final Optional<ParseState> result = offsetValidation.parse(parseState, new Encoding(Sign.UNSIGNED));
         assertTrue(result.isPresent());
         assertEquals(256, result.get().offset.intValueExact());
     }

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -29,6 +29,7 @@ import static io.parsingdata.metal.Shorthand.SELF;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -47,7 +48,7 @@ public class CurrentOffsetTest {
 
     private void checkCurrentOffset(final int size) throws IOException {
         final byte[] data = new byte[size];
-        final Optional<ParseState> result = def("a", con(size)).parse(createFromByteStream(new InMemoryByteStream(data)), enc());
+        final Optional<ParseState> result = def("a", con(size)).parse(env(createFromByteStream(new InMemoryByteStream(data)), enc()));
         assertTrue(result.isPresent());
 
         final ImmutableList<Optional<Value>> offset = CURRENT_OFFSET.eval(result.get(), enc());
@@ -79,7 +80,7 @@ public class CurrentOffsetTest {
         // value - offset + 1 should be 0:
         final Token offsetValidation = rep(def("byte", con(1), eqNum(sub(SELF, sub(CURRENT_OFFSET, con(1))), con(0))));
 
-        final Optional<ParseState> result = offsetValidation.parse(parseState, new Encoding(Sign.UNSIGNED));
+        final Optional<ParseState> result = offsetValidation.parse(env(parseState, new Encoding(Sign.UNSIGNED)));
         assertTrue(result.isPresent());
         assertEquals(256, result.get().offset.intValueExact());
     }

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.Shorthand.eqNum;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.SELF;
 import static io.parsingdata.metal.Shorthand.sub;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 
 import java.io.IOException;
@@ -46,7 +47,7 @@ public class CurrentOffsetTest {
 
     private void checkCurrentOffset(final int size) throws IOException {
         final byte[] data = new byte[size];
-        final Optional<ParseState> result = def("a", con(size)).parse(new ParseState(new InMemoryByteStream(data)), enc());
+        final Optional<ParseState> result = def("a", con(size)).parse(createFromByteStream(new InMemoryByteStream(data)), enc());
         assertTrue(result.isPresent());
 
         final ImmutableList<Optional<Value>> offset = CURRENT_OFFSET.eval(result.get().order, enc());
@@ -73,7 +74,7 @@ public class CurrentOffsetTest {
         for (int i = 0; i < stream.length; i++) {
             stream[i] = (byte) i;
         }
-        final ParseState parseState = new ParseState(new InMemoryByteStream(stream));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(stream));
 
         // value - offset + 1 should be 0:
         final Token offsetValidation = rep(def("byte", con(1), eqNum(sub(SELF, sub(CURRENT_OFFSET, con(1))), con(0))));

--- a/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
@@ -26,6 +26,7 @@ import static io.parsingdata.metal.Shorthand.EMPTY;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
@@ -57,7 +58,7 @@ public class DefSizeTest {
             0x00, 0x00, 0x00, 0x02, // length = 2
             0x04, 0x08
         });
-        final Optional<ParseState> result = FORMAT.parse(new ParseState(stream), new Encoding());
+        final Optional<ParseState> result = FORMAT.parse(createFromByteStream(stream), new Encoding());
 
         assertTrue(result.isPresent());
         assertArrayEquals(
@@ -72,7 +73,7 @@ public class DefSizeTest {
             (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, // length = -1
             0x04, 0x08
         });
-        final Optional<ParseState> result = FORMAT.parse(new ParseState(stream), signed());
+        final Optional<ParseState> result = FORMAT.parse(createFromByteStream(stream), signed());
 
         assertFalse(result.isPresent());
     }

--- a/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
@@ -30,6 +30,7 @@ import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_VE;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -58,7 +59,7 @@ public class DefSizeTest {
             0x00, 0x00, 0x00, 0x02, // length = 2
             0x04, 0x08
         });
-        final Optional<ParseState> result = FORMAT.parse(createFromByteStream(stream), new Encoding());
+        final Optional<ParseState> result = FORMAT.parse(env(createFromByteStream(stream), new Encoding()));
 
         assertTrue(result.isPresent());
         assertArrayEquals(
@@ -73,16 +74,16 @@ public class DefSizeTest {
             (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, // length = -1
             0x04, 0x08
         });
-        final Optional<ParseState> result = FORMAT.parse(createFromByteStream(stream), signed());
+        final Optional<ParseState> result = FORMAT.parse(env(createFromByteStream(stream), signed()));
 
         assertFalse(result.isPresent());
     }
 
     @Test
     public void testEmptyLengthInList() throws IOException {
-        assertFalse(def("a", EMPTY_VE).parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(def("a", EMPTY_VE).parse(env(stream(1, 2, 3, 4))).isPresent());
         final Token aList = seq(any("a"), any("a"));
-        assertFalse(seq(aList, def("b", ref("a"))).parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(seq(aList, def("b", ref("a"))).parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
     @Test
@@ -90,7 +91,7 @@ public class DefSizeTest {
         assertTrue(seq(
             def("twentyone", con(1), eq(con(21))),
             EMPTY,
-            def("fortytwo", con(1), eq(con(42)))).parse(stream(21, 42), enc()).isPresent());
+            def("fortytwo", con(1), eq(con(42)))).parse(env(stream(21, 42))).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
@@ -29,7 +29,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_VE;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -39,7 +39,7 @@ import java.util.Optional;
 import org.junit.Test;
 
 import io.parsingdata.metal.data.ByteStream;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.InMemoryByteStream;
@@ -57,7 +57,7 @@ public class DefSizeTest {
             0x00, 0x00, 0x00, 0x02, // length = 2
             0x04, 0x08
         });
-        final Optional<Environment> result = FORMAT.parse(new Environment(stream), new Encoding());
+        final Optional<ParseState> result = FORMAT.parse(new ParseState(stream), new Encoding());
 
         assertTrue(result.isPresent());
         assertArrayEquals(
@@ -72,7 +72,7 @@ public class DefSizeTest {
             (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, // length = -1
             0x04, 0x08
         });
-        final Optional<Environment> result = FORMAT.parse(new Environment(stream), signed());
+        final Optional<ParseState> result = FORMAT.parse(new ParseState(stream), signed());
 
         assertFalse(result.isPresent());
     }

--- a/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
@@ -36,14 +36,14 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.token.Token;
 
@@ -62,7 +62,7 @@ public class DefinitionTest {
 
     @Test
     public void composed() throws IOException {
-        final Optional<Environment> result = COMPOSED.parse(stream(1, 1, 1, 2, 2, 1, 2), enc());
+        final Optional<ParseState> result = COMPOSED.parse(stream(1, 1, 1, 2, 2, 1, 2), enc());
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
         assertEquals(NONE, graph.getDefinition());

--- a/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
@@ -36,6 +36,7 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -62,7 +63,7 @@ public class DefinitionTest {
 
     @Test
     public void composed() throws IOException {
-        final Optional<ParseState> result = COMPOSED.parse(stream(1, 1, 1, 2, 2, 1, 2), enc());
+        final Optional<ParseState> result = COMPOSED.parse(env(stream(1, 1, 1, 2, 2, 1, 2)));
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
         assertEquals(NONE, graph.getDefinition());

--- a/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
@@ -25,7 +25,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.SELF;
 import static io.parsingdata.metal.Shorthand.shr;
 import static io.parsingdata.metal.util.EncodingFactory.le;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 

--- a/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
@@ -25,6 +25,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.SELF;
 import static io.parsingdata.metal.Shorthand.shr;
 import static io.parsingdata.metal.util.EncodingFactory.le;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -38,13 +39,13 @@ public class EndiannessTest {
     @Test
     public void andAcrossByteBoundaryLE() throws IOException {
         final Token token = def("x", con(2), eq(and(SELF, con(0x03, 0xff)), con(0x01, 0x1b)));
-        assertTrue(token.parse(stream(0x1b, 0x81), le()).isPresent());
+        assertTrue(token.parse(env(stream(0x1b, 0x81), le())).isPresent());
     }
 
     @Test
     public void constructIntermediateConstantLE() throws IOException {
         final Token token = def("x", con(2), eq(and(shr(con(0x82, 0x1b), con(1)), con(0x03, 0xff)), con(0x01, 0x0d)));
-        assertTrue(token.parse(stream(0x00, 0x00), le()).isPresent());
+        assertTrue(token.parse(env(stream(0x00, 0x00), le())).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -34,6 +34,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
@@ -167,10 +168,10 @@ public class EqualityTest {
     @Test
     public void parseGraph() {
         final ParseValue value = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-        final ParseGraph object = new ParseState(DUMMY_STREAM).add(value).order;
+        final ParseGraph object = createFromByteStream(DUMMY_STREAM).add(value).order;
         assertFalse(object.equals(null));
         assertFalse(object.equals("a"));
-        final ParseState parseState = new ParseState(DUMMY_STREAM);
+        final ParseState parseState = createFromByteStream(DUMMY_STREAM);
         assertNotEquals(parseState.addBranch(any("a")).add(value).add(value).closeBranch().addBranch(any("a")).order, parseState.addBranch(any("a")).closeBranch().addBranch(any("a")).order);
         assertNotEquals(parseState.addBranch(any("a")).order, parseState.addBranch(any("a")).closeBranch().order);
         assertNotEquals(parseState.addBranch(any("a")).order, parseState.addBranch(any("b")).order);

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -40,7 +40,7 @@ import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -53,7 +53,7 @@ import java.util.Optional;
 import org.junit.Test;
 
 import io.parsingdata.metal.data.ConstantSource;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseValue;
@@ -82,7 +82,7 @@ public class EqualityTest {
 
     @Test
     public void cycleWithIdenticalTokens() throws IOException {
-        final Optional<Environment> result = LINKED_LIST_COMPOSED_IDENTICAL.parse(stream(0, 0, 1), enc());
+        final Optional<ParseState> result = LINKED_LIST_COMPOSED_IDENTICAL.parse(stream(0, 0, 1), enc());
         assertTrue(result.isPresent());
         assertEquals(1, getAllValues(result.get().order, "header").size);
         assertEquals(2, getReferences(result.get().order).size);
@@ -102,7 +102,7 @@ public class EqualityTest {
 
     @Test
     public void cycleWithEqualTokens() throws IOException {
-        final Optional<Environment> result = LINKED_LIST_COMPOSED_EQUAL.parse(stream(0, 0, 1), enc());
+        final Optional<ParseState> result = LINKED_LIST_COMPOSED_EQUAL.parse(stream(0, 0, 1), enc());
         assertTrue(result.isPresent());
         assertEquals(1, getAllValues(result.get().order, "header").size);
         assertEquals(2, getReferences(result.get().order).size);
@@ -167,13 +167,13 @@ public class EqualityTest {
     @Test
     public void parseGraph() {
         final ParseValue value = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());
-        final ParseGraph object = new Environment(DUMMY_STREAM).add(value).order;
+        final ParseGraph object = new ParseState(DUMMY_STREAM).add(value).order;
         assertFalse(object.equals(null));
         assertFalse(object.equals("a"));
-        final Environment environment = new Environment(DUMMY_STREAM);
-        assertNotEquals(environment.addBranch(any("a")).add(value).add(value).closeBranch().addBranch(any("a")).order, environment.addBranch(any("a")).closeBranch().addBranch(any("a")).order);
-        assertNotEquals(environment.addBranch(any("a")).order, environment.addBranch(any("a")).closeBranch().order);
-        assertNotEquals(environment.addBranch(any("a")).order, environment.addBranch(any("b")).order);
+        final ParseState parseState = new ParseState(DUMMY_STREAM);
+        assertNotEquals(parseState.addBranch(any("a")).add(value).add(value).closeBranch().addBranch(any("a")).order, parseState.addBranch(any("a")).closeBranch().addBranch(any("a")).order);
+        assertNotEquals(parseState.addBranch(any("a")).order, parseState.addBranch(any("a")).closeBranch().order);
+        assertNotEquals(parseState.addBranch(any("a")).order, parseState.addBranch(any("b")).order);
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -41,6 +41,7 @@ import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -83,7 +84,7 @@ public class EqualityTest {
 
     @Test
     public void cycleWithIdenticalTokens() throws IOException {
-        final Optional<ParseState> result = LINKED_LIST_COMPOSED_IDENTICAL.parse(stream(0, 0, 1), enc());
+        final Optional<ParseState> result = LINKED_LIST_COMPOSED_IDENTICAL.parse(env(stream(0, 0, 1)));
         assertTrue(result.isPresent());
         assertEquals(1, getAllValues(result.get().order, "header").size);
         assertEquals(2, getReferences(result.get().order).size);
@@ -103,7 +104,7 @@ public class EqualityTest {
 
     @Test
     public void cycleWithEqualTokens() throws IOException {
-        final Optional<ParseState> result = LINKED_LIST_COMPOSED_EQUAL.parse(stream(0, 0, 1), enc());
+        final Optional<ParseState> result = LINKED_LIST_COMPOSED_EQUAL.parse(env(stream(0, 0, 1)));
         assertTrue(result.isPresent());
         assertEquals(1, getAllValues(result.get().order, "header").size);
         assertEquals(2, getReferences(result.get().order).size);

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.Shorthand.neg;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -80,7 +81,7 @@ public class ErrorsTest {
     public void parseStateWithNegativeOffset() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument offset may not be negative.");
-        new ParseState(DUMMY_STREAM, BigInteger.valueOf(-1));
+        createFromByteStream(DUMMY_STREAM, BigInteger.valueOf(-1));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -28,7 +28,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -39,8 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.ByteStream;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.token.Token;
 
 public class ErrorsTest {
@@ -73,15 +72,15 @@ public class ErrorsTest {
                 any("b"),
                 repn(dummy, ref("b"))
             );
-       Optional<Environment> result = multiRepN.parse(stream(2, 2, 2, 2), enc());
+       Optional<ParseState> result = multiRepN.parse(stream(2, 2, 2, 2), enc());
        assertFalse(result.isPresent());
     }
 
     @Test
-    public void environmentWithNegativeOffset() {
+    public void parseStateWithNegativeOffset() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument offset may not be negative.");
-        new Environment(DUMMY_STREAM, BigInteger.valueOf(-1));
+        new ParseState(DUMMY_STREAM, BigInteger.valueOf(-1));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -29,6 +29,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -53,16 +54,16 @@ public class ErrorsTest {
         thrown = ExpectedException.none();
         // Basic division by zero.
         final Token token = def("a", div(con(1), con(0)));
-        assertFalse(token.parse(stream(1), enc()).isPresent());
+        assertFalse(token.parse(env(stream(1))).isPresent());
         // Try to negate division by zero.
         final Token token2 = def("a", neg(div(con(1), con(0))));
-        assertFalse(token2.parse(stream(1), enc()).isPresent());
+        assertFalse(token2.parse(env(stream(1))).isPresent());
         // Add one to division by zero.
         final Token token3 = def("a", add(div(con(1), con(0)), con(1)));
-        assertFalse(token3.parse(stream(1), enc()).isPresent());
+        assertFalse(token3.parse(env(stream(1))).isPresent());
         // Add division by zero to one.
         final Token token4 = def("a", add(con(1), div(con(1), con(0))));
-        assertFalse(token4.parse(stream(1), enc()).isPresent());
+        assertFalse(token4.parse(env(stream(1))).isPresent());
     }
 
     @Test
@@ -73,7 +74,7 @@ public class ErrorsTest {
                 any("b"),
                 repn(dummy, ref("b"))
             );
-       Optional<ParseState> result = multiRepN.parse(stream(2, 2, 2, 2), enc());
+       Optional<ParseState> result = multiRepN.parse(env(stream(2, 2, 2, 2)));
        assertFalse(result.isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/IterateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/IterateTest.java
@@ -26,7 +26,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;

--- a/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.Shorthand.or;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;

--- a/core/src/test/java/io/parsingdata/metal/PITestCasesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/PITestCasesTest.java
@@ -32,14 +32,14 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.shl;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 
@@ -64,8 +64,8 @@ public class PITestCasesTest {
         parse(SHL, stream(85, 170), enc());
     }
 
-    private void parse(final Token token, final Environment environment, final Encoding encoding) throws IOException {
-        assertTrue(token.parse(environment, encoding).isPresent());
+    private void parse(final Token token, final ParseState parseState, final Encoding encoding) throws IOException {
+        assertTrue(token.parse(parseState, encoding).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/PITestCasesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/PITestCasesTest.java
@@ -32,6 +32,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.shl;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -65,7 +66,7 @@ public class PITestCasesTest {
     }
 
     private void parse(final Token token, final ParseState parseState, final Encoding encoding) throws IOException {
-        assertTrue(token.parse(parseState, encoding).isPresent());
+        assertTrue(token.parse(env(parseState, encoding)).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 import static io.parsingdata.metal.util.TokenDefinitions.notEq;
@@ -42,17 +43,17 @@ public class ReadUntilTest {
 
     @Test
     public void readUntilConstant() throws IOException {
-        assertTrue(_readUntil.parse(stream(1, 2, 3, 4, 42), enc()).isPresent());
+        assertTrue(_readUntil.parse(env(stream(1, 2, 3, 4, 42))).isPresent());
     }
 
     @Test
     public void readUntilNoSkipping() throws IOException {
-        assertTrue(_readUntil.parse(stream(42), enc()).isPresent());
+        assertTrue(_readUntil.parse(env(stream(42))).isPresent());
     }
 
     @Test
     public void readUntilErrorNoTerminator() throws IOException {
-        assertFalse(_readUntil.parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(_readUntil.parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 import static io.parsingdata.metal.util.TokenDefinitions.notEq;
 

--- a/core/src/test/java/io/parsingdata/metal/ReducersTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReducersTest.java
@@ -30,7 +30,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -29,7 +29,7 @@ import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
 
@@ -40,7 +40,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.value.ValueExpression;
-import io.parsingdata.metal.expression.value.reference.Ref.NameRef;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -47,7 +47,7 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.expression.value.ExpandTest.createParseValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static junit.framework.TestCase.assertFalse;
 
@@ -58,7 +58,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseValue;
@@ -105,7 +105,7 @@ public class ShorthandsTest {
     }
 
     private void runChoice(final int data, final String matched) throws IOException {
-        final Optional<Environment> result = multiChoice.parse(stream(data), enc());
+        final Optional<ParseState> result = multiChoice.parse(stream(data), enc());
         assertTrue(result.isPresent());
         assertTrue(result.get().order.current().get().matches(matched));
     }
@@ -135,7 +135,7 @@ public class ShorthandsTest {
 
     @Test
     public void allTokensNamed() throws IOException {
-        final Optional<Environment> result =
+        final Optional<ParseState> result =
             rep("rep",
                 repn("repn",
                     seq("seq",
@@ -162,8 +162,8 @@ public class ShorthandsTest {
         checkNameAndValue("rep.repn.seq.tie.def3", 1, result.get());
     }
 
-    private void checkNameAndValue(final String name, final int value, final Environment env) {
-        ImmutableList<Optional<Value>> values = ref(name).eval(env.order, enc());
+    private void checkNameAndValue(final String name, final int value, final ParseState parseState) {
+        ImmutableList<Optional<Value>> values = ref(name).eval(parseState.order, enc());
         assertFalse(values.isEmpty());
         assertEquals(1, values.size);
         assertEquals(value, values.head.get().asNumeric().intValueExact());
@@ -200,7 +200,7 @@ public class ShorthandsTest {
         assertEquals(DEFB, seq.tokens.tail.head);
     }
 
-    final ParseGraph PARSEGRAPH = new Environment(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42)).order;
+    final ParseGraph PARSEGRAPH = new ParseState(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42)).order;
 
     @Test
     public void mapLeftWithSub() {

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -45,6 +45,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.expression.value.ExpandTest.createParseValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
@@ -200,7 +201,7 @@ public class ShorthandsTest {
         assertEquals(DEFB, seq.tokens.tail.head);
     }
 
-    final ParseGraph PARSEGRAPH = new ParseState(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42)).order;
+    final ParseGraph PARSEGRAPH = createFromByteStream(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42)).order;
 
     @Test
     public void mapLeftWithSub() {

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -48,6 +48,7 @@ import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.expression.value.ExpandTest.createParseValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static junit.framework.TestCase.assertFalse;
@@ -59,9 +60,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.token.Cho;
@@ -77,12 +77,12 @@ public class ShorthandsTest {
 
     @Test
     public void sequenceMultiMatch() throws IOException {
-        assertTrue(multiSequence.parse(stream(1, 2, 3), enc()).isPresent());
+        assertTrue(multiSequence.parse(env(stream(1, 2, 3))).isPresent());
     }
 
     @Test
     public void sequenceMultiNoMatch() throws IOException {
-        assertFalse(multiSequence.parse(stream(1, 2, 2), enc()).isPresent());
+        assertFalse(multiSequence.parse(env(stream(1, 2, 2))).isPresent());
     }
 
     private static final Token multiChoice =
@@ -106,14 +106,14 @@ public class ShorthandsTest {
     }
 
     private void runChoice(final int data, final String matched) throws IOException {
-        final Optional<ParseState> result = multiChoice.parse(stream(data), enc());
+        final Optional<ParseState> result = multiChoice.parse(env(stream(data)));
         assertTrue(result.isPresent());
         assertTrue(result.get().order.current().get().matches(matched));
     }
 
     @Test
     public void choiceMultiNoMatch() throws IOException {
-        assertFalse(multiChoice.parse(stream(0), enc()).isPresent());
+        assertFalse(multiChoice.parse(env(stream(0))).isPresent());
     }
 
     private static final Token nonLocalCompare =
@@ -131,7 +131,7 @@ public class ShorthandsTest {
 
     @Test
     public void nonLocalCompare() throws IOException {
-        assertTrue(nonLocalCompare.parse(stream(1, 'a', 'b', 'c', 0, 0), enc()).isPresent());
+        assertTrue(nonLocalCompare.parse(env(stream(1, 'a', 'b', 'c', 0, 0))).isPresent());
     }
 
     @Test
@@ -155,7 +155,7 @@ public class ShorthandsTest {
                             last(ref("def1")))
                     ), con(1)
                 )
-            ).parse(stream(2, 1, 2), enc());
+            ).parse(env(stream(2, 1, 2)));
         assertTrue(result.isPresent());
         checkNameAndValue("rep.repn.seq.pre.opt.a", 2, result.get());
         checkNameAndValue("rep.repn.seq.cho.def1", 1, result.get());

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -164,7 +164,7 @@ public class ShorthandsTest {
     }
 
     private void checkNameAndValue(final String name, final int value, final ParseState parseState) {
-        ImmutableList<Optional<Value>> values = ref(name).eval(parseState.order, enc());
+        ImmutableList<Optional<Value>> values = ref(name).eval(parseState, enc());
         assertFalse(values.isEmpty());
         assertEquals(1, values.size);
         assertEquals(value, values.head.get().asNumeric().intValueExact());
@@ -201,11 +201,11 @@ public class ShorthandsTest {
         assertEquals(DEFB, seq.tokens.tail.head);
     }
 
-    final ParseGraph PARSEGRAPH = createFromByteStream(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42)).order;
+    final ParseState PARSESTATE = createFromByteStream(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42));
 
     @Test
     public void mapLeftWithSub() {
-        ImmutableList<Optional<Value>> result = mapLeft(Shorthand::sub, ref("a"), con(2)).eval(PARSEGRAPH, enc());
+        ImmutableList<Optional<Value>> result = mapLeft(Shorthand::sub, ref("a"), con(2)).eval(PARSESTATE, enc());
         assertEquals(3, result.size);
         for (int i = 0; i < 3; i++) {
             assertTrue(result.head.isPresent());
@@ -216,7 +216,7 @@ public class ShorthandsTest {
 
     @Test
     public void mapRightWithSub() {
-        ImmutableList<Optional<Value>> result = mapRight(Shorthand::sub, con(126), ref("a")).eval(PARSEGRAPH, enc());
+        ImmutableList<Optional<Value>> result = mapRight(Shorthand::sub, con(126), ref("a")).eval(PARSESTATE, enc());
         assertEquals(3, result.size);
         for (int i = 0; i < 3; i++) {
             assertTrue(result.head.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/SimpleTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SimpleTest.java
@@ -23,6 +23,7 @@ import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -43,25 +44,25 @@ public class SimpleTest {
     @Test
     public void correct() throws IOException {
         final Token token = buildSimpleToken("r1", 1, 1);
-        assertTrue(token.parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertTrue(token.parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
     @Test
     public void sizeError() throws IOException {
         final Token token = buildSimpleToken("r1", 2, 1);
-        assertFalse(token.parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(token.parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
     @Test
     public void predicateError() throws IOException {
         final Token token = buildSimpleToken("r1", 1, 2);
-        assertFalse(token.parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(token.parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
     @Test
     public void sourceError() throws IOException {
         final Token token = buildSimpleToken("r1", 1, 1);
-        assertFalse(token.parse(stream(2, 2, 2, 2), enc()).isPresent());
+        assertFalse(token.parse(env(stream(2, 2, 2, 2))).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SimpleTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SimpleTest.java
@@ -23,7 +23,7 @@ import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -27,14 +27,14 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.token.Token;
 
@@ -51,7 +51,7 @@ public class SubStructTableTest {
 
     @Test
     public void table() throws IOException {
-        final Environment environment = stream(3, 6, 4, 9, 42, 84, 42, 84, 0, 42, 84);
+        final ParseState parseState = stream(3, 6, 4, 9, 42, 84, 42, 84, 0, 42, 84);
                                     /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10
                                      * count:  ^
                                      * pointers:  ^, ^, ^
@@ -59,7 +59,7 @@ public class SubStructTableTest {
                                      * ref2:         +-----^^--^^
                                      * ref3:            +---------------------^^--^^
                                      */
-        final Optional<Environment> result = table.parse(environment, enc());
+        final Optional<ParseState> result = table.parse(parseState, enc());
         assertTrue(result.isPresent());
         assertEquals(4, result.get().offset.intValueExact());
         final ParseGraph graph = result.get().order;
@@ -70,7 +70,7 @@ public class SubStructTableTest {
 
     @Test
     public void tableWithDuplicate() throws IOException {
-        final Environment environment = stream(4, 7, 5, 5, 10, 42, 84, 42, 84, 0, 42, 84);
+        final ParseState parseState = stream(4, 7, 5, 5, 10, 42, 84, 42, 84, 0, 42, 84);
                                     /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10, 11
                                      * count:  ^
                                      * pointers:  ^, ^, ^, ^^
@@ -79,7 +79,7 @@ public class SubStructTableTest {
                                      * ref3:         +---------^^--^^ duplicate!
                                      * ref4:               ++---------------------^^--^^
                                      */
-        final Optional<Environment> result = table.parse(environment, enc());
+        final Optional<ParseState> result = table.parse(parseState, enc());
         assertTrue(result.isPresent());
         assertEquals(5, result.get().offset.intValueExact());
         final ParseGraph graph = result.get().order;

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -52,14 +53,14 @@ public class SubStructTableTest {
     @Test
     public void table() throws IOException {
         final ParseState parseState = stream(3, 6, 4, 9, 42, 84, 42, 84, 0, 42, 84);
-                                    /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10
-                                     * count:  ^
-                                     * pointers:  ^, ^, ^
-                                     * ref1:      +----------------^^--^^
-                                     * ref2:         +-----^^--^^
-                                     * ref3:            +---------------------^^--^^
-                                     */
-        final Optional<ParseState> result = table.parse(parseState, enc());
+                                  /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10
+                                   * count:  ^
+                                   * pointers:  ^, ^, ^
+                                   * ref1:      +----------------^^--^^
+                                   * ref2:         +-----^^--^^
+                                   * ref3:            +---------------------^^--^^
+                                   */
+        final Optional<ParseState> result = table.parse(env(parseState, enc()));
         assertTrue(result.isPresent());
         assertEquals(4, result.get().offset.intValueExact());
         final ParseGraph graph = result.get().order;
@@ -71,15 +72,15 @@ public class SubStructTableTest {
     @Test
     public void tableWithDuplicate() throws IOException {
         final ParseState parseState = stream(4, 7, 5, 5, 10, 42, 84, 42, 84, 0, 42, 84);
-                                    /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10, 11
-                                     * count:  ^
-                                     * pointers:  ^, ^, ^, ^^
-                                     * ref1:      +--------------------^^--^^
-                                     * ref2:         +---------^^--^^
-                                     * ref3:         +---------^^--^^ duplicate!
-                                     * ref4:               ++---------------------^^--^^
-                                     */
-        final Optional<ParseState> result = table.parse(parseState, enc());
+                                  /* offset: 0, 1, 2, 3,  4,  5,  6,  7, 8,  9, 10, 11
+                                   * count:  ^
+                                   * pointers:  ^, ^, ^, ^^
+                                   * ref1:      +--------------------^^--^^
+                                   * ref2:         +---------^^--^^
+                                   * ref3:         +---------^^--^^ duplicate!
+                                   * ref4:               ++---------------------^^--^^
+                                   */
+        final Optional<ParseState> result = table.parse(env(parseState, enc()));
         assertTrue(result.isPresent());
         assertEquals(5, result.get().offset.intValueExact());
         final ParseGraph graph = result.get().order;

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -31,6 +31,7 @@ import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_VE;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -61,13 +62,13 @@ public class SubStructTest {
     @Test
     public void linkedList() throws IOException {
         final ParseState parseState = stream(0, 8, 1, 42, 0, 12, 1, 84, 0, 4, 1);
-                                    /* offset: 0, 1, 2,  3, 4,  5, 6,  7, 8, 9,10
-                                     * struct: -------      --------      -------
-                                     * ref 1:     +-----------------------^
-                                     * ref 2:               ^----------------+
-                                     * ref 3:                   +----------------*
-                                     */
-        final Optional<ParseState> result = LINKED_LIST.parse(parseState, enc());
+                                  /* offset: 0, 1, 2,  3, 4,  5, 6,  7, 8, 9,10
+                                   * struct: -------      --------      -------
+                                   * ref 1:     +-----------------------^
+                                   * ref 2:               ^----------------+
+                                   * ref 3:                   +----------------*
+                                   */
+        final Optional<ParseState> result = LINKED_LIST.parse(env(parseState, enc()));
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
         assertEquals(0, getReferences(graph).size); // No cycles
@@ -85,7 +86,7 @@ public class SubStructTest {
     @Test
     public void linkedListWithSelfReference() throws IOException {
         final ParseState parseState = stream(0, 0, 1);
-        final Optional<ParseState> result = LINKED_LIST.parse(parseState, enc());
+        final Optional<ParseState> result = LINKED_LIST.parse(env(parseState, enc()));
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
         assertEquals(1, getReferences(graph).size);
@@ -99,7 +100,7 @@ public class SubStructTest {
 
     private ParseGraph startCycle(final int offset) throws IOException {
         final ParseState parseState = stream(0, 4, 1, 21, 0, 0, 1).seek(BigInteger.valueOf(offset)).get();
-        final Optional<ParseState> result = LINKED_LIST.parse(parseState, enc());
+        final Optional<ParseState> result = LINKED_LIST.parse(env(parseState, enc()));
         assertTrue(result.isPresent());
         assertEquals(1, getReferences(result.get().order).size);
         return result.get().order;
@@ -153,17 +154,17 @@ public class SubStructTest {
 
     @Test
     public void errorEmptyAddressList() throws IOException {
-        assertFalse(sub(any("a"), ref("b")).parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(sub(any("a"), ref("b")).parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
     @Test
     public void errorEmptyAddress() throws IOException {
-        assertFalse(sub(any("a"), EMPTY_VE).parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(sub(any("a"), EMPTY_VE).parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
     @Test
     public void errorNegativeAddress() {
-        assertFalse(sub(any("a"), con(-1, signed())).parse(stream(1, 2, 3, 4), enc()).isPresent());
+        assertFalse(sub(any("a"), con(-1, signed())).parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -19,7 +19,6 @@ package io.parsingdata.metal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import static io.parsingdata.metal.Shorthand.cat;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
@@ -32,7 +31,7 @@ import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_VE;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static junit.framework.TestCase.assertFalse;
@@ -41,10 +40,9 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseReference;
@@ -62,14 +60,14 @@ public class SubStructTest {
 
     @Test
     public void linkedList() throws IOException {
-        final Environment environment = stream(0, 8, 1, 42, 0, 12, 1, 84, 0, 4, 1);
+        final ParseState parseState = stream(0, 8, 1, 42, 0, 12, 1, 84, 0, 4, 1);
                                     /* offset: 0, 1, 2,  3, 4,  5, 6,  7, 8, 9,10
                                      * struct: -------      --------      -------
                                      * ref 1:     +-----------------------^
                                      * ref 2:               ^----------------+
                                      * ref 3:                   +----------------*
                                      */
-        final Optional<Environment> result = LINKED_LIST.parse(environment, enc());
+        final Optional<ParseState> result = LINKED_LIST.parse(parseState, enc());
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
         assertEquals(0, getReferences(graph).size); // No cycles
@@ -86,8 +84,8 @@ public class SubStructTest {
 
     @Test
     public void linkedListWithSelfReference() throws IOException {
-        final Environment environment = stream(0, 0, 1);
-        final Optional<Environment> result = LINKED_LIST.parse(environment, enc());
+        final ParseState parseState = stream(0, 0, 1);
+        final Optional<ParseState> result = LINKED_LIST.parse(parseState, enc());
         assertTrue(result.isPresent());
         final ParseGraph graph = result.get().order;
         assertEquals(1, getReferences(graph).size);
@@ -100,8 +98,8 @@ public class SubStructTest {
     }
 
     private ParseGraph startCycle(final int offset) throws IOException {
-        final Environment environment = stream(0, 4, 1, 21, 0, 0, 1).seek(BigInteger.valueOf(offset)).get();
-        final Optional<Environment> result = LINKED_LIST.parse(environment, enc());
+        final ParseState parseState = stream(0, 4, 1, 21, 0, 0, 1).seek(BigInteger.valueOf(offset)).get();
+        final Optional<ParseState> result = LINKED_LIST.parse(parseState, enc());
         assertTrue(result.isPresent());
         assertEquals(1, getReferences(result.get().order).size);
         return result.get().order;

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -65,8 +65,8 @@ import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.Shorthand.whl;
-import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
+import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -89,7 +89,6 @@ import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
-import io.parsingdata.metal.util.InMemoryByteStream;
 
 public class ToStringTest {
 
@@ -159,7 +158,7 @@ public class ToStringTest {
     @Test
     public void data() {
         final Environment environment = stream(1, 2);
-        final String envString = "Environment(source:ByteStreamSource(InMemoryByteStream(2));offset:0;order:pg(EMPTY);callbacks:)";
+        final String envString = "Environment(source:ByteStreamSource(InMemoryByteStream(2));offset:0;order:pg(EMPTY))";
         assertEquals(envString, environment.toString());
         final Optional<Environment> result = Optional.of(environment);
         assertEquals("Optional[" + environment + "]", result.toString());
@@ -176,31 +175,23 @@ public class ToStringTest {
 
     @Test
     public void callback() {
-        final String emptyStreamName = "ByteStreamSource(InMemoryByteStream(0))";
-        final String emptyGraphName = "pg(EMPTY)";
-        final InMemoryByteStream emptyStream = new InMemoryByteStream(new byte[] {});
-        final Environment empty = new Environment(emptyStream);
-        final String prefix = "Environment(source:" + emptyStreamName + ";offset:0;order:" + emptyGraphName + ";callbacks:";
+        assertEquals("", Callbacks.NONE.toString());
         final String genericPrefix = "generic: ";
         final String tokenPrefix = "token: ";
-        final String suffix = ")";
-        assertEquals(prefix + suffix, empty.toString());
         final String genericCallbackName = "genericName";
         final Callbacks singleCallbacks = Callbacks.create().add(makeToken("a"), makeCallback("first")).add(makeCallback(genericCallbackName));
-        final Environment one = new Environment(emptyStream, singleCallbacks);
         final String tokenCallback1Name = ">a->first";
-        final String oneName = prefix + genericPrefix + genericCallbackName + "; " + tokenPrefix + tokenCallback1Name + suffix;
-        assertEquals(oneName, one.toString());
+        final String oneName = genericPrefix + genericCallbackName + "; " + tokenPrefix + tokenCallback1Name;
+        assertEquals(oneName, singleCallbacks.toString());
         final Callbacks doubleCallbacks = Callbacks.create().add(makeToken("a"), makeCallback("first")).add(makeToken("b"), makeCallback("second"));
-        final Environment two = new Environment(emptyStream, doubleCallbacks);
         final String tokenCallback2Name = ">b->second";
-        final String twoName = prefix + tokenPrefix + tokenCallback2Name + tokenCallback1Name + suffix;
-        assertEquals(twoName, two.toString());
+        final String twoName = tokenPrefix + tokenCallback2Name + tokenCallback1Name;
+        assertEquals(twoName, doubleCallbacks.toString());
     }
 
     private Token makeToken(final String name) {
         return new Token(name, enc()) {
-            @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) { return null; }
+            @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) { return null; }
             @Override public String toString() { return name; }
         };
     }

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -68,7 +68,7 @@ import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.nio.charset.StandardCharsets;
@@ -77,7 +77,7 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.callback.Callback;
@@ -157,11 +157,11 @@ public class ToStringTest {
 
     @Test
     public void data() {
-        final Environment environment = stream(1, 2);
-        final String envString = "Environment(source:ByteStreamSource(InMemoryByteStream(2));offset:0;order:pg(EMPTY))";
-        assertEquals(envString, environment.toString());
-        final Optional<Environment> result = Optional.of(environment);
-        assertEquals("Optional[" + environment + "]", result.toString());
+        final ParseState parseState = stream(1, 2);
+        final String parseStateString = "ParseState(source:ByteStreamSource(InMemoryByteStream(2));offset:0;order:pg(EMPTY))";
+        assertEquals(parseStateString, parseState.toString());
+        final Optional<ParseState> result = Optional.of(parseState);
+        assertEquals("Optional[" + parseState + "]", result.toString());
         final ParseValue pv1 = new ParseValue("name", NONE, createFromBytes(new byte[]{1, 2}), enc());
         final String pv1String = "pval(name:0x0102)";
         final Optional<Value> ov1 = Optional.of(pv1);
@@ -191,15 +191,15 @@ public class ToStringTest {
 
     private Token makeToken(final String name) {
         return new Token(name, enc()) {
-            @Override protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) { return null; }
+            @Override protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) { return null; }
             @Override public String toString() { return name; }
         };
     }
 
     private Callback makeCallback(final String name) {
         return new Callback() {
-            @Override public void handleSuccess(final Token token, final Environment before, final Environment after) {}
-            @Override public void handleFailure(Token token, Environment before) {}
+            @Override public void handleSuccess(final Token token, final ParseState before, final ParseState after) {}
+            @Override public void handleFailure(Token token, ParseState before) {}
             @Override public String toString() { return name; }
         };
     }

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -145,6 +145,8 @@ public class ToStringTest {
     public void specialExpressions() {
         assertTrue(v().toString().contains("Self"));
         assertEquals("Self", SELF.toString());
+        assertTrue(v().toString().contains("CurrentOffset"));
+        assertEquals("CurrentOffset", CURRENT_OFFSET.toString());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -77,8 +77,9 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.callback.Callback;
 import io.parsingdata.metal.data.callback.Callbacks;
@@ -193,7 +194,7 @@ public class ToStringTest {
 
     private Token makeToken(final String name) {
         return new Token(name, enc()) {
-            @Override protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) { return null; }
+            @Override protected Optional<ParseState> parseImpl(final Environment environment) { return null; }
             @Override public String toString() { return name; }
         };
     }

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -30,7 +30,7 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
@@ -66,8 +66,8 @@ public class TreeTest {
             )
         );
 
-    private final Environment regular;
-    private final Environment cyclic;
+    private final ParseState regular;
+    private final ParseState cyclic;
 
     public TreeTest() throws IOException {
         regular = TREE.parse(stream(HEAD, 0, 6, 10, 8, 8, HEAD, 1, 16, 20, HEAD, 2, 24, 28, 8, 8, HEAD, 3, 0, 0, HEAD, 4, 0, 0, HEAD, 5, 0, 0, HEAD, 6, 0, 0), enc()).get();
@@ -95,8 +95,8 @@ public class TreeTest {
         checkStructure(cyclic);
     }
 
-    private void checkStructure(final Environment environment) {
-        final ParseGraph input = environment.order.head.asGraph(); // order = top-level ParseGraph, head = top-level Seq
+    private void checkStructure(final ParseState parseState) {
+        final ParseGraph input = parseState.order.head.asGraph(); // order = top-level ParseGraph, head = top-level Seq
         checkStructure(input, input, 0);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -30,6 +30,7 @@ import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -70,19 +71,19 @@ public class TreeTest {
     private final ParseState cyclic;
 
     public TreeTest() throws IOException {
-        regular = TREE.parse(stream(HEAD, 0, 6, 10, 8, 8, HEAD, 1, 16, 20, HEAD, 2, 24, 28, 8, 8, HEAD, 3, 0, 0, HEAD, 4, 0, 0, HEAD, 5, 0, 0, HEAD, 6, 0, 0), enc()).get();
-                                 /* *--------+---+        *---------+---+  *---------+---+        *--------*--*  *--------*--*  *--------*--*  *--------*--*
-                                  *          \---|--------/         \---|--|---------|---|--------/              |              |              |
-                                  *              \----------------------|--/         \---|-----------------------|--------------/              |
-                                  *                                     \----------------|-----------------------/                             |
-                                  *                                                      \-----------------------------------------------------/
-                                  */
-        cyclic = TREE.parse(stream(HEAD, 0, 4, 8, HEAD, 1, 8, 0, HEAD, 2, 4, 0), enc()).get();
-                                /* *--------+--+  *--------+--*  *--------+--*
-                                 *          \--|--/        \-----/        |
-                                 *             \--|--------------/        |
-                                 *                \-----------------------/
-                                 */
+        regular = TREE.parse(env(stream(HEAD, 0, 6, 10, 8, 8, HEAD, 1, 16, 20, HEAD, 2, 24, 28, 8, 8, HEAD, 3, 0, 0, HEAD, 4, 0, 0, HEAD, 5, 0, 0, HEAD, 6, 0, 0))).get();
+                                     /* *--------+---+        *---------+---+  *---------+---+        *--------*--*  *--------*--*  *--------*--*  *--------*--*
+                                      *          \---|--------/         \---|--|---------|---|--------/              |              |              |
+                                      *              \----------------------|--/         \---|-----------------------|--------------/              |
+                                      *                                     \----------------|-----------------------/                             |
+                                      *                                                      \-----------------------------------------------------/
+                                      */
+        cyclic = TREE.parse(env(stream(HEAD, 0, 4, 8, HEAD, 1, 8, 0, HEAD, 2, 4, 0))).get();
+                                    /* *--------+--+  *--------+--*  *--------+--*
+                                     *          \--|--/        \-----/        |
+                                     *             \--|--------------/        |
+                                     *                \-----------------------/
+                                     */
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
@@ -35,7 +35,7 @@ public class UtilInflateTest {
 
     @Test
     public void inflateDataFormatError() {
-        final ImmutableList<Optional<Value>> result = inflate(con(0xffffffff)).eval(stream().order, enc());
+        final ImmutableList<Optional<Value>> result = inflate(con(0xffffffff)).eval(stream(), enc());
         assertEquals(1, result.size);
         assertFalse(result.head.isPresent());
     }

--- a/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Util.inflate;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -26,6 +26,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -37,7 +38,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
@@ -52,12 +52,12 @@ public class ValueExpressionSemanticsTest {
 
     @Test
     public void Cat() throws IOException {
-        assertTrue(cat.parse(stream(1, 2, 1, 2), enc()).isPresent());
+        assertTrue(cat.parse(env(stream(1, 2, 1, 2))).isPresent());
     }
 
     @Test
     public void CatNoMatch() throws IOException {
-        assertFalse(cat.parse(stream(1, 2, 12, 12), enc()).isPresent());
+        assertFalse(cat.parse(env(stream(1, 2, 12, 12))).isPresent());
     }
 
     @Test
@@ -68,7 +68,7 @@ public class ValueExpressionSemanticsTest {
             public Optional<Value> eval(Value value, ParseState parseState, Encoding encoding) {
                 return Optional.of(value);
             }
-        })).parse(data, enc());
+        })).parse(env(data, enc()));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -26,7 +26,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
@@ -62,7 +62,7 @@ public class ValueExpressionSemanticsTest {
 
     @Test
     public void callback() throws IOException {
-        final Environment data = stream(1, 2, 3, 4);
+        final ParseState data = stream(1, 2, 3, 4);
         def("a", 4, eq(new UnaryValueExpression(ref("a")) {
             @Override
             public Optional<Value> eval(Value value, ParseGraph graph, Encoding encoding) {

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -65,7 +65,7 @@ public class ValueExpressionSemanticsTest {
         final ParseState data = stream(1, 2, 3, 4);
         def("a", 4, eq(new UnaryValueExpression(ref("a")) {
             @Override
-            public Optional<Value> eval(Value value, ParseGraph graph, Encoding encoding) {
+            public Optional<Value> eval(Value value, ParseState parseState, Encoding encoding) {
                 return Optional.of(value);
             }
         })).parse(data, enc());

--- a/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
@@ -29,16 +29,18 @@ import org.junit.rules.ExpectedException;
 
 public class ByteStreamSourceTest {
 
+    public static final ByteStreamSource DUMMY_BYTE_STREAM_SOURCE = new ByteStreamSource(new ByteStream() {
+        @Override public byte[] read(BigInteger offset, int length) throws IOException { throw new IOException("Always fails."); }
+        @Override public boolean isAvailable(BigInteger offset, int length) { return true; }
+    });
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void brokenByteStream() {
         thrown.expect(UncheckedIOException.class);
-        Slice.createFromSource(new ByteStreamSource(new ByteStream() {
-            @Override public byte[] read(BigInteger offset, int length) throws IOException { throw new IOException("Always fails."); }
-            @Override public boolean isAvailable(BigInteger offset, int length) { return true; }
-        }), ZERO, TEN).get().getData();
+        Slice.createFromSource(DUMMY_BYTE_STREAM_SOURCE, ZERO, TEN).get().getData();
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -12,6 +12,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
+import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
@@ -54,7 +55,7 @@ public class DataExpressionSourceTest {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("ValueExpression dataExpression yields 1 result(s) (expected at least 2).");
         final Optional<ParseState> result = setupResult();
-        final DataExpressionSource source = new DataExpressionSource(ref("a"), 1, result.get().order, enc());
+        final DataExpressionSource source = new DataExpressionSource(ref("a"), 1, result.get(), enc());
         source.getData(ZERO, BigInteger.valueOf(4));
     }
 
@@ -62,7 +63,7 @@ public class DataExpressionSourceTest {
     public void emptyValue() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("ValueExpression dataExpression yields empty Value at index 0.");
-        new DataExpressionSource(div(con(1), con(0)), 0, ParseGraph.EMPTY, enc()).isAvailable(ZERO, ZERO);
+        new DataExpressionSource(div(con(1), con(0)), 0, EMPTY_PARSE_STATE, enc()).isAvailable(ZERO, ZERO);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -13,7 +13,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.math.BigInteger;
 import java.util.Optional;
@@ -30,12 +30,12 @@ public class DataExpressionSourceTest {
     public ExpectedException thrown = ExpectedException.none();
 
     public ParseValue setupValue() {
-        final Optional<Environment> result = setupResult();
+        final Optional<ParseState> result = setupResult();
         assertTrue(result.isPresent());
         return getValue(result.get().order, "b");
     }
 
-    private Optional<Environment> setupResult() {
+    private Optional<ParseState> setupResult() {
         final Token token =
             seq(def("a", con(4)),
                 tie(def("b", con(2)), ref("a")));
@@ -53,7 +53,7 @@ public class DataExpressionSourceTest {
     public void indexOutOfBounds() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("ValueExpression dataExpression yields 1 result(s) (expected at least 2).");
-        final Optional<Environment> result = setupResult();
+        final Optional<ParseState> result = setupResult();
         final DataExpressionSource source = new DataExpressionSource(ref("a"), 1, result.get().order, enc());
         source.getData(ZERO, BigInteger.valueOf(4));
     }

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -14,6 +14,7 @@ import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.math.BigInteger;
@@ -40,7 +41,7 @@ public class DataExpressionSourceTest {
         final Token token =
             seq(def("a", con(4)),
                 tie(def("b", con(2)), ref("a")));
-        return token.parse(stream(1, 2, 3, 4), enc());
+        return token.parse(env(stream(1, 2, 3, 4)));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -30,11 +30,10 @@ import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.data.selection.ByTypeTest.EMPTY_SOURCE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.Optional;
 
 import org.junit.Rule;
@@ -72,7 +71,7 @@ public class ParseGraphTest {
                 any("g"), any("empty"),
                 any("h"), any("empty")
             );
-       Optional<Environment> result = token.parse(stream(97, 0, 98, 0, 99, 0, 100, 0, 101, 0, 102, 0, 103, 0, 104, 0), enc());
+       Optional<ParseState> result = token.parse(stream(97, 0, 98, 0, 99, 0, 100, 0, 101, 0, 102, 0, 103, 0, 104, 0), enc());
         a = getValue(result.get().order, "a");
         b = getValue(result.get().order, "b");
         c = getValue(result.get().order, "c");

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -30,6 +30,7 @@ import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.data.selection.ByTypeTest.EMPTY_SOURCE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -71,7 +72,7 @@ public class ParseGraphTest {
                 any("g"), any("empty"),
                 any("h"), any("empty")
             );
-       Optional<ParseState> result = token.parse(stream(97, 0, 98, 0, 99, 0, 100, 0, 101, 0, 102, 0, 103, 0, 104, 0), enc());
+       Optional<ParseState> result = token.parse(env(stream(97, 0, 98, 0, 99, 0, 100, 0, 101, 0, 102, 0, 103, 0, 104, 0)));
         a = getValue(result.get().order, "a");
         b = getValue(result.get().order, "b");
         c = getValue(result.get().order, "c");
@@ -213,7 +214,7 @@ public class ParseGraphTest {
         assertEquals("None", NONE.toString());
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("This placeholder may not be invoked.");
-        NONE.parse(stream(), enc());
+        NONE.parse(env(stream()));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
@@ -25,7 +25,7 @@ import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.data.Selection.findItemAtOffset;
 import static io.parsingdata.metal.data.Selection.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -54,10 +54,10 @@ public class SelectionTest {
 
     @Test
     public void limit() throws IOException {
-        Optional<Environment> environment = rep(any("a")).parse(stream(1, 2, 3, 4, 5), enc());
-        Assert.assertTrue(environment.isPresent());
+        Optional<ParseState> parseState = rep(any("a")).parse(stream(1, 2, 3, 4, 5), enc());
+        Assert.assertTrue(parseState.isPresent());
         for (int i = 0; i < 7; i++) {
-            assertEquals(Math.min(5, i), getAllValues(environment.get().order, (value) -> value.matches("a"), i).size);
+            assertEquals(Math.min(5, i), getAllValues(parseState.get().order, (value) -> value.matches("a"), i).size);
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
@@ -25,6 +25,7 @@ import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.data.Selection.findItemAtOffset;
 import static io.parsingdata.metal.data.Selection.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -54,7 +55,7 @@ public class SelectionTest {
 
     @Test
     public void limit() throws IOException {
-        Optional<ParseState> parseState = rep(any("a")).parse(stream(1, 2, 3, 4, 5), enc());
+        Optional<ParseState> parseState = rep(any("a")).parse(env(stream(1, 2, 3, 4, 5)));
         Assert.assertTrue(parseState.isPresent());
         for (int i = 0; i < 7; i++) {
             assertEquals(Math.min(5, i), getAllValues(parseState.get().order, (value) -> value.matches("a"), i).size);

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -33,6 +33,7 @@ import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.toByteArray;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
@@ -60,7 +61,7 @@ public class SliceTest {
             seq(def("a", con(3)),
                 post(def("b", con(2)), eq(con(0, 0))),
                 def("c", con(1)),
-                post(def("d", con(1)), eq(con(1)))).parse(new ParseState(stream), enc());
+                post(def("d", con(1)), eq(con(1)))).parse(createFromByteStream(stream), enc());
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 6));
         assertTrue(stream.containsNone(0, 1, 2, 5));
@@ -73,7 +74,7 @@ public class SliceTest {
             seq(def("a", con(3)),
                 post(def("b", len(last(ref("a")))), eq(con(0, 0, 0))),
                 def("c", con(1)),
-                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(new ParseState(stream), enc());
+                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(createFromByteStream(stream), enc());
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 5, 7));
         assertTrue(stream.containsNone(0, 1, 2, 6));

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -99,7 +99,7 @@ public class SliceTest {
         final ParseValue pv1 = new ParseValue("name", NONE, createFromBytes(new byte[]{1, 2}), enc());
         assertEquals("Slice(ConstantSource(0x0102)@0:2)", pv1.slice.toString());
         final ParseState oneValueParseState = stream().add(pv1);
-        final ParseState twoValueParseState = oneValueParseState.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueParseState.order, enc()), ZERO, BigInteger.valueOf(2)).get(), enc()));
+        final ParseState twoValueParseState = oneValueParseState.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueParseState, enc()), ZERO, BigInteger.valueOf(2)).get(), enc()));
         final String dataExpressionSliceString = getValue(twoValueParseState.order, "name2").slice.toString();
         assertTrue(dataExpressionSliceString.startsWith("Slice(DataExpressionSource(NameRef(name)[0]("));
         assertTrue(dataExpressionSliceString.endsWith(")@0:2)"));

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -37,7 +37,7 @@ import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.math.BigInteger;
 import java.util.Optional;
@@ -56,11 +56,11 @@ public class SliceTest {
     @Test
     public void lazyRead() {
         final ReadTrackingByteStream stream = new ReadTrackingByteStream(new InMemoryByteStream(toByteArray(1, 2, 3, 0, 0, 4, 1)));
-        final Optional<Environment> result =
+        final Optional<ParseState> result =
             seq(def("a", con(3)),
                 post(def("b", con(2)), eq(con(0, 0))),
                 def("c", con(1)),
-                post(def("d", con(1)), eq(con(1)))).parse(new Environment(stream), enc());
+                post(def("d", con(1)), eq(con(1)))).parse(new ParseState(stream), enc());
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 6));
         assertTrue(stream.containsNone(0, 1, 2, 5));
@@ -69,11 +69,11 @@ public class SliceTest {
     @Test
     public void lazyLength() {
         final ReadTrackingByteStream stream = new ReadTrackingByteStream(new InMemoryByteStream(toByteArray(1, 2, 3, 0, 0, 0, 4, 1)));
-        final Optional<Environment> result =
+        final Optional<ParseState> result =
             seq(def("a", con(3)),
                 post(def("b", len(last(ref("a")))), eq(con(0, 0, 0))),
                 def("c", con(1)),
-                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(new Environment(stream), enc());
+                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(new ParseState(stream), enc());
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 5, 7));
         assertTrue(stream.containsNone(0, 1, 2, 6));
@@ -97,9 +97,9 @@ public class SliceTest {
     public void sliceToString() {
         final ParseValue pv1 = new ParseValue("name", NONE, createFromBytes(new byte[]{1, 2}), enc());
         assertEquals("Slice(ConstantSource(0x0102)@0:2)", pv1.slice.toString());
-        final Environment oneValueEnvironment = stream().add(pv1);
-        final Environment twoValueEnvironment = oneValueEnvironment.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueEnvironment.order, enc()), ZERO, BigInteger.valueOf(2)).get(), enc()));
-        final String dataExpressionSliceString = getValue(twoValueEnvironment.order, "name2").slice.toString();
+        final ParseState oneValueParseState = stream().add(pv1);
+        final ParseState twoValueParseState = oneValueParseState.add(new ParseValue("name2", NONE, Slice.createFromSource(new DataExpressionSource(ref("name"), 0, oneValueParseState.order, enc()), ZERO, BigInteger.valueOf(2)).get(), enc()));
+        final String dataExpressionSliceString = getValue(twoValueParseState.order, "name2").slice.toString();
         assertTrue(dataExpressionSliceString.startsWith("Slice(DataExpressionSource(NameRef(name)[0]("));
         assertTrue(dataExpressionSliceString.endsWith(")@0:2)"));
     }

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -38,6 +38,7 @@ import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.math.BigInteger;
@@ -61,7 +62,7 @@ public class SliceTest {
             seq(def("a", con(3)),
                 post(def("b", con(2)), eq(con(0, 0))),
                 def("c", con(1)),
-                post(def("d", con(1)), eq(con(1)))).parse(createFromByteStream(stream), enc());
+                post(def("d", con(1)), eq(con(1)))).parse(env(createFromByteStream(stream), enc()));
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 6));
         assertTrue(stream.containsNone(0, 1, 2, 5));
@@ -74,7 +75,7 @@ public class SliceTest {
             seq(def("a", con(3)),
                 post(def("b", len(last(ref("a")))), eq(con(0, 0, 0))),
                 def("c", con(1)),
-                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(createFromByteStream(stream), enc());
+                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(env(createFromByteStream(stream), enc()));
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 5, 7));
         assertTrue(stream.containsNone(0, 1, 2, 6));

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 
 import java.io.IOException;
@@ -53,7 +54,7 @@ public class SourceAndSliceTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
             { new ConstantSource(DATA) },
-            { new DataExpressionSource(con(DATA), 0, ParseGraph.EMPTY, enc()) },
+            { new DataExpressionSource(con(DATA), 0, EMPTY_PARSE_STATE, enc()) },
             { new ByteStreamSource(new InMemoryByteStream(DATA) ) }
         });
     }

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -33,6 +33,7 @@ import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.data.Selection.getAllRoots;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -79,7 +80,7 @@ public class CallbackTest {
                 .add(cho, countingCallback)
                 .add(sequence, countingCallback);
         final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 2, 1 }));
-        assertTrue(sequence.parse(parseState, callbacks, enc()).isPresent());
+        assertTrue(sequence.parse(env(parseState, callbacks, enc())).isPresent());
         countingCallback.assertCounts(4, 1);
     }
 
@@ -105,14 +106,14 @@ public class CallbackTest {
     public void testSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L);
         final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2 }));
-        assertTrue(SIMPLE_SEQ.parse(parseState, callbacks, enc()).isPresent());
+        assertTrue(SIMPLE_SEQ.parse(env(parseState, callbacks, enc())).isPresent());
     }
 
     @Test
     public void testRepSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L, 2L);
         final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
-        assertTrue(rep(SIMPLE_SEQ).parse(parseState, callbacks, enc()).isPresent());
+        assertTrue(rep(SIMPLE_SEQ).parse(env(parseState, callbacks, enc())).isPresent());
     }
 
     @Test
@@ -138,7 +139,7 @@ public class CallbackTest {
                     public void handleFailure(Token token, ParseState before) {}
                 });
         final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
-        assertTrue(repeatingSeq.parse(parseState, callbacks, enc()).isPresent());
+        assertTrue(repeatingSeq.parse(env(parseState, callbacks, enc())).isPresent());
     }
 
     @Test
@@ -153,7 +154,7 @@ public class CallbackTest {
             public void handleFailure(Token token, ParseState before) {}
         });
         final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }));
-        assertTrue(SubStructTest.LINKED_LIST.parse(parseState, callbacks, enc()).isPresent());
+        assertTrue(SubStructTest.LINKED_LIST.parse(env(parseState, callbacks, enc())).isPresent());
         // The ParseReference does not trigger the callback:
         assertEquals(2, linkedListCount);
     }
@@ -172,7 +173,7 @@ public class CallbackTest {
 
         final Callbacks callbacks = Callbacks.create().add(genericCallback);
         final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2, 4 }));
-        final Optional<ParseState> parse = CHOICE.parse(parseState, callbacks, enc());
+        final Optional<ParseState> parse = CHOICE.parse(env(parseState, callbacks, enc()));
         assertTrue(parse.isPresent());
         genericCallback.assertAllHandled();
     }
@@ -203,7 +204,7 @@ public class CallbackTest {
         final long expectedSuccessCount = expectedSuccessDefinitions.size();
         final long expectedFailureCount = expectedFailureDefinitions.size();
         final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 2 }));
-        assertTrue(cho.parse(parseState, callbacks, enc()).isPresent());
+        assertTrue(cho.parse(env(parseState, callbacks, enc())).isPresent());
         genericCallback.assertAllHandled();
         countingCallback.assertCounts(expectedSuccessCount, expectedFailureCount);
     }

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -77,8 +77,8 @@ public class CallbackTest {
                 .add(POST_TWO, countingCallback)
                 .add(cho, countingCallback)
                 .add(sequence, countingCallback);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 2, 1 }), callbacks);
-        assertTrue(sequence.parse(environment, enc()).isPresent());
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 2, 1 }));
+        assertTrue(sequence.parse(environment, callbacks, enc()).isPresent());
         countingCallback.assertCounts(4, 1);
     }
 
@@ -103,15 +103,15 @@ public class CallbackTest {
     @Test
     public void testSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2 }), callbacks);
-        assertTrue(SIMPLE_SEQ.parse(environment, enc()).isPresent());
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2 }));
+        assertTrue(SIMPLE_SEQ.parse(environment, callbacks, enc()).isPresent());
     }
 
     @Test
     public void testRepSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L, 2L);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }), callbacks);
-        assertTrue(rep(SIMPLE_SEQ).parse(environment, enc()).isPresent());
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
+        assertTrue(rep(SIMPLE_SEQ).parse(environment, callbacks, enc()).isPresent());
     }
 
     @Test
@@ -136,8 +136,8 @@ public class CallbackTest {
                     @Override
                     public void handleFailure(Token token, Environment before) {}
                 });
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }), callbacks);
-        assertTrue(repeatingSeq.parse(environment, enc()).isPresent());
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
+        assertTrue(repeatingSeq.parse(environment, callbacks, enc()).isPresent());
     }
 
     @Test
@@ -151,8 +151,8 @@ public class CallbackTest {
             @Override
             public void handleFailure(Token token, Environment before) {}
         });
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }), callbacks);
-        assertTrue(SubStructTest.LINKED_LIST.parse(environment, enc()).isPresent());
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }));
+        assertTrue(SubStructTest.LINKED_LIST.parse(environment, callbacks, enc()).isPresent());
         // The ParseReference does not trigger the callback:
         assertEquals(2, linkedListCount);
     }
@@ -170,8 +170,8 @@ public class CallbackTest {
             expectedFailureDefinitions);
 
         final Callbacks callbacks = Callbacks.create().add(genericCallback);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 4 }), callbacks);
-        final Optional<Environment> parse = CHOICE.parse(environment, enc());
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 4 }));
+        final Optional<Environment> parse = CHOICE.parse(environment, callbacks, enc());
         assertTrue(parse.isPresent());
         genericCallback.assertAllHandled();
     }
@@ -201,8 +201,8 @@ public class CallbackTest {
             .add(cho, countingCallback);
         final long expectedSuccessCount = expectedSuccessDefinitions.size();
         final long expectedFailureCount = expectedFailureDefinitions.size();
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 2 }), callbacks);
-        assertTrue(cho.parse(environment, enc()).isPresent());
+        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 2 }));
+        assertTrue(cho.parse(environment, callbacks, enc()).isPresent());
         genericCallback.assertAllHandled();
         countingCallback.assertCounts(expectedSuccessCount, expectedFailureCount);
     }

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -29,6 +29,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.data.Selection.getAllRoots;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
@@ -77,7 +78,7 @@ public class CallbackTest {
                 .add(POST_TWO, countingCallback)
                 .add(cho, countingCallback)
                 .add(sequence, countingCallback);
-        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 2, 1 }));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 2, 1 }));
         assertTrue(sequence.parse(parseState, callbacks, enc()).isPresent());
         countingCallback.assertCounts(4, 1);
     }
@@ -103,14 +104,14 @@ public class CallbackTest {
     @Test
     public void testSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L);
-        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2 }));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2 }));
         assertTrue(SIMPLE_SEQ.parse(parseState, callbacks, enc()).isPresent());
     }
 
     @Test
     public void testRepSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L, 2L);
-        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
         assertTrue(rep(SIMPLE_SEQ).parse(parseState, callbacks, enc()).isPresent());
     }
 
@@ -136,7 +137,7 @@ public class CallbackTest {
                     @Override
                     public void handleFailure(Token token, ParseState before) {}
                 });
-        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
         assertTrue(repeatingSeq.parse(parseState, callbacks, enc()).isPresent());
     }
 
@@ -151,7 +152,7 @@ public class CallbackTest {
             @Override
             public void handleFailure(Token token, ParseState before) {}
         });
-        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }));
         assertTrue(SubStructTest.LINKED_LIST.parse(parseState, callbacks, enc()).isPresent());
         // The ParseReference does not trigger the callback:
         assertEquals(2, linkedListCount);
@@ -170,7 +171,7 @@ public class CallbackTest {
             expectedFailureDefinitions);
 
         final Callbacks callbacks = Callbacks.create().add(genericCallback);
-        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2, 4 }));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 1, 2, 4 }));
         final Optional<ParseState> parse = CHOICE.parse(parseState, callbacks, enc());
         assertTrue(parse.isPresent());
         genericCallback.assertAllHandled();
@@ -201,7 +202,7 @@ public class CallbackTest {
             .add(cho, countingCallback);
         final long expectedSuccessCount = expectedSuccessDefinitions.size();
         final long expectedFailureCount = expectedFailureDefinitions.size();
-        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 2 }));
+        final ParseState parseState = createFromByteStream(new InMemoryByteStream(new byte[] { 2 }));
         assertTrue(cho.parse(parseState, callbacks, enc()).isPresent());
         genericCallback.assertAllHandled();
         countingCallback.assertCounts(expectedSuccessCount, expectedFailureCount);

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -44,7 +44,7 @@ import java.util.Optional;
 import org.junit.Test;
 
 import io.parsingdata.metal.SubStructTest;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.token.Token;
@@ -77,8 +77,8 @@ public class CallbackTest {
                 .add(POST_TWO, countingCallback)
                 .add(cho, countingCallback)
                 .add(sequence, countingCallback);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 2, 1 }));
-        assertTrue(sequence.parse(environment, callbacks, enc()).isPresent());
+        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 2, 1 }));
+        assertTrue(sequence.parse(parseState, callbacks, enc()).isPresent());
         countingCallback.assertCounts(4, 1);
     }
 
@@ -90,28 +90,28 @@ public class CallbackTest {
             private int count = 0;
 
             @Override
-            public void handleSuccess(Token token, Environment before, Environment after) {
+            public void handleSuccess(Token token, ParseState before, ParseState after) {
                 final ImmutableList<ParseItem> roots = getAllRoots(after.order, token);
                 assertEquals(offsets[count++], roots.head.asGraph().tail.head.asValue().slice.offset.longValueExact());
             }
 
             @Override
-            public void handleFailure(Token token, Environment before) {}
+            public void handleFailure(Token token, ParseState before) {}
         });
     }
 
     @Test
     public void testSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2 }));
-        assertTrue(SIMPLE_SEQ.parse(environment, callbacks, enc()).isPresent());
+        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2 }));
+        assertTrue(SIMPLE_SEQ.parse(parseState, callbacks, enc()).isPresent());
     }
 
     @Test
     public void testRepSimpleCallback() throws IOException {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L, 2L);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
-        assertTrue(rep(SIMPLE_SEQ).parse(environment, callbacks, enc()).isPresent());
+        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
+        assertTrue(rep(SIMPLE_SEQ).parse(parseState, callbacks, enc()).isPresent());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class CallbackTest {
         final Callbacks callbacks = createCallbackList(SIMPLE_SEQ, 0L, 2L)
                 .add(repeatingSeq, new Callback() {
                     @Override
-                    public void handleSuccess(Token token, Environment before, Environment after) {
+                    public void handleSuccess(Token token, ParseState before, ParseState after) {
                         final ImmutableList<ParseItem> repRoots = getAllRoots(after.order, token);
                         assertEquals(1, repRoots.size);
 
@@ -134,25 +134,25 @@ public class CallbackTest {
                     }
 
                     @Override
-                    public void handleFailure(Token token, Environment before) {}
+                    public void handleFailure(Token token, ParseState before) {}
                 });
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
-        assertTrue(repeatingSeq.parse(environment, callbacks, enc()).isPresent());
+        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2, 3, 4 }));
+        assertTrue(repeatingSeq.parse(parseState, callbacks, enc()).isPresent());
     }
 
     @Test
     public void refInCallback() throws IOException {
         final Callbacks callbacks = Callbacks.create().add(SubStructTest.LINKED_LIST, new Callback() {
             @Override
-            public void handleSuccess(Token token, Environment before, Environment after) {
+            public void handleSuccess(Token token, ParseState before, ParseState after) {
                 linkedListCount++;
             }
 
             @Override
-            public void handleFailure(Token token, Environment before) {}
+            public void handleFailure(Token token, ParseState before) {}
         });
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }));
-        assertTrue(SubStructTest.LINKED_LIST.parse(environment, callbacks, enc()).isPresent());
+        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 0, 3, 1, 0, 0, 1 }));
+        assertTrue(SubStructTest.LINKED_LIST.parse(parseState, callbacks, enc()).isPresent());
         // The ParseReference does not trigger the callback:
         assertEquals(2, linkedListCount);
     }
@@ -170,8 +170,8 @@ public class CallbackTest {
             expectedFailureDefinitions);
 
         final Callbacks callbacks = Callbacks.create().add(genericCallback);
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 1, 2, 4 }));
-        final Optional<Environment> parse = CHOICE.parse(environment, callbacks, enc());
+        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 1, 2, 4 }));
+        final Optional<ParseState> parse = CHOICE.parse(parseState, callbacks, enc());
         assertTrue(parse.isPresent());
         genericCallback.assertAllHandled();
     }
@@ -201,8 +201,8 @@ public class CallbackTest {
             .add(cho, countingCallback);
         final long expectedSuccessCount = expectedSuccessDefinitions.size();
         final long expectedFailureCount = expectedFailureDefinitions.size();
-        final Environment environment = new Environment(new InMemoryByteStream(new byte[] { 2 }));
-        assertTrue(cho.parse(environment, callbacks, enc()).isPresent());
+        final ParseState parseState = new ParseState(new InMemoryByteStream(new byte[] { 2 }));
+        assertTrue(cho.parse(parseState, callbacks, enc()).isPresent());
         genericCallback.assertAllHandled();
         countingCallback.assertCounts(expectedSuccessCount, expectedFailureCount);
     }
@@ -221,13 +221,13 @@ public class CallbackTest {
         }
 
         @Override
-        public void handleSuccess(Token token, Environment before, Environment after) {
+        public void handleSuccess(Token token, ParseState before, ParseState after) {
             assertThat(after.offset.longValueExact(), is(equalTo(expectedSuccessOffsets.pop())));
             assertThat(token, is(equalTo(expectedSuccessDefinitions.pop())));
         }
 
         @Override
-        public void handleFailure(Token token, Environment before) {
+        public void handleFailure(Token token, ParseState before) {
             assertThat(before.offset.longValueExact(), is(equalTo(expectedFailureOffsets.pop())));
             assertThat(token, is(equalTo(expectedFailureDefinitions.pop())));
         }
@@ -245,12 +245,12 @@ public class CallbackTest {
         private int failureCount = 0;
 
         @Override
-        public void handleSuccess(final Token token, Environment before, Environment after) {
+        public void handleSuccess(final Token token, ParseState before, ParseState after) {
             successCount++;
         }
 
         @Override
-        public void handleFailure(Token token, Environment before) {
+        public void handleFailure(Token token, ParseState before) {
             failureCount++;
         }
 

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -40,7 +40,7 @@ import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.data.selection.ByToken.get;
 import static io.parsingdata.metal.data.selection.ByToken.getAll;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -52,7 +52,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
@@ -77,8 +77,8 @@ public class ByTokenTest {
     private static final Token MUT_REC_1 = seq(DEF1, new Token("", enc()) {
 
         @Override
-        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-            return MUT_REC_2.parse(scope, environment, encoding);
+        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+            return MUT_REC_2.parse(scope, parseState, encoding);
         }
     });
 
@@ -226,8 +226,8 @@ public class ByTokenTest {
         }
     }
 
-    private ParseGraph parseResultGraph(final Environment env, final Token def) {
-        return def.parse(env, enc()).get().order;
+    private ParseGraph parseResultGraph(final ParseState parseState, final Token def) {
+        return def.parse(parseState, enc()).get().order;
     }
 
     @Test
@@ -235,7 +235,7 @@ public class ByTokenTest {
         final Token smallSub = sub(DEF2, last(ref("value1")));
         final Token extraSub = sub(any("x"), last(ref("value1")));
         final Token composition = seq(DEF1, smallSub, extraSub, smallSub, extraSub);
-        final Optional<Environment> result = composition.parse(stream(0), enc());
+        final Optional<ParseState> result = composition.parse(stream(0), enc());
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> items = getAll(result.get().order, DEF2);
         // should return the ParseGraph created by the Sub and the ParseReference that refers to the existing ParseItem
@@ -249,7 +249,7 @@ public class ByTokenTest {
     @Test
     public void getAllRootsSingle() throws IOException {
         final Token topSeq = seq(any("a"), smallSeq);
-        final Optional<Environment> result = topSeq.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = topSeq.parse(stream(1, 2, 3), enc());
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> seqItems = getAllRoots(result.get().order, smallSeq);
         assertEquals(1, seqItems.size);
@@ -262,7 +262,7 @@ public class ByTokenTest {
     @Test
     public void getAllRootsMulti() throws IOException {
         final Token topSeq = seq(any("a"), smallSeq, smallSeq);
-        final Optional<Environment> result = topSeq.parse(stream(1, 2, 3, 2, 3), enc());
+        final Optional<ParseState> result = topSeq.parse(stream(1, 2, 3, 2, 3), enc());
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> seqItems = getAllRoots(result.get().order, smallSeq);
         assertEquals(2, seqItems.size);
@@ -285,7 +285,7 @@ public class ByTokenTest {
 
     @Test
     public void getAllRootsMultiSub() throws IOException {
-        final Optional<Environment> result = rep(seq(smallSeq, sub(smallSeq, CURRENT_OFFSET))).parse(stream(1, 2, 1, 2, 1, 2, 1, 2), enc());
+        final Optional<ParseState> result = rep(seq(smallSeq, sub(smallSeq, CURRENT_OFFSET))).parse(stream(1, 2, 1, 2, 1, 2, 1, 2), enc());
                                                                                            /* 1: +--------+
                                                                                            /* 2:       +--------+
                                                                                            /* 3:             +--------+ */
@@ -311,15 +311,15 @@ public class ByTokenTest {
         }
 
         @Override
-        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
-            return token.parse(scope, environment, encoding);
+        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+            return token.parse(scope, parseState, encoding);
         }
     }
 
     @Test
     public void getAllRootsMultiSelf() throws IOException {
         final CustomToken customToken = new CustomToken();
-        final Optional<Environment> result = customToken.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = customToken.parse(stream(1, 2, 3), enc());
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> seqItems = getAllRoots(result.get().order, customToken.token);
         assertEquals(3, seqItems.size);

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -40,6 +40,7 @@ import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.data.selection.ByToken.get;
 import static io.parsingdata.metal.data.selection.ByToken.getAll;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -52,14 +53,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.Selection;
-import io.parsingdata.metal.data.callback.Callbacks;
-import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 
 public class ByTokenTest {
@@ -77,8 +77,8 @@ public class ByTokenTest {
     private static final Token MUT_REC_1 = seq(DEF1, new Token("", enc()) {
 
         @Override
-        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-            return MUT_REC_2.parse(scope, parseState, encoding);
+        protected Optional<ParseState> parseImpl(final Environment environment) {
+            return MUT_REC_2.parse(environment);
         }
     });
 
@@ -227,7 +227,7 @@ public class ByTokenTest {
     }
 
     private ParseGraph parseResultGraph(final ParseState parseState, final Token def) {
-        return def.parse(parseState, enc()).get().order;
+        return def.parse(env(parseState, enc())).get().order;
     }
 
     @Test
@@ -235,7 +235,7 @@ public class ByTokenTest {
         final Token smallSub = sub(DEF2, last(ref("value1")));
         final Token extraSub = sub(any("x"), last(ref("value1")));
         final Token composition = seq(DEF1, smallSub, extraSub, smallSub, extraSub);
-        final Optional<ParseState> result = composition.parse(stream(0), enc());
+        final Optional<ParseState> result = composition.parse(env(stream(0)));
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> items = getAll(result.get().order, DEF2);
         // should return the ParseGraph created by the Sub and the ParseReference that refers to the existing ParseItem
@@ -249,7 +249,7 @@ public class ByTokenTest {
     @Test
     public void getAllRootsSingle() throws IOException {
         final Token topSeq = seq(any("a"), smallSeq);
-        final Optional<ParseState> result = topSeq.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = topSeq.parse(env(stream(1, 2, 3)));
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> seqItems = getAllRoots(result.get().order, smallSeq);
         assertEquals(1, seqItems.size);
@@ -262,7 +262,7 @@ public class ByTokenTest {
     @Test
     public void getAllRootsMulti() throws IOException {
         final Token topSeq = seq(any("a"), smallSeq, smallSeq);
-        final Optional<ParseState> result = topSeq.parse(stream(1, 2, 3, 2, 3), enc());
+        final Optional<ParseState> result = topSeq.parse(env(stream(1, 2, 3, 2, 3)));
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> seqItems = getAllRoots(result.get().order, smallSeq);
         assertEquals(2, seqItems.size);
@@ -285,7 +285,7 @@ public class ByTokenTest {
 
     @Test
     public void getAllRootsMultiSub() throws IOException {
-        final Optional<ParseState> result = rep(seq(smallSeq, sub(smallSeq, CURRENT_OFFSET))).parse(stream(1, 2, 1, 2, 1, 2, 1, 2), enc());
+        final Optional<ParseState> result = rep(seq(smallSeq, sub(smallSeq, CURRENT_OFFSET))).parse(env(stream(1, 2, 1, 2, 1, 2, 1, 2)));
                                                                                            /* 1: +--------+
                                                                                            /* 2:       +--------+
                                                                                            /* 3:             +--------+ */
@@ -311,15 +311,15 @@ public class ByTokenTest {
         }
 
         @Override
-        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
-            return token.parse(scope, parseState, encoding);
+        protected Optional<ParseState> parseImpl(final Environment environment) {
+            return token.parse(environment);
         }
     }
 
     @Test
     public void getAllRootsMultiSelf() throws IOException {
         final CustomToken customToken = new CustomToken();
-        final Optional<ParseState> result = customToken.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = customToken.parse(env(stream(1, 2, 3)));
         assertTrue(result.isPresent());
         final ImmutableList<ParseItem> seqItems = getAllRoots(result.get().order, customToken.token);
         assertEquals(3, seqItems.size);

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
+import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.opt;
@@ -35,10 +35,10 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
+import static io.parsingdata.metal.data.Selection.getAllRoots;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.data.selection.ByToken.get;
 import static io.parsingdata.metal.data.selection.ByToken.getAll;
-import static io.parsingdata.metal.data.Selection.getAllRoots;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -58,6 +58,7 @@ import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.Selection;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 
@@ -76,7 +77,7 @@ public class ByTokenTest {
     private static final Token MUT_REC_1 = seq(DEF1, new Token("", enc()) {
 
         @Override
-        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
             return MUT_REC_2.parse(scope, environment, encoding);
         }
     });
@@ -310,7 +311,7 @@ public class ByTokenTest {
         }
 
         @Override
-        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Encoding encoding) {
+        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
             return token.parse(scope, environment, encoding);
         }
     }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -20,6 +20,7 @@ import static java.math.BigInteger.ZERO;
 
 import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 
 import java.math.BigInteger;
@@ -28,7 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseReference;
 import io.parsingdata.metal.data.Source;
 
@@ -46,7 +46,7 @@ public class ByTypeTest {
     public void unresolvableRef() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("A ParseReference must point to an existing graph.");
-        getReferences(new ParseState(DUMMY_STREAM).add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).order);
+        getReferences(createFromByteStream(DUMMY_STREAM).add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).order);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -28,7 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseReference;
 import io.parsingdata.metal.data.Source;
 
@@ -46,7 +46,7 @@ public class ByTypeTest {
     public void unresolvableRef() {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("A ParseReference must point to an existing graph.");
-        getReferences(new Environment(DUMMY_STREAM).add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).order);
+        getReferences(new ParseState(DUMMY_STREAM).add(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).order);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -34,9 +35,8 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.util.InMemoryByteStream;
 
 public class BytesTest {
@@ -61,7 +61,7 @@ public class BytesTest {
                 def("value", con(2)),
                 def("divider", con(1)),
                 def("divider", con(1)),
-                def("divider", con(1))).parse(stream(1, 0, 127, 127, 127, 0, 255, 0, 1), enc());
+                def("divider", con(1))).parse(env(stream(1, 0, 127, 127, 127, 0, 255, 0, 1)));
         assertTrue(result.isPresent());
         final ImmutableList<Optional<Value>> bytesAfterDivision = bytes(div(ref("value"), ref("divider"))).eval(result.get(), enc());
         assertEquals(3, bytesAfterDivision.size); // 1 of the first division, 0 of the second, 2 of the third

--- a/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
@@ -26,14 +26,14 @@ import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 
@@ -51,7 +51,7 @@ public class BytesTest {
 
     @Test
     public void bytesListContainsEmpty() throws IOException {
-        Optional<Environment> result =
+        Optional<ParseState> result =
             seq(def("value", con(2)),
                 def("value", con(2)),
                 def("value", con(2)),

--- a/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
@@ -25,6 +25,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
@@ -36,17 +37,20 @@ import org.junit.Test;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.util.InMemoryByteStream;
 
 public class BytesTest {
 
+    public static final ParseState EMPTY_PARSE_STATE = createFromByteStream(new InMemoryByteStream(new byte[] {}));
+
     @Test
     public void bytesEmpty() {
-        assertEquals(0, bytes(ref("random")).eval(ParseGraph.EMPTY, enc()).size);
+        assertEquals(0, bytes(ref("random")).eval(EMPTY_PARSE_STATE, enc()).size);
     }
 
     @Test
     public void bytesListContainsOnlyEmpty() {
-        assertEquals(0, bytes(div(con(1), con(0))).eval(ParseGraph.EMPTY, enc()).size);
+        assertEquals(0, bytes(div(con(1), con(0))).eval(EMPTY_PARSE_STATE, enc()).size);
     }
 
     @Test
@@ -59,7 +63,7 @@ public class BytesTest {
                 def("divider", con(1)),
                 def("divider", con(1))).parse(stream(1, 0, 127, 127, 127, 0, 255, 0, 1), enc());
         assertTrue(result.isPresent());
-        final ImmutableList<Optional<Value>> bytesAfterDivision = bytes(div(ref("value"), ref("divider"))).eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> bytesAfterDivision = bytes(div(ref("value"), ref("divider"))).eval(result.get(), enc());
         assertEquals(3, bytesAfterDivision.size); // 1 of the first division, 0 of the second, 2 of the third
         assertEquals(1, bytesAfterDivision.head.get().asNumeric().intValueExact()); // first value (0x0100) / first divider (0xFF)
         // second division result is missing because of division by zero

--- a/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/CurrentOffsetTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value;
+
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.last;
+import static io.parsingdata.metal.Shorthand.post;
+import static io.parsingdata.metal.Shorthand.pre;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.Shorthand.sub;
+import static io.parsingdata.metal.Shorthand.tie;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.token.Token;
+
+public class CurrentOffsetTest {
+
+    @Test
+    public void currentOffset() {
+        final Optional<ParseState> result =
+            seq(
+                prePostDef("zero", 0),
+                sub(prePostDef("three", 3), con(3)),
+                prePostDef("one", 1),
+                tie(prePostDef("zeroInOne", 0), last(ref("one"))),
+                prePostDef("two", 2)
+            ).parse(stream(0, 1, 2, 3, 4), enc());
+        assertTrue(result.isPresent());
+    }
+
+    private Token prePostDef(final String name, final int offset) {
+        return
+            post(pre(def(name, 1), eq(CURRENT_OFFSET, con(offset))), eq(CURRENT_OFFSET, con(offset+1)));
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/expression/value/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/CurrentOffsetTest.java
@@ -30,6 +30,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
@@ -50,7 +51,7 @@ public class CurrentOffsetTest {
                 prePostDef("one", 1),
                 tie(prePostDef("zeroInOne", 0), last(ref("one"))),
                 prePostDef("two", 2)
-            ).parse(stream(0, 1, 2, 3, 4), enc());
+            ).parse(env(stream(0, 1, 2, 3, 4)));
         assertTrue(result.isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -31,9 +31,9 @@ import static io.parsingdata.metal.Shorthand.elvis;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
-import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -42,11 +42,9 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.token.Token;
-import io.parsingdata.metal.util.InMemoryByteStream;
 
 public class ElvisExpressionTest {
 
@@ -59,7 +57,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisLeft() throws IOException { // the building
-        final Optional<ParseState> result = choice.parse(stream(1), enc());
+        final Optional<ParseState> result = choice.parse(env(stream(1)));
         final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get(), enc());
 
         assertNotNull(eval);
@@ -69,7 +67,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisRight() throws IOException {
-        final Optional<ParseState> result = choice.parse(stream(2), enc());
+        final Optional<ParseState> result = choice.parse(env(stream(2)));
         final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get(), enc());
 
         assertNotNull(eval);
@@ -87,7 +85,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisList() throws IOException {
-        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
+        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(env(stream(1, 2, 3, 4)));
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get(), enc());
@@ -98,7 +96,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisListWithEmpty() throws IOException {
-        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
+        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(env(stream(1, 2, 3, 4)));
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("c"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get(), enc());
@@ -109,7 +107,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisListDifferentLengths() throws IOException {
-        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b"), any("b")).parse(stream(1, 2, 3, 4, 5), enc());
+        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b"), any("b")).parse(env(stream(1, 2, 3, 4, 5)));
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get(), enc());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -32,7 +32,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -40,7 +40,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.token.Token;
@@ -56,7 +56,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisLeft() throws IOException { // the building
-        final Optional<Environment> result = choice.parse(stream(1), enc());
+        final Optional<ParseState> result = choice.parse(stream(1), enc());
         final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get().order, enc());
 
         assertNotNull(eval);
@@ -66,7 +66,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisRight() throws IOException {
-        final Optional<Environment> result = choice.parse(stream(2), enc());
+        final Optional<ParseState> result = choice.parse(stream(2), enc());
         final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get().order, enc());
 
         assertNotNull(eval);
@@ -84,7 +84,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisList() throws IOException {
-        final Optional<Environment> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
+        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
@@ -95,7 +95,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisListWithEmpty() throws IOException {
-        final Optional<Environment> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
+        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("c"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
@@ -106,7 +106,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisListDifferentLengths() throws IOException {
-        final Optional<Environment> result = seq(any("a"), any("a"), any("b"), any("b"), any("b")).parse(stream(1, 2, 3, 4, 5), enc());
+        final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b"), any("b")).parse(stream(1, 2, 3, 4, 5), enc());
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
         final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -31,6 +31,8 @@ import static io.parsingdata.metal.Shorthand.elvis;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
+import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -44,6 +46,7 @@ import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.token.Token;
+import io.parsingdata.metal.util.InMemoryByteStream;
 
 public class ElvisExpressionTest {
 
@@ -57,7 +60,7 @@ public class ElvisExpressionTest {
     @Test
     public void elvisLeft() throws IOException { // the building
         final Optional<ParseState> result = choice.parse(stream(1), enc());
-        final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get(), enc());
 
         assertNotNull(eval);
         assertEquals(1, eval.size);
@@ -67,7 +70,7 @@ public class ElvisExpressionTest {
     @Test
     public void elvisRight() throws IOException {
         final Optional<ParseState> result = choice.parse(stream(2), enc());
-        final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> eval = elvisExpression.eval(result.get(), enc());
 
         assertNotNull(eval);
         assertEquals(1, eval.size);
@@ -76,7 +79,7 @@ public class ElvisExpressionTest {
 
     @Test
     public void elvisNone() throws IOException {
-        final ImmutableList<Optional<Value>> eval = elvisExpression.eval(ParseGraph.EMPTY, enc());
+        final ImmutableList<Optional<Value>> eval = elvisExpression.eval(EMPTY_PARSE_STATE, enc());
 
         assertNotNull(eval);
         assertTrue(eval.isEmpty());
@@ -87,7 +90,7 @@ public class ElvisExpressionTest {
         final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
-        final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> eval = elvis.eval(result.get(), enc());
         assertEquals(2, eval.size);
         assertEquals(2, eval.head.get().asNumeric().intValueExact());
         assertEquals(1, eval.tail.head.get().asNumeric().intValueExact());
@@ -98,7 +101,7 @@ public class ElvisExpressionTest {
         final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b")).parse(stream(1, 2, 3, 4), enc());
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("c"), ref("b"));
-        final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> eval = elvis.eval(result.get(), enc());
         assertEquals(2, eval.size);
         assertEquals(4, eval.head.get().asNumeric().intValueExact());
         assertEquals(3, eval.tail.head.get().asNumeric().intValueExact());
@@ -109,7 +112,7 @@ public class ElvisExpressionTest {
         final Optional<ParseState> result = seq(any("a"), any("a"), any("b"), any("b"), any("b")).parse(stream(1, 2, 3, 4, 5), enc());
         assertTrue(result.isPresent());
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
-        final ImmutableList<Optional<Value>> eval = elvis.eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> eval = elvis.eval(result.get(), enc());
         assertEquals(3, eval.size);
         assertEquals(2, eval.head.get().asNumeric().intValueExact());
         assertEquals(1, eval.tail.head.get().asNumeric().intValueExact());
@@ -119,14 +122,14 @@ public class ElvisExpressionTest {
     @Test
     public void elvisListEmpty() {
         final ValueExpression elvis = elvis(ref("a"), ref("b"));
-        final ImmutableList<Optional<Value>> eval = elvis.eval(stream(0).order, enc());
+        final ImmutableList<Optional<Value>> eval = elvis.eval(stream(0), enc());
         assertEquals(0, eval.size);
     }
 
     @Test
     public void elvisLeftNone() {
         final ValueExpression elvis = elvis(div(con(1), con(0)), con(1));
-        final ImmutableList<Optional<Value>> eval = elvis.eval(stream(0).order, enc());
+        final ImmutableList<Optional<Value>> eval = elvis.eval(stream(0), enc());
         assertEquals(1, eval.size);
         assertEquals(1, eval.head.get().asNumeric().intValueExact());
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -26,6 +26,7 @@ import static io.parsingdata.metal.Shorthand.exp;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
+import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -52,7 +53,7 @@ public class ExpandTest {
 
     @Test
     public void expandEmpty() {
-        final ImmutableList<Optional<Value>> result = exp(ref("a"), con(5)).eval(ParseGraph.EMPTY, enc());
+        final ImmutableList<Optional<Value>> result = exp(ref("a"), con(5)).eval(EMPTY_PARSE_STATE, enc());
         assertTrue(result.isEmpty());
     }
 
@@ -60,25 +61,25 @@ public class ExpandTest {
     public void expandEmptyTimes() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Count must evaluate to a single non-empty value.");
-        exp(con(1), div(con(1), con(0))).eval(ParseGraph.EMPTY, enc());
+        exp(con(1), div(con(1), con(0))).eval(EMPTY_PARSE_STATE, enc());
     }
 
     @Test
     public void expandListTimes() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Count must evaluate to a single non-empty value.");
-        exp(con(1), ref("a")).eval(createFromByteStream(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2).order, enc());
+        exp(con(1), ref("a")).eval(createFromByteStream(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2), enc());
     }
 
     @Test
     public void expandZeroTimes() {
-        final ImmutableList<Optional<Value>> result = exp(con(1), con(0)).eval(ParseGraph.EMPTY, enc());
+        final ImmutableList<Optional<Value>> result = exp(con(1), con(0)).eval(EMPTY_PARSE_STATE, enc());
         assertTrue(result.isEmpty());
     }
 
     @Test
     public void expandValue() {
-        ImmutableList<Optional<Value>> result = exp(con(VALUE_1), con(SIZE)).eval(ParseGraph.EMPTY, enc());
+        ImmutableList<Optional<Value>> result = exp(con(VALUE_1), con(SIZE)).eval(EMPTY_PARSE_STATE, enc());
         assertEquals(SIZE, result.size);
         for (int i = 0; i < SIZE; i++) {
             assertTrue(result.head.isPresent());
@@ -89,7 +90,7 @@ public class ExpandTest {
 
     @Test
     public void expandList() {
-        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(createFromByteStream(DUMMY_STREAM).add(PARSEVALUE_2).add(PARSEVALUE_1).order, enc());
+        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(createFromByteStream(DUMMY_STREAM).add(PARSEVALUE_2).add(PARSEVALUE_1), enc());
         assertEquals(2 * SIZE, result.size);
         for (int i = 0; i < SIZE; i++) {
             assertTrue(result.head.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -24,6 +24,7 @@ import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.exp;
 import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
@@ -34,7 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseValue;
@@ -67,7 +67,7 @@ public class ExpandTest {
     public void expandListTimes() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Count must evaluate to a single non-empty value.");
-        exp(con(1), ref("a")).eval(new ParseState(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2).order, enc());
+        exp(con(1), ref("a")).eval(createFromByteStream(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2).order, enc());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class ExpandTest {
 
     @Test
     public void expandList() {
-        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(new ParseState(DUMMY_STREAM).add(PARSEVALUE_2).add(PARSEVALUE_1).order, enc());
+        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(createFromByteStream(DUMMY_STREAM).add(PARSEVALUE_2).add(PARSEVALUE_1).order, enc());
         assertEquals(2 * SIZE, result.size);
         for (int i = 0; i < SIZE; i++) {
             assertTrue(result.head.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -34,7 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseValue;
@@ -67,7 +67,7 @@ public class ExpandTest {
     public void expandListTimes() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Count must evaluate to a single non-empty value.");
-        exp(con(1), ref("a")).eval(new Environment(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2).order, enc());
+        exp(con(1), ref("a")).eval(new ParseState(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2).order, enc());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class ExpandTest {
 
     @Test
     public void expandList() {
-        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(new Environment(DUMMY_STREAM).add(PARSEVALUE_2).add(PARSEVALUE_1).order, enc());
+        ImmutableList<Optional<Value>> result = exp(ref("a"), con(SIZE)).eval(new ParseState(DUMMY_STREAM).add(PARSEVALUE_2).add(PARSEVALUE_1).order, enc());
         assertEquals(2 * SIZE, result.size);
         for (int i = 0; i < SIZE; i++) {
             assertTrue(result.head.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -60,25 +60,20 @@ public class FoldEdgeCaseTest {
 
     @Test
     public void valuesContainsEmpty() {
-        assertTrue(foldLeft(div(con(1), con(0)), Shorthand::add).eval(stream(0).order, enc()).isEmpty());
-        assertTrue(foldRight(div(con(1), con(0)), Shorthand::add).eval(stream(0).order, enc()).isEmpty());
+        assertTrue(foldLeft(div(con(1), con(0)), Shorthand::add).eval(stream(0), enc()).isEmpty());
+        assertTrue(foldRight(div(con(1), con(0)), Shorthand::add).eval(stream(0), enc()).isEmpty());
     }
 
     @Test
     public void foldToEmpty() throws IOException {
         final ParseState parseState = rep(any("value")).parse(stream(1, 0), enc()).get();
-        assertFalse(foldLeft(ref("value"), Shorthand::div).eval(parseState.order, enc()).head.isPresent());
-        assertFalse(foldRight(ref("value"), Shorthand::div).eval(parseState.order, enc()).head.isPresent());
+        assertFalse(foldLeft(ref("value"), Shorthand::div).eval(parseState, enc()).head.isPresent());
+        assertFalse(foldRight(ref("value"), Shorthand::div).eval(parseState, enc()).head.isPresent());
     }
 
     @Test
     public void inputContainsEmptyInTail() {
-        assertTrue(foldRight(new ValueExpression() {
-            @Override
-            public ImmutableList<Optional<Value>> eval(ParseGraph graph, Encoding encoding) {
-                return ImmutableList.create(Optional.<Value>empty()).add(Optional.of(new Value(createFromBytes(new byte[] { 1, 2 }), enc())));
-            }
-        }, Shorthand::add).eval(stream(0).order, enc()).isEmpty());
+        assertTrue(foldRight((parseState, encoding) -> ImmutableList.create(Optional.<Value>empty()).add(Optional.of(new Value(createFromBytes(new byte[] { 1, 2 }), enc()))), Shorthand::add).eval(stream(0), enc()).isEmpty());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -31,7 +31,7 @@ import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.parsingdata.metal.Shorthand;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.encoding.Encoding;
@@ -66,9 +66,9 @@ public class FoldEdgeCaseTest {
 
     @Test
     public void foldToEmpty() throws IOException {
-        final Environment environment = rep(any("value")).parse(stream(1, 0), enc()).get();
-        assertFalse(foldLeft(ref("value"), Shorthand::div).eval(environment.order, enc()).head.isPresent());
-        assertFalse(foldRight(ref("value"), Shorthand::div).eval(environment.order, enc()).head.isPresent());
+        final ParseState parseState = rep(any("value")).parse(stream(1, 0), enc()).get();
+        assertFalse(foldLeft(ref("value"), Shorthand::div).eval(parseState.order, enc()).head.isPresent());
+        assertFalse(foldRight(ref("value"), Shorthand::div).eval(parseState.order, enc()).head.isPresent());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class FoldEdgeCaseTest {
 
     @Test
     public void multipleInits() throws IOException {
-        final Optional<Environment> parseResult =
+        final Optional<ParseState> parseResult =
             seq(
                 def("init", 1),
                 def("init", 1),
@@ -100,7 +100,7 @@ public class FoldEdgeCaseTest {
 
     @Test
     public void noValues() throws IOException {
-        final Optional<Environment> parseResult =
+        final Optional<ParseState> parseResult =
             cho(
                 def("folded", 1, eq(foldLeft(ref("toFold"), Shorthand::add))),
                 def("folded", 1, eq(foldRight(ref("toFold"), Shorthand::add)))

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -31,6 +31,7 @@ import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -43,10 +44,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.parsingdata.metal.Shorthand;
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
-import io.parsingdata.metal.data.ParseGraph;
-import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.data.ParseState;
 
 /**
  * See {@link io.parsingdata.metal.ReducersTest} for other fold tests.
@@ -66,7 +65,7 @@ public class FoldEdgeCaseTest {
 
     @Test
     public void foldToEmpty() throws IOException {
-        final ParseState parseState = rep(any("value")).parse(stream(1, 0), enc()).get();
+        final ParseState parseState = rep(any("value")).parse(env(stream(1, 0))).get();
         assertFalse(foldLeft(ref("value"), Shorthand::div).eval(parseState, enc()).head.isPresent());
         assertFalse(foldRight(ref("value"), Shorthand::div).eval(parseState, enc()).head.isPresent());
     }
@@ -88,7 +87,7 @@ public class FoldEdgeCaseTest {
                     def("folded", 1, eq(foldLeft(ref("toFold"), Shorthand::add, ref("init")))),
                     def("folded", 1, eq(foldRight(ref("toFold"), Shorthand::add, ref("init"))))
                 )
-            ).parse(stream(1, 2, 1, 2, 3), enc());
+            ).parse(env(stream(1, 2, 1, 2, 3)));
 
         assertFalse(parseResult.isPresent());
     }
@@ -99,7 +98,7 @@ public class FoldEdgeCaseTest {
             cho(
                 def("folded", 1, eq(foldLeft(ref("toFold"), Shorthand::add))),
                 def("folded", 1, eq(foldRight(ref("toFold"), Shorthand::add)))
-            ).parse(stream(1), enc());
+            ).parse(env(stream(1)));
 
         assertFalse(parseResult.isPresent());
     }
@@ -114,7 +113,7 @@ public class FoldEdgeCaseTest {
             def("toFold", 1),
             def("toFold", 1),
             def("folded", 1, eq(expression))
-        ).parse(stream(1, 2, 1, 2, 3), enc());
+        ).parse(env(stream(1, 2, 1, 2, 3)));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
@@ -66,7 +66,7 @@ public class NthExpressionTest {
     public void testNanIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [Nan], result = [Nan]
         final Optional<ParseState> result = format.parse(stream(5, 1, 2, 3, 4, 5, 0), enc());
-        final ImmutableList<Optional<Value>> values = nth(ref("value"), div(con(0), con(0))).eval(result.get().order, enc());
+        final ImmutableList<Optional<Value>> values = nth(ref("value"), div(con(0), con(0))).eval(result.get(), enc());
         assertThat(values.size, is(equalTo(1L)));
         assertThat(values.head.isPresent(), is(equalTo(false)));
     }
@@ -144,7 +144,7 @@ public class NthExpressionTest {
     private ImmutableList<Optional<Value>> makeList(final ParseState parseState, final long listSize) throws IOException {
         final Optional<ParseState> result = format.parse(parseState, signed());
         assertTrue(result.isPresent());
-        final ImmutableList<Optional<Value>> values = nth.eval(result.get().order, signed());
+        final ImmutableList<Optional<Value>> values = nth.eval(result.get(), signed());
         assertThat(values.size, is(equalTo(listSize)));
         return values;
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
@@ -29,7 +29,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.token.Token;
 
@@ -65,7 +65,7 @@ public class NthExpressionTest {
     @Test
     public void testNanIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [Nan], result = [Nan]
-        final Optional<Environment> result = format.parse(stream(5, 1, 2, 3, 4, 5, 0), enc());
+        final Optional<ParseState> result = format.parse(stream(5, 1, 2, 3, 4, 5, 0), enc());
         final ImmutableList<Optional<Value>> values = nth(ref("value"), div(con(0), con(0))).eval(result.get().order, enc());
         assertThat(values.size, is(equalTo(1L)));
         assertThat(values.head.isPresent(), is(equalTo(false)));
@@ -141,8 +141,8 @@ public class NthExpressionTest {
         }
     }
 
-    private ImmutableList<Optional<Value>> makeList(final Environment environment, final long listSize) throws IOException {
-        final Optional<Environment> result = format.parse(environment, signed());
+    private ImmutableList<Optional<Value>> makeList(final ParseState parseState, final long listSize) throws IOException {
+        final Optional<ParseState> result = format.parse(parseState, signed());
         assertTrue(result.isPresent());
         final ImmutableList<Optional<Value>> values = nth.eval(result.get().order, signed());
         assertThat(values.size, is(equalTo(listSize)));

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
@@ -29,6 +29,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -65,7 +66,7 @@ public class NthExpressionTest {
     @Test
     public void testNanIndex() throws IOException {
         // 5 values = [1, 2, 3, 4, 5], 1 index = [Nan], result = [Nan]
-        final Optional<ParseState> result = format.parse(stream(5, 1, 2, 3, 4, 5, 0), enc());
+        final Optional<ParseState> result = format.parse(env(stream(5, 1, 2, 3, 4, 5, 0)));
         final ImmutableList<Optional<Value>> values = nth(ref("value"), div(con(0), con(0))).eval(result.get(), enc());
         assertThat(values.size, is(equalTo(1L)));
         assertThat(values.head.isPresent(), is(equalTo(false)));
@@ -142,7 +143,7 @@ public class NthExpressionTest {
     }
 
     private ImmutableList<Optional<Value>> makeList(final ParseState parseState, final long listSize) throws IOException {
-        final Optional<ParseState> result = format.parse(parseState, signed());
+        final Optional<ParseState> result = format.parse(env(parseState, signed()));
         assertTrue(result.isPresent());
         final ImmutableList<Optional<Value>> values = nth.eval(result.get(), signed());
         assertThat(values.size, is(equalTo(listSize)));

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -33,31 +33,32 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 
 public class RefEdgeCaseTest {
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    ParseGraph parseGraph;
+    ParseState parseState;
 
     @Before
     public void before() throws IOException {
-        parseGraph = rep(any("a")).parse(stream(1, 2, 3), enc()).get().order;
+        parseState = rep(any("a")).parse(stream(1, 2, 3), enc()).get();
     }
 
     @Test
     public void multiLimit() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Limit must evaluate to a single non-empty value.");
-        ref("a", exp(con(1), con(3))).eval(parseGraph, enc());
+        ref("a", exp(con(1), con(3))).eval(parseState, enc());
     }
 
     @Test
     public void emptyLimit() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Limit must evaluate to a single non-empty value.");
-        ref("a", div(con(1), con(0))).eval(parseGraph, enc());
+        ref("a", div(con(1), con(0))).eval(parseState, enc());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -22,6 +22,7 @@ import static io.parsingdata.metal.Shorthand.exp;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -32,7 +33,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseState;
 
 public class RefEdgeCaseTest {
@@ -44,7 +44,7 @@ public class RefEdgeCaseTest {
 
     @Before
     public void before() throws IOException {
-        parseState = rep(any("a")).parse(stream(1, 2, 3), enc()).get();
+        parseState = rep(any("a")).parse(env(stream(1, 2, 3))).get();
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -22,7 +22,7 @@ import static io.parsingdata.metal.Shorthand.exp;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionEvalEmptyTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionEvalEmptyTest.java
@@ -50,7 +50,7 @@ public class ValueExpressionEvalEmptyTest {
     }
 
     private void parse(final ValueExpression expression) {
-        final ImmutableList<Optional<Value>> output = expression.eval(stream(0).order, enc());
+        final ImmutableList<Optional<Value>> output = expression.eval(stream(0), enc());
         assertEquals(1, output.size);
         assertFalse(output.head.isPresent());
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionEvalEmptyTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionEvalEmptyTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.mod;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionListSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionListSemanticsTest.java
@@ -29,7 +29,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Arrays;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
@@ -20,7 +20,7 @@ public class OffsetTest {
 
     @Test
     public void definedValueOffset() {
-        final ImmutableList<Optional<Value>> offsetCon = offset(con(1)).eval(stream().order, enc());
+        final ImmutableList<Optional<Value>> offsetCon = offset(con(1)).eval(stream(), enc());
         assertFalse(offsetCon.isEmpty());
         assertEquals(1, offsetCon.size);
         assertTrue(offsetCon.head.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.offset;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -24,6 +24,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -39,12 +40,12 @@ public class DefTest {
 
     @Test
     public void scopeWithoutEncoding() throws IOException {
-        assertEquals(1, getValue(def("a", 1).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValueExact());
+        assertEquals(1, getValue(def("a", 1).parse(env("scope", stream(1), enc())).get().order, "scope.a").asNumeric().intValueExact());
     }
 
     @Test
     public void scopeWithEncoding() throws IOException {
-        assertEquals(1, getValue(def("a", 1, signed()).parse("scope", stream(1), enc()).get().order, "scope.a").asNumeric().intValueExact());
+        assertEquals(1, getValue(def("a", 1, signed()).parse(env("scope", stream(1), enc())).get().order, "scope.a").asNumeric().intValueExact());
     }
 
     @Test
@@ -56,7 +57,7 @@ public class DefTest {
 
     @Test
     public void errorNegativeSize() {
-        assertFalse(def("negativeSize", con(-1, signed())).parse(stream(1), enc()).isPresent());
+        assertFalse(def("negativeSize", con(-1, signed())).parse(env(stream(1))).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -31,7 +31,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/test/java/io/parsingdata/metal/token/PostTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PostTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -46,7 +47,7 @@ public class PostTest {
 
     @Test
     public void postconditionTrue() throws IOException {
-        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(env(stream(1, 1)));
 
         // token parses and postcondition is true
         assertThat(result.isPresent(), is(true));
@@ -55,7 +56,7 @@ public class PostTest {
 
     @Test
     public void postconditionFalse() throws IOException {
-        final Optional<ParseState> result = SEQUENCE.parse(stream(0, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(env(stream(0, 1)));
 
         // token parses, but postcondition is false
         assertThat(result.isPresent(), is(false));
@@ -63,7 +64,7 @@ public class PostTest {
 
     @Test
     public void postconditionParseFails() throws IOException {
-        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 2), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(env(stream(1, 2)));
 
         // parse fails
         assertThat(result.isPresent(), is(false));

--- a/core/src/test/java/io/parsingdata/metal/token/PostTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PostTest.java
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -35,7 +35,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 
 public class PostTest {
 
@@ -46,7 +46,7 @@ public class PostTest {
 
     @Test
     public void postconditionTrue() throws IOException {
-        final Optional<Environment> result = SEQUENCE.parse(stream(1, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 1), enc());
 
         // token parses and postcondition is true
         assertThat(result.isPresent(), is(true));
@@ -55,7 +55,7 @@ public class PostTest {
 
     @Test
     public void postconditionFalse() throws IOException {
-        final Optional<Environment> result = SEQUENCE.parse(stream(0, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(stream(0, 1), enc());
 
         // token parses, but postcondition is false
         assertThat(result.isPresent(), is(false));
@@ -63,7 +63,7 @@ public class PostTest {
 
     @Test
     public void postconditionParseFails() throws IOException {
-        final Optional<Environment> result = SEQUENCE.parse(stream(1, 2), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 2), enc());
 
         // parse fails
         assertThat(result.isPresent(), is(false));

--- a/core/src/test/java/io/parsingdata/metal/token/PreTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PreTest.java
@@ -27,14 +27,14 @@ import static io.parsingdata.metal.Shorthand.pre;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 
 public class PreTest {
 
@@ -43,7 +43,7 @@ public class PreTest {
 
     @Test
     public void preconditionTrue() throws IOException {
-        final Optional<Environment> result = SEQUENCE.parse(stream(1, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 1), enc());
 
         // precondition is true, token is parsed
         assertThat(result.get().offset.longValueExact(), is(2L));
@@ -51,7 +51,7 @@ public class PreTest {
 
     @Test
     public void preconditionFalse() throws IOException {
-        final Optional<Environment> result = SEQUENCE.parse(stream(0, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(stream(0, 1), enc());
 
         // precondition is false, token is not parsed
         assertThat(result.isPresent(), is(false));
@@ -59,7 +59,7 @@ public class PreTest {
 
     @Test
     public void preconditionTrueParseFails() throws IOException {
-        final Optional<Environment> result = SEQUENCE.parse(stream(1, 2), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 2), enc());
 
         // precondition is true, but token can't be parsed
         assertThat(result.isPresent(), is(false));

--- a/core/src/test/java/io/parsingdata/metal/token/PreTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PreTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.Shorthand.pre;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class PreTest {
 
     @Test
     public void preconditionTrue() throws IOException {
-        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(env(stream(1, 1)));
 
         // precondition is true, token is parsed
         assertThat(result.get().offset.longValueExact(), is(2L));
@@ -51,7 +52,7 @@ public class PreTest {
 
     @Test
     public void preconditionFalse() throws IOException {
-        final Optional<ParseState> result = SEQUENCE.parse(stream(0, 1), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(env(stream(0, 1)));
 
         // precondition is false, token is not parsed
         assertThat(result.isPresent(), is(false));
@@ -59,7 +60,7 @@ public class PreTest {
 
     @Test
     public void preconditionTrueParseFails() throws IOException {
-        final Optional<ParseState> result = SEQUENCE.parse(stream(1, 2), enc());
+        final Optional<ParseState> result = SEQUENCE.parse(env(stream(1, 2)));
 
         // precondition is true, but token can't be parsed
         assertThat(result.isPresent(), is(false));

--- a/core/src/test/java/io/parsingdata/metal/token/TieTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TieTest.java
@@ -39,6 +39,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.Util.inflate;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
@@ -93,7 +94,7 @@ public class TieTest {
     }
 
     private Optional<ParseState> checkFullParse(Token token, byte[] data) throws IOException {
-        final Optional<ParseState> result = token.parse(new ParseState(new InMemoryByteStream(data)), enc());
+        final Optional<ParseState> result = token.parse(createFromByteStream(new InMemoryByteStream(data)), enc());
         assertTrue(result.isPresent());
         assertEquals(data.length, result.get().offset.intValueExact());
         return result;

--- a/core/src/test/java/io/parsingdata/metal/token/TieTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TieTest.java
@@ -90,7 +90,7 @@ public class TieTest {
     @Test
     public void checkContainerSource() throws IOException {
         final Optional<ParseState> result = parseContainer();
-        checkFullParse(INC_PREV_MOD_100, fold(ref("value"), Shorthand::cat).eval(result.get().order, enc()).head.get().getValue());
+        checkFullParse(INC_PREV_MOD_100, fold(ref("value"), Shorthand::cat).eval(result.get(), enc()).head.get().getValue());
     }
 
     private Optional<ParseState> checkFullParse(Token token, byte[] data) throws IOException {

--- a/core/src/test/java/io/parsingdata/metal/token/TieTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TieTest.java
@@ -42,7 +42,7 @@ import static io.parsingdata.metal.Util.inflate;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;
@@ -52,10 +52,9 @@ import java.util.zip.Deflater;
 import org.junit.Test;
 
 import io.parsingdata.metal.Shorthand;
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
-import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.util.InMemoryByteStream;
 
@@ -76,25 +75,25 @@ public class TieTest {
 
     @Test
     public void smallContainer() throws IOException {
-        final Optional<Environment> result = parseContainer();
+        final Optional<ParseState> result = parseContainer();
         assertEquals(5, result.get().offset.intValueExact());
         assertEquals(6, getAllValues(result.get().order, "value").size);
     }
 
-    private Optional<Environment> parseContainer() throws IOException {
-        final Optional<Environment> result = CONTAINER.parse(stream(2, 3, 7, 5, 9, 3, 4, 1, 2, 5, 6), enc());
+    private Optional<ParseState> parseContainer() throws IOException {
+        final Optional<ParseState> result = CONTAINER.parse(stream(2, 3, 7, 5, 9, 3, 4, 1, 2, 5, 6), enc());
         assertTrue(result.isPresent());
         return result;
     }
 
     @Test
     public void checkContainerSource() throws IOException {
-        final Optional<Environment> result = parseContainer();
+        final Optional<ParseState> result = parseContainer();
         checkFullParse(INC_PREV_MOD_100, fold(ref("value"), Shorthand::cat).eval(result.get().order, enc()).head.get().getValue());
     }
 
-    private Optional<Environment> checkFullParse(Token token, byte[] data) throws IOException {
-        final Optional<Environment> result = token.parse(new Environment(new InMemoryByteStream(data)), enc());
+    private Optional<ParseState> checkFullParse(Token token, byte[] data) throws IOException {
+        final Optional<ParseState> result = token.parse(new ParseState(new InMemoryByteStream(data)), enc());
         assertTrue(result.isPresent());
         assertEquals(data.length, result.get().offset.intValueExact());
         return result;
@@ -130,7 +129,7 @@ public class TieTest {
             seq(def("size", con(4)),
                 def("data", last(ref("size"))),
                 tie(l2Token, inflate(last(ref("data")))));
-        final Optional<Environment> result = checkFullParse(l1Token, l1Data);
+        final Optional<ParseState> result = checkFullParse(l1Token, l1Data);
         assertEquals(80, result.get().order.head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asGraph().head.asValue().asNumeric().intValueExact());
     }
 
@@ -174,7 +173,7 @@ public class TieTest {
             seq(def("d", con(3)),
                 tie(SIMPLE_SEQ, ref("d")),
                 sub(SIMPLE_SEQ, con(0)));
-        final Optional<Environment> result = nestedSeq.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = nestedSeq.parse(stream(1, 2, 3), enc());
         assertTrue(result.isPresent());
         assertEquals(0, getReferences(result.get().order).size);
     }
@@ -185,7 +184,7 @@ public class TieTest {
             seq(def("d", con(3)),
                 def("d", con(3)),
                 tie(SIMPLE_SEQ, ref("d")));
-        final Optional<Environment> result = multiTie.parse(stream(1, 2, 3, 1, 2, 3), enc());
+        final Optional<ParseState> result = multiTie.parse(stream(1, 2, 3, 1, 2, 3), enc());
         assertTrue(result.isPresent());
         assertEquals(0, getReferences(result.get().order).size);
         final String[] names = { "a", "b", "c", "d" };
@@ -202,7 +201,7 @@ public class TieTest {
             seq(def("d", con(3)),
                 tie(SIMPLE_SEQ, refD),
                 tie(SIMPLE_SEQ, refD));
-        final Optional<Environment> result = duplicateTie.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = duplicateTie.parse(stream(1, 2, 3), enc());
         assertTrue(result.isPresent());
         assertEquals(0, getReferences(result.get().order).size);
         assertEquals(1, getAllValues(result.get().order, "d").size);

--- a/core/src/test/java/io/parsingdata/metal/token/TieTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TieTest.java
@@ -43,6 +43,7 @@ import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.data.selection.ByType.getReferences;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -82,7 +83,7 @@ public class TieTest {
     }
 
     private Optional<ParseState> parseContainer() throws IOException {
-        final Optional<ParseState> result = CONTAINER.parse(stream(2, 3, 7, 5, 9, 3, 4, 1, 2, 5, 6), enc());
+        final Optional<ParseState> result = CONTAINER.parse(env(stream(2, 3, 7, 5, 9, 3, 4, 1, 2, 5, 6)));
         assertTrue(result.isPresent());
         return result;
     }
@@ -94,7 +95,7 @@ public class TieTest {
     }
 
     private Optional<ParseState> checkFullParse(Token token, byte[] data) throws IOException {
-        final Optional<ParseState> result = token.parse(createFromByteStream(new InMemoryByteStream(data)), enc());
+        final Optional<ParseState> result = token.parse(env(createFromByteStream(new InMemoryByteStream(data)), enc()));
         assertTrue(result.isPresent());
         assertEquals(data.length, result.get().offset.intValueExact());
         return result;
@@ -174,7 +175,7 @@ public class TieTest {
             seq(def("d", con(3)),
                 tie(SIMPLE_SEQ, ref("d")),
                 sub(SIMPLE_SEQ, con(0)));
-        final Optional<ParseState> result = nestedSeq.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = nestedSeq.parse(env(stream(1, 2, 3)));
         assertTrue(result.isPresent());
         assertEquals(0, getReferences(result.get().order).size);
     }
@@ -185,7 +186,7 @@ public class TieTest {
             seq(def("d", con(3)),
                 def("d", con(3)),
                 tie(SIMPLE_SEQ, ref("d")));
-        final Optional<ParseState> result = multiTie.parse(stream(1, 2, 3, 1, 2, 3), enc());
+        final Optional<ParseState> result = multiTie.parse(env(stream(1, 2, 3, 1, 2, 3)));
         assertTrue(result.isPresent());
         assertEquals(0, getReferences(result.get().order).size);
         final String[] names = { "a", "b", "c", "d" };
@@ -202,7 +203,7 @@ public class TieTest {
             seq(def("d", con(3)),
                 tie(SIMPLE_SEQ, refD),
                 tie(SIMPLE_SEQ, refD));
-        final Optional<ParseState> result = duplicateTie.parse(stream(1, 2, 3), enc());
+        final Optional<ParseState> result = duplicateTie.parse(env(stream(1, 2, 3)));
         assertTrue(result.isPresent());
         assertEquals(0, getReferences(result.get().order).size);
         assertEquals(1, getAllValues(result.get().order, "d").size);
@@ -216,19 +217,19 @@ public class TieTest {
     @Test
     public void tieWithEmptyListFromDataExpression() throws IOException {
         final Token token = seq(any("a"), tie(any("b"), last(ref("c"))));
-        assertFalse(token.parse(stream(0), enc()).isPresent());
+        assertFalse(token.parse(env(stream(0))).isPresent());
     }
 
     @Test
     public void tieFail() throws IOException {
         final Token token = seq(def("a", con(1), eq(con(0))), tie(def("b", con(1), eq(con(1))), last(ref("a"))));
-        assertFalse(token.parse(stream(0), enc()).isPresent());
+        assertFalse(token.parse(env(stream(0))).isPresent());
     }
 
     @Test
     public void tieWithEmptyValueFromDataExpression() throws IOException {
         final Token token = seq(any("a"), tie(any("b"), div(con(1), con(0))));
-        assertFalse(token.parse(stream(0), enc()).isPresent());
+        assertFalse(token.parse(env(stream(0))).isPresent());
     }
 
     @Test
@@ -237,8 +238,8 @@ public class TieTest {
             seq(def("a", con(1), eq(con(1))),
                 def("b", con(1), eq(con(2))),
                 def("c", con(1), eq(con(3))));
-        assertTrue(tie(strictSeq, con(1, 2, 3)).parse(stream(), enc()).isPresent());
-        assertFalse(tie(strictSeq, con(1, 2, 4)).parse(stream(), enc()).isPresent());
+        assertTrue(tie(strictSeq, con(1, 2, 3)).parse(env(stream())).isPresent());
+        assertFalse(tie(strictSeq, con(1, 2, 4)).parse(env(stream())).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/TokenRefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenRefTest.java
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.io.IOException;

--- a/core/src/test/java/io/parsingdata/metal/token/TokenRefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenRefTest.java
@@ -27,6 +27,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.token;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
@@ -38,25 +39,25 @@ public class TokenRefTest {
 
     @Test
     public void nonExistingRefToken() throws IOException {
-        assertFalse(token("a").parse(stream(0), enc()).isPresent());
-        assertFalse(seq("a", any("b"), token("c")).parse(stream(0), enc()).isPresent());
-        assertFalse(sub(token("a"), con(0)).parse(stream(0), enc()).isPresent());
+        assertFalse(token("a").parse(env(stream(0))).isPresent());
+        assertFalse(seq("a", any("b"), token("c")).parse(env(stream(0))).isPresent());
+        assertFalse(sub(token("a"), con(0)).parse(env(stream(0))).isPresent());
     }
 
     @Test
     public void findRightDefinition() throws IOException {
         // Clearly reference the second:
-        assertTrue(createNamedTokens("out", "in", "in").parse(stream(21, 42), enc()).isPresent());
-        assertTrue(createNamedTokens("out", "in", "in").parse(stream(21, 21, 42), enc()).isPresent());
-        assertTrue(createNamedTokens("out", "in", "in").parse(stream(21, 21, 21, 42), enc()).isPresent());
+        assertTrue(createNamedTokens("out", "in", "in").parse(env(stream(21, 42))).isPresent());
+        assertTrue(createNamedTokens("out", "in", "in").parse(env(stream(21, 21, 42))).isPresent());
+        assertTrue(createNamedTokens("out", "in", "in").parse(env(stream(21, 21, 21, 42))).isPresent());
         // Clearly reference the first:
-        assertTrue(createNamedTokens("in", "out", "in").parse(stream(21, 42), enc()).isPresent());
-        assertTrue(createNamedTokens("in", "out", "in").parse(stream(21, 42, 21, 42), enc()).isPresent());
+        assertTrue(createNamedTokens("in", "out", "in").parse(env(stream(21, 42))).isPresent());
+        assertTrue(createNamedTokens("in", "out", "in").parse(env(stream(21, 42, 21, 42))).isPresent());
         // Reference the first:
-        assertTrue(createNamedTokens("in", "in", "in").parse(stream(21, 42), enc()).isPresent());
-        assertTrue(createNamedTokens("in", "in", "in").parse(stream(21, 42, 21, 42), enc()).isPresent());
+        assertTrue(createNamedTokens("in", "in", "in").parse(env(stream(21, 42))).isPresent());
+        assertTrue(createNamedTokens("in", "in", "in").parse(env(stream(21, 42, 21, 42))).isPresent());
         // So that this will fail:
-        assertFalse(createNamedTokens("in", "in", "in").parse(stream(21, 21, 42), enc()).isPresent());
+        assertFalse(createNamedTokens("in", "in", "in").parse(env(stream(21, 21, 42))).isPresent());
     }
 
     private Token createNamedTokens(String firstSeq, String secondSeq, String refName) {

--- a/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
 public class TokenTest {
@@ -34,7 +35,7 @@ public class TokenTest {
     public ExpectedException thrown = ExpectedException.none();
     private final Token token = new Token("", null) {
         @Override
-        protected Optional<Environment> parseImpl(String scope, Environment environment, Encoding encoding) {
+        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
             return null;
         }
     };

--- a/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.token;
 
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.callback.Callbacks;
 import io.parsingdata.metal.encoding.Encoding;
 
@@ -35,15 +35,15 @@ public class TokenTest {
     public ExpectedException thrown = ExpectedException.none();
     private final Token token = new Token("", null) {
         @Override
-        protected Optional<Environment> parseImpl(final String scope, final Environment environment, final Callbacks callbacks, final Encoding encoding) {
+        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
             return null;
         }
     };
 
     @Test
-    public void parseNullEnvironment() throws IOException {
+    public void parseNullParseState() throws IOException {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument environment may not be null.");
+        thrown.expectMessage("Argument parseState may not be null.");
         token.parse("", null, new Encoding());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -25,9 +27,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.callback.Callbacks;
-import io.parsingdata.metal.encoding.Encoding;
 
 public class TokenTest {
 
@@ -35,7 +36,7 @@ public class TokenTest {
     public ExpectedException thrown = ExpectedException.none();
     private final Token token = new Token("", null) {
         @Override
-        protected Optional<ParseState> parseImpl(final String scope, final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        protected Optional<ParseState> parseImpl(final Environment environment) {
             return null;
         }
     };
@@ -44,14 +45,14 @@ public class TokenTest {
     public void parseNullParseState() throws IOException {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument parseState may not be null.");
-        token.parse("", null, new Encoding());
+        token.parse(env(null, enc()));
     }
 
     @Test
     public void parseNullScope() throws IOException {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument scope may not be null.");
-        token.parse(null, stream(), new Encoding());
+        token.parse(env(null, stream(), enc()));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -35,14 +35,14 @@ import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -56,9 +56,9 @@ public class UntilTest {
 
     @Test
     public void threeNewLines() throws IOException {
-        final Optional<Environment> environment = createToken(con(0), post(def("newline", con(1)), eq(con('\n')))).parse(stream(INPUT, US_ASCII), enc());
-        assertTrue(environment.isPresent());
-        ImmutableList<ParseValue> values = getAllValues(environment.get().order, "line");
+        final Optional<ParseState> parseState = createToken(con(0), post(def("newline", con(1)), eq(con('\n')))).parse(stream(INPUT, US_ASCII), enc());
+        assertTrue(parseState.isPresent());
+        ImmutableList<ParseValue> values = getAllValues(parseState.get().order, "line");
         assertEquals(3, values.size);
         assertEquals(values.head.asString(), INPUT_3);
         assertEquals(values.tail.head.asString(), INPUT_2);
@@ -67,9 +67,9 @@ public class UntilTest {
 
     @Test
     public void untilInclusive() throws IOException {
-        final Optional<Environment> environment = createToken(con(1), post(EMPTY, eq(mod(last(ref("line")), con(256)), con('\n')))).parse(stream(INPUT, US_ASCII), enc());
-        assertTrue(environment.isPresent());
-        ImmutableList<ParseValue> values = getAllValues(environment.get().order, "line");
+        final Optional<ParseState> parseState = createToken(con(1), post(EMPTY, eq(mod(last(ref("line")), con(256)), con('\n')))).parse(stream(INPUT, US_ASCII), enc());
+        assertTrue(parseState.isPresent());
+        ImmutableList<ParseValue> values = getAllValues(parseState.get().order, "line");
         assertEquals(3, values.size);
         assertEquals(values.head.asString(), INPUT_3 + '\n');
         assertEquals(values.tail.head.asString(), INPUT_2 + '\n');

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -35,6 +35,7 @@ import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -56,7 +57,7 @@ public class UntilTest {
 
     @Test
     public void threeNewLines() throws IOException {
-        final Optional<ParseState> parseState = createToken(con(0), post(def("newline", con(1)), eq(con('\n')))).parse(stream(INPUT, US_ASCII), enc());
+        final Optional<ParseState> parseState = createToken(con(0), post(def("newline", con(1)), eq(con('\n')))).parse(env(stream(INPUT, US_ASCII)));
         assertTrue(parseState.isPresent());
         ImmutableList<ParseValue> values = getAllValues(parseState.get().order, "line");
         assertEquals(3, values.size);
@@ -67,7 +68,7 @@ public class UntilTest {
 
     @Test
     public void untilInclusive() throws IOException {
-        final Optional<ParseState> parseState = createToken(con(1), post(EMPTY, eq(mod(last(ref("line")), con(256)), con('\n')))).parse(stream(INPUT, US_ASCII), enc());
+        final Optional<ParseState> parseState = createToken(con(1), post(EMPTY, eq(mod(last(ref("line")), con(256)), con('\n')))).parse(env(stream(INPUT, US_ASCII)));
         assertTrue(parseState.isPresent());
         ImmutableList<ParseValue> values = getAllValues(parseState.get().order, "line");
         assertEquals(3, values.size);
@@ -78,12 +79,12 @@ public class UntilTest {
 
     @Test
     public void allDefaultValueExpressions() throws IOException {
-        assertTrue(until("value", def("terminator", 1, eq(con(0)))).parse(stream(1, 2, 3, 0), enc()).isPresent());
+        assertTrue(until("value", def("terminator", 1, eq(con(0)))).parse(env(stream(1, 2, 3, 0))).isPresent());
     }
 
     @Test
     public void errorNegativeSize() {
-        assertFalse(until("value", con(-1, signed()), def("terminator", 1, eq(con(0)))).parse(stream(1, 2, 3, 0), enc()).isPresent());
+        assertFalse(until("value", con(-1, signed()), def("terminator", 1, eq(con(0)))).parse(env(stream(1, 2, 3, 0))).isPresent());
     }
 
     private Token createToken(final ValueExpression initialSize, final Token terminator) {

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -29,7 +29,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static junit.framework.TestCase.assertFalse;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 
 public class WhileTest {
 
@@ -51,14 +51,14 @@ public class WhileTest {
     public void parseAll() throws IOException {
         // two sequences of two bytes would be parsed: [0,9] and [1,10]
         // the while stops because the second 'value' is >= 1
-        final Optional<Environment> result = WHILE.parse(stream(0, 9, 1, 10, 2, 11), enc());
+        final Optional<ParseState> result = WHILE.parse(stream(0, 9, 1, 10, 2, 11), enc());
 
         assertThat(result.get().offset.longValueExact(), is(4L));
     }
 
     @Test
     public void parseFails() throws IOException {
-        final Optional<Environment> result = WHILE.parse(stream(0, 9, 0, 8), enc());
+        final Optional<ParseState> result = WHILE.parse(stream(0, 9, 0, 8), enc());
 
         // parsing fails because the nested token couldn't be parsed ('value2' <= 9)
         assertFalse(result.isPresent());
@@ -68,7 +68,7 @@ public class WhileTest {
     public void whileWithoutExpression() throws IOException {
         // passing null as predicate make this a while(true):
         final Token trueWhile = whl(def("value", 1), null, enc());
-        final Optional<Environment> result = trueWhile.parse(stream(0), enc());
+        final Optional<ParseState> result = trueWhile.parse(stream(0), enc());
 
         // parsing fails because the nested def fails at the end of the stream
         assertFalse(result.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -29,6 +29,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static junit.framework.TestCase.assertFalse;
 
@@ -51,14 +52,14 @@ public class WhileTest {
     public void parseAll() throws IOException {
         // two sequences of two bytes would be parsed: [0,9] and [1,10]
         // the while stops because the second 'value' is >= 1
-        final Optional<ParseState> result = WHILE.parse(stream(0, 9, 1, 10, 2, 11), enc());
+        final Optional<ParseState> result = WHILE.parse(env(stream(0, 9, 1, 10, 2, 11)));
 
         assertThat(result.get().offset.longValueExact(), is(4L));
     }
 
     @Test
     public void parseFails() throws IOException {
-        final Optional<ParseState> result = WHILE.parse(stream(0, 9, 0, 8), enc());
+        final Optional<ParseState> result = WHILE.parse(env(stream(0, 9, 0, 8)));
 
         // parsing fails because the nested token couldn't be parsed ('value2' <= 9)
         assertFalse(result.isPresent());
@@ -68,7 +69,7 @@ public class WhileTest {
     public void whileWithoutExpression() throws IOException {
         // passing null as predicate make this a while(true):
         final Token trueWhile = whl(def("value", 1), null, enc());
-        final Optional<ParseState> result = trueWhile.parse(stream(0), enc());
+        final Optional<ParseState> result = trueWhile.parse(env(stream(0)));
 
         // parsing fails because the nested def fails at the end of the stream
         assertFalse(result.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/util/EnvironmentFactory.java
+++ b/core/src/test/java/io/parsingdata/metal/util/EnvironmentFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.util;
+
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.callback.Callbacks;
+import io.parsingdata.metal.encoding.Encoding;
+
+public class EnvironmentFactory {
+
+    public static Environment env(final String scope, final ParseState parseState, final Encoding encoding) {
+        return new Environment(scope, parseState, encoding);
+    }
+
+    public static Environment env(final ParseState parseState, final Callbacks callbacks, final Encoding encoding) {
+        return new Environment(parseState, callbacks, encoding);
+    }
+
+    public static Environment env(final ParseState parseState, final Encoding encoding) {
+        return new Environment(parseState, encoding);
+    }
+
+    public static Environment env(final ParseState parseState) {
+        return new Environment(parseState, enc());
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -58,7 +58,7 @@ public class InMemoryByteStream implements ByteStream {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), Arrays.hashCode(data));
+        return Objects.hash(getClass(), Arrays.hashCode(data));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.token.Token;
 
@@ -36,13 +36,13 @@ public class ParameterizedParse {
 
     @Parameter(0) public String description;
     @Parameter(1) public Token token;
-    @Parameter(2) public Environment environment;
+    @Parameter(2) public ParseState parseState;
     @Parameter(3) public Encoding encoding;
     @Parameter(4) public boolean result;
 
     @Test
     public void test() throws IOException {
-        assertEquals(result, token.parse(environment, encoding).isPresent());
+        assertEquals(result, token.parse(parseState, encoding).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
@@ -18,6 +18,8 @@ package io.parsingdata.metal.util;
 
 import static org.junit.Assert.assertEquals;
 
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
+
 import java.io.IOException;
 
 import org.junit.Ignore;
@@ -42,7 +44,7 @@ public class ParameterizedParse {
 
     @Test
     public void test() throws IOException {
-        assertEquals(result, token.parse(parseState, encoding).isPresent());
+        assertEquals(result, token.parse(env(parseState, encoding)).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/ParseStateFactory.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParseStateFactory.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal.util;
 
 import static io.parsingdata.metal.Shorthand.toByteArray;
+import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 
 import java.io.IOException;
 import java.net.URI;
@@ -29,15 +30,15 @@ import io.parsingdata.metal.data.ParseState;
 public class ParseStateFactory {
 
     public static ParseState stream(final int... bytes) {
-        return new ParseState(new InMemoryByteStream(toByteArray(bytes)));
+        return createFromByteStream(new InMemoryByteStream(toByteArray(bytes)));
     }
 
     public static ParseState stream(final URI resource) throws IOException {
-        return new ParseState(new InMemoryByteStream(Files.readAllBytes(Paths.get(resource))));
+        return createFromByteStream(new InMemoryByteStream(Files.readAllBytes(Paths.get(resource))));
     }
 
     public static ParseState stream(final String value, final Charset charset) {
-        return new ParseState(new InMemoryByteStream(value.getBytes(charset)));
+        return createFromByteStream(new InMemoryByteStream(value.getBytes(charset)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/ParseStateFactory.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParseStateFactory.java
@@ -24,20 +24,20 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 
-public class EnvironmentFactory {
+public class ParseStateFactory {
 
-    public static Environment stream(final int... bytes) {
-        return new Environment(new InMemoryByteStream(toByteArray(bytes)));
+    public static ParseState stream(final int... bytes) {
+        return new ParseState(new InMemoryByteStream(toByteArray(bytes)));
     }
 
-    public static Environment stream(final URI resource) throws IOException {
-        return new Environment(new InMemoryByteStream(Files.readAllBytes(Paths.get(resource))));
+    public static ParseState stream(final URI resource) throws IOException {
+        return new ParseState(new InMemoryByteStream(Files.readAllBytes(Paths.get(resource))));
     }
 
-    public static Environment stream(final String value, final Charset charset) {
-        return new Environment(new InMemoryByteStream(value.getBytes(charset)));
+    public static ParseState stream(final String value, final Charset charset) {
+        return new ParseState(new InMemoryByteStream(value.getBytes(charset)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
@@ -78,7 +78,7 @@ public class ReadTrackingByteStream implements ByteStream {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass().hashCode(), Objects.hashCode(byteStream));
+        return Objects.hash(getClass(), Objects.hashCode(byteStream));
     }
 
 }

--- a/formats/src/main/java/io/parsingdata/metal/expression/value/GUID.java
+++ b/formats/src/main/java/io/parsingdata/metal/expression/value/GUID.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
@@ -55,7 +56,7 @@ public final class GUID {
         return new ValueExpression() {
 
             @Override
-            public ImmutableList<Optional<Value>> eval(final ParseGraph graph, final Encoding encoding) {
+            public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
                 // Note that GUID bytes differ from UUID bytes, as the first 3 parts can be reversed
                 return cat(
                     cat(
@@ -65,7 +66,7 @@ public final class GUID {
                         two(parts[2], encoding)),
                     cat(
                         two(parts[3], BIG_ENDIAN),
-                        six(parts[4], BIG_ENDIAN))).eval(graph, encoding);
+                        six(parts[4], BIG_ENDIAN))).eval(parseState, encoding);
             }
         };
     }

--- a/formats/src/main/java/io/parsingdata/metal/format/Callback.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/Callback.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.zip.CRC32;
 
 import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
@@ -34,7 +35,7 @@ public final class Callback {
     public static ValueExpression crc32(final ValueExpression target) {
         return new UnaryValueExpression(target) {
             @Override
-            public Optional<Value> eval(final Value value, final ParseGraph graph, final Encoding encoding) {
+            public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
                 final CRC32 crc = new CRC32();
                 crc.update(value.getValue());
                 final long crcValue = crc.getValue();

--- a/formats/src/test/java/io/parsingdata/metal/expression/value/GUIDTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/expression/value/GUIDTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.expression.value.GUID.guid;
 import static io.parsingdata.metal.util.ClassDefinition.checkUtilityClass;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/formats/src/test/java/io/parsingdata/metal/expression/value/GUIDTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/expression/value/GUIDTest.java
@@ -24,6 +24,7 @@ import static io.parsingdata.metal.expression.value.GUID.guid;
 import static io.parsingdata.metal.util.ClassDefinition.checkUtilityClass;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.le;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
@@ -48,8 +49,8 @@ public class GUIDTest {
     @Test
     public void parseGUID() throws IOException, URISyntaxException {
         final Token guid = def("guid", 16, eq(guid("00c27766-f623-4200-9d64-115e9bfd4a08")));
-        assertTrue("be", guid.parse(stream(0x00, 0xc2, 0x77, 0x66, 0xf6, 0x23, 0x42, 0x00, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08), enc()).isPresent());
-        assertTrue("le", guid.parse(stream(0x66, 0x77, 0xc2, 0x00, 0x23, 0xf6, 0x00, 0x42, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08), le()).isPresent());
+        assertTrue("be", guid.parse(env(stream(0x00, 0xc2, 0x77, 0x66, 0xf6, 0x23, 0x42, 0x00, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08))).isPresent());
+        assertTrue("le", guid.parse(env(stream(0x66, 0x77, 0xc2, 0x00, 0x23, 0xf6, 0x00, 0x42, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08), le())).isPresent());
 
         _exception.expect(IllegalArgumentException.class);
         _exception.expectMessage("Invalid GUID string: test");

--- a/formats/src/test/java/io/parsingdata/metal/expression/value/UUIDTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/expression/value/UUIDTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.expression.value.UUID.uuid;
 import static io.parsingdata.metal.util.ClassDefinition.checkUtilityClass;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import org.junit.Test;
 

--- a/formats/src/test/java/io/parsingdata/metal/expression/value/UUIDTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/expression/value/UUIDTest.java
@@ -23,7 +23,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.expression.value.UUID.uuid;
 import static io.parsingdata.metal.util.ClassDefinition.checkUtilityClass;
-import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import org.junit.Test;
@@ -40,7 +40,7 @@ public class UUIDTest {
     @Test
     public void parseUUID() throws Exception {
         final Token uuid = def("uuid", 16, eq(uuid("00c27766-f623-4200-9d64-115e9bfd4a08")));
-        assertTrue(uuid.parse(stream(0x00, 0xc2, 0x77, 0x66, 0xf6, 0x23, 0x42, 0x00, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08), enc()).isPresent());
-        assertFalse(uuid.parse(stream(0x66, 0x77, 0xc2, 0x00, 0x23, 0xf6, 0x00, 0x42, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08), enc()).isPresent());
+        assertTrue(uuid.parse(env(stream(0x00, 0xc2, 0x77, 0x66, 0xf6, 0x23, 0x42, 0x00, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08))).isPresent());
+        assertFalse(uuid.parse(env(stream(0x66, 0x77, 0xc2, 0x00, 0x23, 0xf6, 0x00, 0x42, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08))).isPresent());
     }
 }

--- a/formats/src/test/java/io/parsingdata/metal/format/CallbackTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/CallbackTest.java
@@ -37,7 +37,7 @@ public class CallbackTest {
 
     @Test
     public void crc32Good() {
-        final ImmutableList<Optional<Value>> result = crc32(con(0x01020304)).eval(stream().order, enc());
+        final ImmutableList<Optional<Value>> result = crc32(con(0x01020304)).eval(stream(), enc());
         assertEquals(1, result.size);
         assertTrue(result.head.isPresent());
         assertArrayEquals(new byte[] { -74, 60, -5, -51 }, result.head.get().getValue());
@@ -45,7 +45,7 @@ public class CallbackTest {
 
     @Test
     public void inflateGood() {
-        final ImmutableList<Optional<Value>> result = inflate(con(0xcb, 0x4d, 0x2d, 0x49, 0xcc, 0x01, 0x00)).eval(stream().order, enc());
+        final ImmutableList<Optional<Value>> result = inflate(con(0xcb, 0x4d, 0x2d, 0x49, 0xcc, 0x01, 0x00)).eval(stream(), enc());
         assertEquals(1, result.size);
         assertTrue(result.head.isPresent());
         assertEquals("metal", result.head.get().asString());

--- a/formats/src/test/java/io/parsingdata/metal/format/CallbackTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/CallbackTest.java
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Util.inflate;
 import static io.parsingdata.metal.format.Callback.crc32;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 

--- a/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
@@ -17,7 +17,7 @@
 package io.parsingdata.metal.format;
 
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -26,7 +26,7 @@ import java.util.Collection;
 
 import org.junit.runners.Parameterized;
 
-import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.util.ParameterizedParse;
 
 public class FormatTest extends ParameterizedParse {
@@ -34,14 +34,14 @@ public class FormatTest extends ParameterizedParse {
     @Parameterized.Parameters(name="{0} ({4})")
     public static Collection<Object[]> data() throws URISyntaxException, IOException {
         return Arrays.asList(new Object[][] {
-            { "PNG", PNG.FORMAT, env("/test.png"), enc(), true },
-            { "ZIP", ZIP.FORMAT, env("/singlefile-zip30-ubuntu.zip"), enc(), true },
-            { "ZIP2", ZIP.FORMAT, env("/multifile-zip30-ubuntu.zip"), enc(), true },
-            { "JPEG", JPEG.FORMAT, env("/test.jpg"), enc(), true },
+            { "PNG", PNG.FORMAT, parseState("/test.png"), enc(), true },
+            { "ZIP", ZIP.FORMAT, parseState("/singlefile-zip30-ubuntu.zip"), enc(), true },
+            { "ZIP2", ZIP.FORMAT, parseState("/multifile-zip30-ubuntu.zip"), enc(), true },
+            { "JPEG", JPEG.FORMAT, parseState("/test.jpg"), enc(), true },
         });
     }
 
-    private static Environment env(final String path) throws URISyntaxException, IOException {
+    private static ParseState parseState(final String path) throws URISyntaxException, IOException {
         return stream(FormatTest.class.getResource(path).toURI());
     }
 

--- a/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
@@ -29,7 +29,7 @@ import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.format.VarInt.decodeVarInt;
 import static io.parsingdata.metal.format.VarInt.varInt;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static io.parsingdata.metal.util.EnvironmentFactory.stream;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Arrays;
 import java.util.Collection;


### PR DESCRIPTION
Resolves #216.

This PR tackles some abstraction issues. The resolution resolves a functional bug. The six commits show the following six changes:

1. `Callbacks` was extracted from the `Environment` class.
2. The `Environment` class was renamed to `ParseState`.
3. Of the three remaining constructors on `ParseState`, two are renamed to factory methods to better reflect their functionality.
4. Both `equals()` and `hashCode()` methods were implemented on `ParseState`.
5. The `eval()` methods of `ValueExpression` and `Expression` were modified to accept a `ParseState` instead of a `ParseGraph`.
6. The `Shorthand` approximate implementation of `CURRENT_OFFSET` is replaced with an implementation that returns the actual `offset` field of the `ParseState`.

After that, another branch was merged that recreates an `Environment` class: #222.