### PR TITLE
Implement lazy versions of Cat and Bytes

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -36,7 +36,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(checkNotNegative(offset, "offset"), checkNotNegative(length, "length"))) {
+        if (!isAvailable(offset, length)) {
             throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
         }
         try {

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -36,7 +36,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(checkNotNegative(offset, "offset"), length)) {
+        if (!isAvailable(checkNotNegative(offset, "offset"), checkNotNegative(length, "length"))) {
             throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
         }
         try {
@@ -48,7 +48,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
-        return input.isAvailable(offset, length.intValueExact());
+        return input.isAvailable(checkNotNegative(offset, "offset"), checkNotNegative(length, "length").intValueExact());
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
@@ -27,8 +27,8 @@ import io.parsingdata.metal.expression.value.Value;
 
 public class ConcatenatedValueSource extends Source {
 
-    private final Value left;
-    private final Value right;
+    public final Value left;
+    public final Value right;
 
     public ConcatenatedValueSource(final Value left, final Value right) {
         this.left = checkNotNull(left, "left");
@@ -60,7 +60,7 @@ public class ConcatenatedValueSource extends Source {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + left.toString() + "," + right.toString() + "))";
+        return getClass().getSimpleName() + "(" + left + "," + right + "))";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.data;
+
+import static io.parsingdata.metal.Util.checkNotNegative;
+import static io.parsingdata.metal.Util.checkNotNull;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+import io.parsingdata.metal.Util;
+import io.parsingdata.metal.expression.value.Value;
+
+public class ConcatenatedValueSource extends Source {
+
+    private final Value left;
+    private final Value right;
+
+    public ConcatenatedValueSource(final Value left, final Value right) {
+        this.left = checkNotNull(left, "left");
+        this.right = checkNotNull(right, "right");
+    }
+
+    @Override
+    protected byte[] getData(final BigInteger offset, final BigInteger length) {
+        if (!isAvailable(offset, length)) {
+            throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
+        }
+        final byte[] outputData = new byte[length.intValueExact()];
+        if (offset.add(length).compareTo(left.getLength()) <= 0) {
+            System.arraycopy(left.getValue(), offset.intValueExact(), outputData, 0, length.intValueExact());
+        } else if (offset.compareTo(left.getLength()) >= 0) {
+            System.arraycopy(right.getValue(), offset.subtract(left.getLength()).intValueExact(), outputData, 0, length.intValueExact());
+        } else {
+            final BigInteger leftPartLength = left.getLength().subtract(offset);
+            System.arraycopy(left.getValue(), offset.intValueExact(), outputData, 0, leftPartLength.intValueExact());
+            System.arraycopy(right.getValue(), 0, outputData, leftPartLength.intValueExact(), length.subtract(leftPartLength).intValueExact());
+        }
+        return outputData;
+    }
+
+    @Override
+    protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
+        return checkNotNegative(length, "length").add(checkNotNegative(offset, "offset")).compareTo(left.getLength().add(right.getLength())) <= 0;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + left.toString() + "," + right.toString() + "))";
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return Util.notNullAndSameClass(this, obj)
+            && Objects.equals(left, ((ConcatenatedValueSource)obj).left)
+            && Objects.equals(right, ((ConcatenatedValueSource)obj).right);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass(), left, right);
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -36,7 +36,7 @@ public class ConstantSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(checkNotNegative(offset, "offset"), checkNotNegative(length, "length"))) {
+        if (!isAvailable(offset, length)) {
             throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
         }
         final byte[] outputData = new byte[length.intValueExact()];

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -36,7 +36,7 @@ public class ConstantSource extends Source {
 
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
-        if (!isAvailable(checkNotNegative(offset, "offset"), length)) {
+        if (!isAvailable(checkNotNegative(offset, "offset"), checkNotNegative(length, "length"))) {
             throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
         }
         final byte[] outputData = new byte[length.intValueExact()];
@@ -46,7 +46,7 @@ public class ConstantSource extends Source {
 
     @Override
     protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
-        return length.add(offset).compareTo(BigInteger.valueOf(data.length)) <= 0;
+        return checkNotNegative(length, "length").add((checkNotNegative(offset, "offset"))).compareTo(BigInteger.valueOf(data.length)) <= 0;
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -49,7 +49,7 @@ public class DataExpressionSource extends Source {
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
         checkNotNegative(offset, "offset");
         final Value inputValue = getValue();
-        if (length.add(offset).compareTo(inputValue.slice.length) > 0) {
+        if (checkNotNegative(length, "length").add(offset).compareTo(inputValue.slice.length) > 0) {
             throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
         }
         final byte[] outputData = new byte[length.intValueExact()];
@@ -59,7 +59,7 @@ public class DataExpressionSource extends Source {
 
     @Override
     protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
-        return offset.add(length).compareTo(getValue().slice.length) <= 0;
+        return checkNotNegative(offset, "offset").add(checkNotNegative(length, "length")).compareTo(getValue().slice.length) <= 0;
     }
 
     private Value getValue() {

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal.data;
 
 import static java.math.BigInteger.ZERO;
 
+import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.math.BigInteger;
@@ -39,7 +40,7 @@ public class Slice {
     }
 
     public static Optional<Slice> createFromSource(final Source source, final BigInteger offset, final BigInteger length) {
-        if (offset.compareTo(ZERO) < 0 ||
+        if (checkNotNull(offset, "offset").compareTo(ZERO) < 0 ||
             checkNotNull(length, "length").compareTo(ZERO) < 0 ||
             !checkNotNull(source, "source").isAvailable(offset, length)) {
             return Optional.empty();
@@ -56,10 +57,7 @@ public class Slice {
     }
 
     public byte[] getData(final BigInteger limit) {
-        if (limit.compareTo(ZERO) < 0) {
-            throw new IllegalArgumentException("Argument limit may not be negative.");
-        }
-        final BigInteger calculatedLength = limit.compareTo(length) > 0 ? length : limit;
+        final BigInteger calculatedLength = checkNotNegative(limit, "limit").compareTo(length) > 0 ? length : limit;
         return source.getData(offset, calculatedLength);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -16,11 +16,14 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static java.math.BigInteger.ONE;
+
 import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.Slice.createFromBytes;
+import static io.parsingdata.metal.data.Slice.createFromSource;
 
+import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -63,16 +66,16 @@ public class Bytes implements ValueExpression {
 
     private Trampoline<ImmutableList<Optional<Value>>> toBytes(final ImmutableList<Optional<Value>> output, final Optional<Value> head, final ImmutableList<Optional<Value>> tail, final Encoding encoding) {
         final ImmutableList<Optional<Value>> result = output.add(
-            head.map(value -> bytesToValues(new ImmutableList<>(), value.getValue(), 0, encoding).computeResult())
+            head.map(value -> bytesToValues(new ImmutableList<>(), value, 0, encoding).computeResult())
                 .orElseGet(ImmutableList::new));
         return tail.isEmpty() ? complete(() -> result) : intermediate(() -> toBytes(result, tail.head, tail.tail, encoding));
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> bytesToValues(final ImmutableList<Optional<Value>> output, final byte[] value, final int i, final Encoding encoding) {
-        if (i >= value.length) {
+    private Trampoline<ImmutableList<Optional<Value>>> bytesToValues(final ImmutableList<Optional<Value>> output, final Value value, final int i, final Encoding encoding) {
+        if (BigInteger.valueOf(i).compareTo(value.getLength()) >= 0) {
             return complete(() -> output);
         }
-        return intermediate(() -> bytesToValues(output.add(Optional.of(new Value(createFromBytes(new byte[] { value[i] }), encoding))), value, i + 1, encoding));
+        return intermediate(() -> bytesToValues(output.add(Optional.of(new Value(createFromSource(value.slice.source, value.slice.offset.add(BigInteger.valueOf(i)), ONE).get(), encoding))), value, i + 1, encoding));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -61,21 +61,21 @@ public class Bytes implements ValueExpression {
         if (input.isEmpty()) {
             return input;
         }
-        return toBytes(new ImmutableList<>(), input.head, input.tail, encoding).computeResult();
+        return toByteValues(new ImmutableList<>(), input.head, input.tail, encoding).computeResult();
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> toBytes(final ImmutableList<Optional<Value>> output, final Optional<Value> head, final ImmutableList<Optional<Value>> tail, final Encoding encoding) {
+    private Trampoline<ImmutableList<Optional<Value>>> toByteValues(final ImmutableList<Optional<Value>> output, final Optional<Value> head, final ImmutableList<Optional<Value>> tail, final Encoding encoding) {
         final ImmutableList<Optional<Value>> result = output.add(
-            head.map(value -> bytesToValues(new ImmutableList<>(), value, 0, encoding).computeResult())
+            head.map(value -> extractByteValues(new ImmutableList<>(), value, 0, encoding).computeResult())
                 .orElseGet(ImmutableList::new));
-        return tail.isEmpty() ? complete(() -> result) : intermediate(() -> toBytes(result, tail.head, tail.tail, encoding));
+        return tail.isEmpty() ? complete(() -> result) : intermediate(() -> toByteValues(result, tail.head, tail.tail, encoding));
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> bytesToValues(final ImmutableList<Optional<Value>> output, final Value value, final int i, final Encoding encoding) {
+    private Trampoline<ImmutableList<Optional<Value>>> extractByteValues(final ImmutableList<Optional<Value>> output, final Value value, final int i, final Encoding encoding) {
         if (BigInteger.valueOf(i).compareTo(value.getLength()) >= 0) {
             return complete(() -> output);
         }
-        return intermediate(() -> bytesToValues(output.add(Optional.of(new Value(createFromSource(value.slice.source, value.slice.offset.add(BigInteger.valueOf(i)), ONE).get(), encoding))), value, i + 1, encoding));
+        return intermediate(() -> extractByteValues(output.add(Optional.of(new Value(createFromSource(value.slice.source, value.slice.offset.add(BigInteger.valueOf(i)), ONE).get(), encoding))), value, i + 1, encoding));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -17,12 +17,9 @@
 package io.parsingdata.metal.expression.value;
 
 import static java.math.BigInteger.ZERO;
-import static java.util.Optional.empty;
 
-import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
-import java.math.BigInteger;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ConcatenatedValueSource;
@@ -41,7 +38,7 @@ public class Cat extends BinaryValueExpression {
     @Override
     public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
         return createFromSource(new ConcatenatedValueSource(left, right), ZERO, left.getLength().add(right.getLength()))
-            .flatMap(source -> Optional.of(new Value(source, encoding)));
+            .map(source -> new Value(source, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -16,10 +16,16 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static io.parsingdata.metal.data.Slice.createFromBytes;
+import static java.math.BigInteger.ZERO;
+import static java.util.Optional.empty;
 
+import static io.parsingdata.metal.data.Slice.createFromBytes;
+import static io.parsingdata.metal.data.Slice.createFromSource;
+
+import java.math.BigInteger;
 import java.util.Optional;
 
+import io.parsingdata.metal.data.ConcatenatedValueSource;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
@@ -34,12 +40,8 @@ public class Cat extends BinaryValueExpression {
 
     @Override
     public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        final byte[] leftBytes = left.getValue();
-        final byte[] rightBytes = right.getValue();
-        final byte[] concatenatedBytes = new byte[leftBytes.length + rightBytes.length];
-        System.arraycopy(leftBytes, 0, concatenatedBytes, 0, leftBytes.length);
-        System.arraycopy(rightBytes, 0, concatenatedBytes, leftBytes.length, rightBytes.length);
-        return Optional.of(new Value(createFromBytes(concatenatedBytes), encoding));
+        return createFromSource(new ConcatenatedValueSource(left, right), ZERO, left.getLength().add(right.getLength()))
+            .flatMap(source -> Optional.of(new Value(source, encoding)));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -57,6 +57,7 @@ import org.junit.runners.Parameterized.Parameter;
 
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.ByteStreamSource;
+import io.parsingdata.metal.data.ConcatenatedValueSource;
 import io.parsingdata.metal.data.ConstantSource;
 import io.parsingdata.metal.data.DataExpressionSource;
 import io.parsingdata.metal.data.ParseGraph;
@@ -189,7 +190,7 @@ public class AutoEqualityTest {
             // Data structures
             Value.class, ParseValue.class, ParseReference.class, ParseState.class,
             // Inputs
-            ConstantSource.class, DataExpressionSource.class, ByteStreamSource.class
+            ConstantSource.class, DataExpressionSource.class, ByteStreamSource.class, ConcatenatedValueSource.class
             );
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.parsingdata.metal.data;
 
 import static java.math.BigInteger.ZERO;

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.data.Slice.createFromSource;
 import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 
@@ -39,6 +40,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.util.InMemoryByteStream;
 
 @RunWith(Parameterized.class)
@@ -55,7 +57,8 @@ public class SourceAndSliceTest {
         return Arrays.asList(new Object[][] {
             { new ConstantSource(DATA) },
             { new DataExpressionSource(con(DATA), 0, EMPTY_PARSE_STATE, enc()) },
-            { new ByteStreamSource(new InMemoryByteStream(DATA) ) }
+            { new ByteStreamSource(new InMemoryByteStream(DATA)) },
+            { new ConcatenatedValueSource(new Value(createFromSource(new ConstantSource(DATA), ZERO, BigInteger.valueOf(2)).get(), enc()), new Value(createFromSource(new ConstantSource(DATA), BigInteger.valueOf(2), BigInteger.valueOf(2)).get(), enc())) }
         });
     }
 
@@ -73,14 +76,16 @@ public class SourceAndSliceTest {
 
     @Test
     public void validSlice() {
+        checkSlice(ZERO, 2);
         checkSlice(ZERO, 4);
         checkSlice(ONE, 3);
         checkSlice(BigInteger.valueOf(2), 1);
+        checkSlice(BigInteger.valueOf(2), 2);
         checkSlice(BigInteger.valueOf(4), 0);
     }
 
     private void checkSlice(final BigInteger offset, final int length) {
-        assertTrue(compareDataSlices(Slice.createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset.intValueExact()));
+        assertTrue(compareDataSlices(createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset.intValueExact()));
     }
 
     private boolean compareDataSlices(byte[] data, int offset) {
@@ -100,7 +105,7 @@ public class SourceAndSliceTest {
 
     @Test
     public void readBeyondEndOfSlice() {
-        assertFalse(Slice.createFromSource(source, ONE, BigInteger.valueOf(4)).isPresent());
+        assertFalse(createFromSource(source, ONE, BigInteger.valueOf(4)).isPresent());
     }
 
     @Test
@@ -111,7 +116,7 @@ public class SourceAndSliceTest {
 
     @Test
     public void startReadBeyondEndOfSlice() {
-        assertFalse(Slice.createFromSource(source, BigInteger.valueOf(5), ZERO).isPresent());
+        assertFalse(createFromSource(source, BigInteger.valueOf(5), ZERO).isPresent());
     }
 
     @Test
@@ -122,7 +127,7 @@ public class SourceAndSliceTest {
 
     @Test
     public void startReadAtNegativeOffsetSlice() {
-        assertFalse(Slice.createFromSource(source, BigInteger.valueOf(-1L), ONE).isPresent());
+        assertFalse(createFromSource(source, BigInteger.valueOf(-1L), ONE).isPresent());
     }
 
 }


### PR DESCRIPTION
Resolves #225.
Resolves #226.
Resolves #227.

`Cat` and `Bytes` are now lazy. Additionally, checks are added to the `Source` implementations to assure that provided `offset` and `length` arguments are not null and not negative.