### PR TITLE
List-based ConcatenatedValueSource and FoldCat

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -48,7 +48,7 @@ import io.parsingdata.metal.expression.value.Elvis;
 import io.parsingdata.metal.expression.value.Expand;
 import io.parsingdata.metal.expression.value.FoldLeft;
 import io.parsingdata.metal.expression.value.FoldRight;
-import io.parsingdata.metal.expression.value.CatList;
+import io.parsingdata.metal.expression.value.FoldCat;
 import io.parsingdata.metal.expression.value.Reverse;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
@@ -185,7 +185,7 @@ public final class Shorthand {
     public static ValueExpression nth(final ValueExpression values, final ValueExpression indices) { return new Nth(values, indices); }
     public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
     public static ValueExpression cat(final ValueExpression left, final ValueExpression right) { return new Cat(left, right); }
-    public static ValueExpression catList(final ValueExpression operand) { return new CatList(operand); }
+    public static ValueExpression cat(final ValueExpression operand) { return new FoldCat(operand); }
     public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
     public static ValueExpression count(final ValueExpression operand) { return new Count(operand); }
     public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -48,6 +48,7 @@ import io.parsingdata.metal.expression.value.Elvis;
 import io.parsingdata.metal.expression.value.Expand;
 import io.parsingdata.metal.expression.value.FoldLeft;
 import io.parsingdata.metal.expression.value.FoldRight;
+import io.parsingdata.metal.expression.value.CatList;
 import io.parsingdata.metal.expression.value.Reverse;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
@@ -184,6 +185,7 @@ public final class Shorthand {
     public static ValueExpression nth(final ValueExpression values, final ValueExpression indices) { return new Nth(values, indices); }
     public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
     public static ValueExpression cat(final ValueExpression left, final ValueExpression right) { return new Cat(left, right); }
+    public static ValueExpression catList(final ValueExpression operand) { return new CatList(operand); }
     public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
     public static ValueExpression count(final ValueExpression operand) { return new Count(operand); }
     public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }

--- a/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
@@ -43,7 +43,7 @@ public class ConcatenatedValueSource extends Source {
     @Override
     protected byte[] getData(final BigInteger offset, final BigInteger length) {
         if (!isAvailable(offset, length)) {
-            throw new IllegalStateException("Data to read is not available ([offset=" + offset + ";length=" + length + ";source=" + this + ").");
+            throw new IllegalStateException("Data to read is not available (offset=" + offset + ";length=" + length + ";source=" + this + ").");
         }
         return getData(values, ZERO, ZERO, offset, length, new byte[length.intValueExact()]).computeResult();
     }
@@ -53,7 +53,7 @@ public class ConcatenatedValueSource extends Source {
             return complete(() -> output);
         }
         if (values.isEmpty()) {
-            throw new IllegalStateException("Data to read is not available ([offset =" + offset + "; length=" + length + ";source=" + this + ").");
+            throw new IllegalStateException("Data to read is not available (offset=" + offset + ";length=" + length + ";source=" + this + ").");
         }
         if (currentOffset.add(values.head.slice.length).compareTo(offset) <= 0) {
             return intermediate(() -> getData(values.tail, currentOffset.add(values.head.slice.length), currentDest, offset, length, output));
@@ -71,7 +71,7 @@ public class ConcatenatedValueSource extends Source {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + values + "(" + length + ")))";
+        return getClass().getSimpleName() + "(" + values + "(" + length + "))";
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -76,7 +76,7 @@ public class DataExpressionSource extends Source {
                 .map(Value::getValue)
                 .orElseThrow(() -> new IllegalStateException("ValueExpression dataExpression yields empty Value at index " + index + "."));
         }
-        return Arrays.copyOf(cache, cache.length);
+        return cache.clone();
     }
 
     private Trampoline<Optional<Value>> getValueAtIndex(final ImmutableList<Optional<Value>> results, final int index, final int current) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -20,9 +20,11 @@ import static java.math.BigInteger.ZERO;
 
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
+import java.math.BigInteger;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ConcatenatedValueSource;
+import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
@@ -37,7 +39,8 @@ public class Cat extends BinaryValueExpression {
 
     @Override
     public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        return createFromSource(new ConcatenatedValueSource(left, right), ZERO, left.getLength().add(right.getLength()))
+        final BigInteger length = left.getLength().add(right.getLength());
+        return createFromSource(new ConcatenatedValueSource(ImmutableList.create(right).add(left), length), ZERO, length)
             .map(source -> new Value(source, encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -39,8 +39,8 @@ public class Cat extends BinaryValueExpression {
 
     @Override
     public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        final BigInteger length = left.getLength().add(right.getLength());
-        return createFromSource(new ConcatenatedValueSource(ImmutableList.create(right).add(left), length), ZERO, length)
+        return ConcatenatedValueSource.create(ImmutableList.create(Optional.of(left)).add(Optional.of(right)))
+            .flatMap(source -> createFromSource(source, ZERO, left.getLength().add(right.getLength())))
             .map(source -> new Value(source, encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/CatList.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/CatList.java
@@ -23,9 +23,11 @@ import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
 import java.math.BigInteger;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
+import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ConcatenatedValueSource;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
@@ -66,6 +68,22 @@ public class CatList implements ValueExpression {
             return complete(() -> size);
         }
         return intermediate(() -> calculateTotalSize(values.tail, size.add(values.head.slice.length)));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + operand + ")";
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return Util.notNullAndSameClass(this, obj)
+            && Objects.equals(operand, ((CatList)obj).operand);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/CatList.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/CatList.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value;
+
+import static java.math.BigInteger.ZERO;
+
+import static io.parsingdata.metal.Trampoline.complete;
+import static io.parsingdata.metal.Trampoline.intermediate;
+import static io.parsingdata.metal.data.Slice.createFromSource;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import io.parsingdata.metal.Trampoline;
+import io.parsingdata.metal.data.ConcatenatedValueSource;
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.encoding.Encoding;
+
+public class CatList implements ValueExpression {
+
+    public final ValueExpression operand;
+
+    public CatList(final ValueExpression operand) {
+        this.operand = operand;
+    }
+
+    @Override
+    public ImmutableList<Optional<Value>> eval(ParseState parseState, Encoding encoding) {
+        final ImmutableList<Value> values = unwrap(operand.eval(parseState, encoding), new ImmutableList<>()).computeResult();
+        final BigInteger length = calculateTotalSize(values);
+        return createFromSource(new ConcatenatedValueSource(values, length), ZERO, length)
+            .map(source -> new ImmutableList<Optional<Value>>().add(Optional.of(new Value(source, encoding))))
+            .orElseGet(ImmutableList::new);
+    }
+
+    private static <T, U extends T> Trampoline<ImmutableList<T>> unwrap(final ImmutableList<Optional<U>> input, final ImmutableList<T> output) {
+        if (input.isEmpty()) {
+            return complete(() -> output);
+        }
+        return input.head
+            .map(value -> intermediate(() -> unwrap(input.tail, output.add(value))))
+            .orElseGet(() -> intermediate(() -> unwrap(input.tail, output)));
+    }
+
+    private BigInteger calculateTotalSize(final ImmutableList<Value> values) {
+        return calculateTotalSize(values, ZERO).computeResult();
+    }
+
+    private Trampoline<BigInteger> calculateTotalSize(final ImmutableList<Value> values, final BigInteger size) {
+        if (values.isEmpty()) {
+            return complete(() -> size);
+        }
+        return intermediate(() -> calculateTotalSize(values.tail, size.add(values.head.slice.length)));
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -52,6 +52,9 @@ public class FoldCat implements ValueExpression {
     public ImmutableList<Optional<Value>> eval(ParseState parseState, Encoding encoding) {
         final ImmutableList<Value> values = unwrap(operand.eval(parseState, encoding), new ImmutableList<>()).computeResult();
         final BigInteger length = calculateTotalSize(values);
+        if (length.compareTo(ZERO) == 0) {
+            return ImmutableList.create(Optional.empty());
+        }
         return createFromSource(new ConcatenatedValueSource(values, length), ZERO, length)
             .map(source -> new ImmutableList<Optional<Value>>().add(Optional.of(new Value(source, encoding))))
             .orElseGet(ImmutableList::new);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -49,7 +49,7 @@ public class FoldCat implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(ParseState parseState, Encoding encoding) {
+    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
         final ImmutableList<Value> values = unwrap(operand.eval(parseState, encoding), new ImmutableList<>()).computeResult();
         final BigInteger length = calculateTotalSize(values);
         if (length.compareTo(ZERO) == 0) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -33,11 +33,18 @@ import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
-public class CatList implements ValueExpression {
+/**
+ * A {@link ValueExpression} that represents an optimized version of a
+ * {@link FoldLeft} operation with a {@link Cat} ValueExpression as reducer.
+ *
+ * @see FoldLeft
+ * @see Cat
+ */
+public class FoldCat implements ValueExpression {
 
     public final ValueExpression operand;
 
-    public CatList(final ValueExpression operand) {
+    public FoldCat(final ValueExpression operand) {
         this.operand = operand;
     }
 
@@ -78,7 +85,7 @@ public class CatList implements ValueExpression {
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((CatList)obj).operand);
+            && Objects.equals(operand, ((FoldCat)obj).operand);
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -79,7 +79,7 @@ import io.parsingdata.metal.expression.comparison.LtEqNum;
 import io.parsingdata.metal.expression.comparison.LtNum;
 import io.parsingdata.metal.expression.value.Bytes;
 import io.parsingdata.metal.expression.value.Cat;
-import io.parsingdata.metal.expression.value.CatList;
+import io.parsingdata.metal.expression.value.FoldCat;
 import io.parsingdata.metal.expression.value.Const;
 import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.Elvis;
@@ -187,7 +187,7 @@ public class AutoEqualityTest {
             And.class, Or.class, ShiftLeft.class, ShiftRight.class, Add.class, Div.class, Mod.class, Mul.class,
             io.parsingdata.metal.expression.value.arithmetic.Sub.class, Cat.class, Nth.class, Elvis.class,
             FoldLeft.class, FoldRight.class, Const.class, Expand.class, Bytes.class, CurrentOffset.class,
-            CatList.class,
+            FoldCat.class,
             // Expressions
             Eq.class, EqNum.class, EqStr.class, GtEqNum.class, GtNum.class, LtEqNum.class, LtNum.class,
             io.parsingdata.metal.expression.logical.And.class, io.parsingdata.metal.expression.logical.Or.class,

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -79,6 +79,7 @@ import io.parsingdata.metal.expression.comparison.LtEqNum;
 import io.parsingdata.metal.expression.comparison.LtNum;
 import io.parsingdata.metal.expression.value.Bytes;
 import io.parsingdata.metal.expression.value.Cat;
+import io.parsingdata.metal.expression.value.CatList;
 import io.parsingdata.metal.expression.value.Const;
 import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.Elvis;
@@ -186,6 +187,7 @@ public class AutoEqualityTest {
             And.class, Or.class, ShiftLeft.class, ShiftRight.class, Add.class, Div.class, Mod.class, Mul.class,
             io.parsingdata.metal.expression.value.arithmetic.Sub.class, Cat.class, Nth.class, Elvis.class,
             FoldLeft.class, FoldRight.class, Const.class, Expand.class, Bytes.class, CurrentOffset.class,
+            CatList.class,
             // Expressions
             Eq.class, EqNum.class, EqStr.class, GtEqNum.class, GtNum.class, LtEqNum.class, LtNum.class,
             io.parsingdata.metal.expression.logical.And.class, io.parsingdata.metal.expression.logical.Or.class,

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -60,6 +60,7 @@ import io.parsingdata.metal.data.ByteStreamSource;
 import io.parsingdata.metal.data.ConcatenatedValueSource;
 import io.parsingdata.metal.data.ConstantSource;
 import io.parsingdata.metal.data.DataExpressionSource;
+import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;
 import io.parsingdata.metal.data.ParseReference;
@@ -151,6 +152,7 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> BYTE_STREAMS = Arrays.asList(() -> new InMemoryByteStream(new byte[] { 1, 2 }), () -> DUMMY_STREAM);
     private static final List<Supplier<Object>> BIG_INTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
     private static final List<Supplier<Object>> PARSE_STATES = Arrays.asList(() -> createFromByteStream(DUMMY_STREAM), () -> createFromByteStream(DUMMY_STREAM, ONE), () -> new ParseState(GRAPH_WITH_REFERENCE, DUMMY_BYTE_STREAM_SOURCE, TEN));
+    private static final List<Supplier<Object>> IMMUTABLE_LISTS = Arrays.asList(ImmutableList::new, () -> ImmutableList.create("TEST"), () -> ImmutableList.create(1), () -> ImmutableList.create(1).add(2));
     private static final Map<Class, List<Supplier<Object>>> mapping = new HashMap<Class, List<Supplier<Object>>>() {{
         put(String.class, STRINGS);
         put(Encoding.class, ENCODINGS);
@@ -170,6 +172,7 @@ public class AutoEqualityTest {
         put(ByteStream.class, BYTE_STREAMS);
         put(BigInteger.class, BIG_INTEGERS);
         put(ParseState.class, PARSE_STATES);
+        put(ImmutableList.class, IMMUTABLE_LISTS);
     }};
 
     @Parameterized.Parameters(name="{0}")

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -25,6 +25,7 @@ import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.and;
 import static io.parsingdata.metal.Shorthand.bytes;
 import static io.parsingdata.metal.Shorthand.cat;
+import static io.parsingdata.metal.Shorthand.catList;
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.count;
@@ -121,7 +122,7 @@ public class ToStringTest {
     }
 
     private ValueExpression v() {
-        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(last(ref(n())), first(nth(exp(ref(n()), con(1)), con(1)))), con(1)), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));
+        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(catList(last(ref(n()))), first(nth(exp(ref(n()), con(1)), con(1)))), con(1)), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -122,7 +122,7 @@ public class ToStringTest {
     }
 
     private ValueExpression v() {
-        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(Shorthand.cat(last(ref(n()))), first(nth(exp(ref(n()), con(1)), con(1)))), con(1)), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));
+        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(cat(last(ref(n()))), first(nth(exp(ref(n()), con(1)), con(1)))), con(1)), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -25,7 +25,7 @@ import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.and;
 import static io.parsingdata.metal.Shorthand.bytes;
 import static io.parsingdata.metal.Shorthand.cat;
-import static io.parsingdata.metal.Shorthand.catList;
+import static io.parsingdata.metal.Shorthand.cat;
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.count;
@@ -122,7 +122,7 @@ public class ToStringTest {
     }
 
     private ValueExpression v() {
-        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(catList(last(ref(n()))), first(nth(exp(ref(n()), con(1)), con(1)))), con(1)), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));
+        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(Shorthand.cat(last(ref(n()))), first(nth(exp(ref(n()), con(1)), con(1)))), con(1)), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
@@ -20,21 +20,17 @@ import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
 
+import static org.junit.Assert.assertFalse;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class ConcatenatedValueSourceErrorTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void emptyConcatenatedValueSource() {
-        final ConcatenatedValueSource cvs = new ConcatenatedValueSource(new ImmutableList<>(), TEN);
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Data to read is not available (offset=0;length=1;source=ConcatenatedValueSource((10))).");
-        Slice.createFromSource(cvs, ZERO, ONE).get().getData();
+        assertFalse(ConcatenatedValueSource.create(new ImmutableList<>()).isPresent());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.data;
+
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.TEN;
+import static java.math.BigInteger.ZERO;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ConcatenatedValueSourceErrorTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void emptyConcatenatedValueSource() {
+        final ConcatenatedValueSource cvs = new ConcatenatedValueSource(new ImmutableList<>(), TEN);
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Data to read is not available (offset=0;length=1;source=ConcatenatedValueSource((10))).");
+        Slice.createFromSource(cvs, ZERO, ONE).get().getData();
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -25,6 +25,7 @@ import static io.parsingdata.metal.util.EncodingFactory.enc;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,17 +37,16 @@ import io.parsingdata.metal.expression.value.Value;
 @RunWith(Parameterized.class)
 public class ConcatenatedValueSourceTest {
 
-    public static final BigInteger SIZE = BigInteger.valueOf(25);
-    public static final ConcatenatedValueSource cvs = new ConcatenatedValueSource(createValues(), SIZE);
+    public static final ConcatenatedValueSource cvs = ConcatenatedValueSource.create(createValues()).get();
 
-    private static ImmutableList<Value> createValues() {
+    private static ImmutableList<Optional<Value>> createValues() {
         final byte[] twoSliceSource = new byte[] { -1, -1, 5, 6, 7, 8, 9, -1, -1, 10, 11, 12, 13, 14, -1, -1 };
         return ImmutableList
-            .create(createFromBytes(new byte[] { 20, 21, 22, 23, 24 }, enc()))
-            .add(createFromBytes(new byte[] { 15, 16, 17, 18, 19 }, enc()))
-            .add(new Value(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(9), BigInteger.valueOf(5)).get(), enc()))
-            .add(new Value(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(2), BigInteger.valueOf(5)).get(), enc()))
-            .add(createFromBytes(new byte[] { 0, 1, 2, 3, 4 }, enc()));
+            .create(Optional.of(createFromBytes(new byte[] { 0, 1, 2, 3, 4 }, enc())))
+            .add(Optional.of(new Value(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(2), BigInteger.valueOf(5)).get(), enc())))
+            .add(Optional.of(new Value(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(9), BigInteger.valueOf(5)).get(), enc())))
+            .add(Optional.of(createFromBytes(new byte[] { 15, 16, 17, 18, 19 }, enc())))
+            .add(Optional.of(createFromBytes(new byte[] { 20, 21, 22, 23, 24 }, enc())));
     }
 
     @Parameter public String description;
@@ -56,31 +56,31 @@ public class ConcatenatedValueSourceTest {
     @Parameterized.Parameters(name="{0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "full", 0, SIZE.intValueExact() }, // [XXXXX][XXXXX][XXXXX][XXXXX][XXXXX]
-            { "none", 0, 0 },                    // [.....][.....][.....][.....][.....]
-            { "full(0)", 0, 5 },                 // [XXXXX][.....][.....][.....][.....]
-            { "part(1)", 1, 3 },                 // [.XXX.][.....][.....][.....][.....]
-            { "full(0) to part(1)", 0, 8 },      // [XXXXX][XXX..][.....][.....][.....]
-            { "part(0) to part(1)", 2, 6 },      // [..XXX][XXX..][.....][.....][.....]
-            { "part(0) to full(1)", 2, 8 },      // [..XXX][XXXXX][.....][.....][.....]
-            { "full(0) to part(2)", 0, 12 },     // [XXXXX][XXXXX][XX...][.....][.....]
-            { "full(0) to full(2)", 0, 15 },     // [XXXXX][XXXXX][XXXXX][.....][.....]
-            { "part(0) to part(2)", 3, 8 },      // [...XX][XXXXX][X....][.....][.....]
-            { "part(0) to full(2)", 3, 12 },     // [...XX][XXXXX][XXXXX][.....][.....]
-            { "full(0) to part(3)", 0, 17 },     // [XXXXX][XXXXX][XXXXX][XX...][.....]
-            { "part(0) to full(3)", 4, 16 },     // [....X][XXXXX][XXXXX][XXXXX][.....]
-            { "full(0) to part(4)", 0, 22 },     // [XXXXX][XXXXX][XXXXX][XXXXX][XX...]
-            { "part(0) to part(4)", 3, 20 },     // [...XX][XXXXX][XXXXX][XXXXX][XXX..]
-            { "part(0) to full(4)", 4, 21 },     // [....X][XXXXX][XXXXX][XXXXX][XXXXX]
-            { "full(1) to full(3)", 5, 15 },     // [.....][XXXXX][XXXXX][XXXXX][.....]
-            { "part(1) to full(3)", 7, 13 },     // [.....][..XXX][XXXXX][XXXXX][.....]
-            { "part(1) to part(3)", 8, 11 },     // [.....][...XX][XXXXX][XXXX.][.....]
-            { "full(2) to full(4)", 10, 15 },    // [.....][.....][XXXXX][XXXXX][XXXXX]
-            { "full(2) to part(4)", 10, 12 },    // [.....][.....][XXXXX][XXXXX][XX...]
-            { "part(2) to full(4)", 12, 13 },    // [.....][.....][..XXX][XXXXX][XXXXX]
-            { "part(2) to part(4)", 11, 11 },    // [.....][.....][.XXXX][XXXXX][XX...]
-            { "full(4)", 20, 5 },                // [.....][.....][.....][.....][XXXXX]
-            { "part(4)", 21, 4 }                 // [.....][.....][.....][.....][.XXXX]
+            { "full", 0, 25 },                // [XXXXX][XXXXX][XXXXX][XXXXX][XXXXX]
+            { "none", 0, 0 },                 // [.....][.....][.....][.....][.....]
+            { "full(0)", 0, 5 },              // [XXXXX][.....][.....][.....][.....]
+            { "part(1)", 1, 3 },              // [.XXX.][.....][.....][.....][.....]
+            { "full(0) to part(1)", 0, 8 },   // [XXXXX][XXX..][.....][.....][.....]
+            { "part(0) to part(1)", 2, 6 },   // [..XXX][XXX..][.....][.....][.....]
+            { "part(0) to full(1)", 2, 8 },   // [..XXX][XXXXX][.....][.....][.....]
+            { "full(0) to part(2)", 0, 12 },  // [XXXXX][XXXXX][XX...][.....][.....]
+            { "full(0) to full(2)", 0, 15 },  // [XXXXX][XXXXX][XXXXX][.....][.....]
+            { "part(0) to part(2)", 3, 8 },   // [...XX][XXXXX][X....][.....][.....]
+            { "part(0) to full(2)", 3, 12 },  // [...XX][XXXXX][XXXXX][.....][.....]
+            { "full(0) to part(3)", 0, 17 },  // [XXXXX][XXXXX][XXXXX][XX...][.....]
+            { "part(0) to full(3)", 4, 16 },  // [....X][XXXXX][XXXXX][XXXXX][.....]
+            { "full(0) to part(4)", 0, 22 },  // [XXXXX][XXXXX][XXXXX][XXXXX][XX...]
+            { "part(0) to part(4)", 3, 20 },  // [...XX][XXXXX][XXXXX][XXXXX][XXX..]
+            { "part(0) to full(4)", 4, 21 },  // [....X][XXXXX][XXXXX][XXXXX][XXXXX]
+            { "full(1) to full(3)", 5, 15 },  // [.....][XXXXX][XXXXX][XXXXX][.....]
+            { "part(1) to full(3)", 7, 13 },  // [.....][..XXX][XXXXX][XXXXX][.....]
+            { "part(1) to part(3)", 8, 11 },  // [.....][...XX][XXXXX][XXXX.][.....]
+            { "full(2) to full(4)", 10, 15 }, // [.....][.....][XXXXX][XXXXX][XXXXX]
+            { "full(2) to part(4)", 10, 12 }, // [.....][.....][XXXXX][XXXXX][XX...]
+            { "part(2) to full(4)", 12, 13 }, // [.....][.....][..XXX][XXXXX][XXXXX]
+            { "part(2) to part(4)", 11, 11 }, // [.....][.....][.XXXX][XXXXX][XX...]
+            { "full(4)", 20, 5 },             // [.....][.....][.....][.....][XXXXX]
+            { "part(4)", 21, 4 }              // [.....][.....][.....][.....][.XXXX]
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.data;
+
+import static org.junit.Assert.assertEquals;
+
+import static io.parsingdata.metal.data.Slice.createFromSource;
+import static io.parsingdata.metal.expression.value.ConstantFactory.createFromBytes;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import io.parsingdata.metal.expression.value.Value;
+
+@RunWith(Parameterized.class)
+public class ConcatenatedValueSourceTest {
+
+    public static final BigInteger SIZE = BigInteger.valueOf(25);
+    public static final ConcatenatedValueSource cvs = new ConcatenatedValueSource(createValues(), SIZE);
+
+    private static ImmutableList<Value> createValues() {
+        final byte[] twoSliceSource = new byte[] { -1, -1, 5, 6, 7, 8, 9, -1, -1, 10, 11, 12, 13, 14, -1, -1 };
+        return ImmutableList
+            .create(createFromBytes(new byte[] { 20, 21, 22, 23, 24 }, enc()))
+            .add(createFromBytes(new byte[] { 15, 16, 17, 18, 19 }, enc()))
+            .add(new Value(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(9), BigInteger.valueOf(5)).get(), enc()))
+            .add(new Value(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(2), BigInteger.valueOf(5)).get(), enc()))
+            .add(createFromBytes(new byte[] { 0, 1, 2, 3, 4 }, enc()));
+    }
+
+    @Parameter public String description;
+    @Parameter(1) public int offset;
+    @Parameter(2) public int length;
+
+    @Parameterized.Parameters(name="{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "full", 0, SIZE.intValueExact() }, // [XXXXX][XXXXX][XXXXX][XXXXX][XXXXX]
+            { "none", 0, 0 },                    // [.....][.....][.....][.....][.....]
+            { "full(0)", 0, 5 },                 // [XXXXX][.....][.....][.....][.....]
+            { "part(1)", 1, 3 },                 // [.XXX.][.....][.....][.....][.....]
+            { "full(0) to part(1)", 0, 8 },      // [XXXXX][XXX..][.....][.....][.....]
+            { "part(0) to part(1)", 2, 6 },      // [..XXX][XXX..][.....][.....][.....]
+            { "part(0) to full(1)", 2, 8 },      // [..XXX][XXXXX][.....][.....][.....]
+            { "full(0) to part(2)", 0, 12 },     // [XXXXX][XXXXX][XX...][.....][.....]
+            { "full(0) to full(2)", 0, 15 },     // [XXXXX][XXXXX][XXXXX][.....][.....]
+            { "part(0) to part(2)", 3, 8 },      // [...XX][XXXXX][X....][.....][.....]
+            { "part(0) to full(2)", 3, 12 },     // [...XX][XXXXX][XXXXX][.....][.....]
+            { "full(0) to part(3)", 0, 17 },     // [XXXXX][XXXXX][XXXXX][XX...][.....]
+            { "part(0) to full(3)", 4, 16 },     // [....X][XXXXX][XXXXX][XXXXX][.....]
+            { "full(0) to part(4)", 0, 22 },     // [XXXXX][XXXXX][XXXXX][XXXXX][XX...]
+            { "part(0) to part(4)", 3, 20 },     // [...XX][XXXXX][XXXXX][XXXXX][XXX..]
+            { "part(0) to full(4)", 4, 21 },     // [....X][XXXXX][XXXXX][XXXXX][XXXXX]
+            { "full(1) to full(3)", 5, 15 },     // [.....][XXXXX][XXXXX][XXXXX][.....]
+            { "part(1) to full(3)", 7, 13 },     // [.....][..XXX][XXXXX][XXXXX][.....]
+            { "part(1) to part(3)", 8, 11 },     // [.....][...XX][XXXXX][XXXX.][.....]
+            { "full(2) to full(4)", 10, 15 },    // [.....][.....][XXXXX][XXXXX][XXXXX]
+            { "full(2) to part(4)", 10, 12 },    // [.....][.....][XXXXX][XXXXX][XX...]
+            { "part(2) to full(4)", 12, 13 },    // [.....][.....][..XXX][XXXXX][XXXXX]
+            { "part(2) to part(4)", 11, 11 },    // [.....][.....][.XXXX][XXXXX][XX...]
+            { "full(4)", 20, 5 },                // [.....][.....][.....][.....][XXXXX]
+            { "part(4)", 21, 4 }                 // [.....][.....][.....][.....][.XXXX]
+        });
+    }
+
+    @Test
+    public void checkData() {
+        byte[] data = cvs.getData(BigInteger.valueOf(offset), BigInteger.valueOf(length));
+        assertEquals(length, data.length);
+        for (int i = 0; i < length; i++) {
+            assertEquals(offset+i, data[i]);
+        }
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,7 +59,7 @@ public class SourceAndSliceTest {
             { new ConstantSource(DATA) },
             { new DataExpressionSource(con(DATA), 0, EMPTY_PARSE_STATE, enc()) },
             { new ByteStreamSource(new InMemoryByteStream(DATA)) },
-            { new ConcatenatedValueSource(ImmutableList.create(new Value(createFromSource(new ConstantSource(DATA), BigInteger.valueOf(2), BigInteger.valueOf(2)).get(), enc())).add(new Value(createFromSource(new ConstantSource(DATA), ZERO, BigInteger.valueOf(2)).get(), enc())), BigInteger.valueOf(DATA.length)) }
+            { ConcatenatedValueSource.create(ImmutableList.create(Optional.of(new Value(createFromSource(new ConstantSource(DATA), ZERO, BigInteger.valueOf(2)).get(), enc()))).add(Optional.of(new Value(createFromSource(new ConstantSource(DATA), BigInteger.valueOf(2), BigInteger.valueOf(2)).get(), enc())))).get() }
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -58,7 +58,7 @@ public class SourceAndSliceTest {
             { new ConstantSource(DATA) },
             { new DataExpressionSource(con(DATA), 0, EMPTY_PARSE_STATE, enc()) },
             { new ByteStreamSource(new InMemoryByteStream(DATA)) },
-            { new ConcatenatedValueSource(new Value(createFromSource(new ConstantSource(DATA), ZERO, BigInteger.valueOf(2)).get(), enc()), new Value(createFromSource(new ConstantSource(DATA), BigInteger.valueOf(2), BigInteger.valueOf(2)).get(), enc())) }
+            { new ConcatenatedValueSource(ImmutableList.create(new Value(createFromSource(new ConstantSource(DATA), BigInteger.valueOf(2), BigInteger.valueOf(2)).get(), enc())).add(new Value(createFromSource(new ConstantSource(DATA), ZERO, BigInteger.valueOf(2)).get(), enc())), BigInteger.valueOf(DATA.length)) }
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.cat;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.ref;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
+import static io.parsingdata.metal.util.TokenDefinitions.any;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import io.parsingdata.metal.data.Environment;
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseState;
+
+public class FoldCatTest {
+
+    public static final Optional<ParseState> RESULT =
+        seq(any("a"),
+            any("a"),
+            any("a")).parse(new Environment(stream("abc", StandardCharsets.US_ASCII), enc()));
+
+    @Test
+    public void foldCatRegular() {
+        assertEquals("abc", foldString("a").get().asString());
+    }
+
+    @Test
+    public void foldCatEmpty() {
+        assertEquals(Optional.empty(), foldString("b"));
+    }
+
+    private Optional<Value> foldString(final String name) {
+        assertTrue(RESULT.isPresent());
+        ImmutableList<Optional<Value>> values = cat(ref(name)).eval(RESULT.get(), enc());
+        assertEquals(1, values.size);
+        return values.head;
+    }
+
+    @Test
+    public void foldCatEmptyResult() {
+        ImmutableList<Optional<Value>> values = cat(div(con(1), con(0))).eval(EMPTY_PARSE_STATE, enc());
+        assertEquals(1, values.size);
+        assertEquals(Optional.empty(), values.head);
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
@@ -40,14 +40,9 @@ import io.parsingdata.metal.data.ParseState;
 
 public class FoldCatTest {
 
-    public static final Optional<ParseState> RESULT =
-        seq(any("a"),
-            any("a"),
-            any("a")).parse(new Environment(stream("abc", StandardCharsets.US_ASCII), enc()));
-
     @Test
     public void foldCatRegular() {
-        assertEquals("abc", foldString("a").get().asString());
+        assertEquals("abc", foldString("any").get().asString());
     }
 
     @Test
@@ -56,8 +51,12 @@ public class FoldCatTest {
     }
 
     private Optional<Value> foldString(final String name) {
-        assertTrue(RESULT.isPresent());
-        ImmutableList<Optional<Value>> values = cat(ref(name)).eval(RESULT.get(), enc());
+        final Optional<ParseState> result =
+            seq(any("any"),
+                any("any"),
+                any("any")).parse(new Environment(stream("abc", StandardCharsets.US_ASCII), enc()));
+        assertTrue(result.isPresent());
+        ImmutableList<Optional<Value>> values = cat(ref(name)).eval(result.get(), enc());
         assertEquals(1, values.size);
         return values.head;
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
@@ -47,7 +47,7 @@ public class FoldCatTest {
 
     @Test
     public void foldCatEmpty() {
-        assertEquals(Optional.empty(), foldString("b"));
+        assertEquals(Optional.empty(), foldString("other"));
     }
 
     private Optional<Value> foldString(final String name) {


### PR DESCRIPTION
Resolves #230: Added `FoldCat`, a folding version of the `Cat` `ValueExpression` that essentially implements an optimized version of calling `Fold` with `Cat` as reducer.
Resolves #229: `ConcatenatedValueSource` is now list-based, in order to improve the scalability of long chains of concatenated values.
Resolves #232: `DataExpressionSource` now caches its data, because it needs to resolve it in its entirety anyway to perform any read- or size-related operation on it. The method that fills the cache is marked `synchronized`, which may be inefficient in some cases but for all current Metal use cases this is not expected to be a problem.