### PR TITLE
Lazy calculate utility

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Lazily.java
+++ b/core/src/main/java/io/parsingdata/metal/Lazily.java
@@ -17,7 +17,9 @@ package io.parsingdata.metal;
 
 import java.util.function.Supplier;
 
-public class Lazily {
+public final class Lazily {
+
+    private Lazily() {}
 
     /**
      * Constructs a lazily calculated value (of type T) the first time it is retrieved.  <br/><br/>

--- a/core/src/main/java/io/parsingdata/metal/Lazily.java
+++ b/core/src/main/java/io/parsingdata/metal/Lazily.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 SWAT.engineering BV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.parsingdata.metal;
+
+import java.util.function.Supplier;
+
+public class Lazily {
+
+    /**
+     * Constructs a lazily calculated value (of type T) the first time it is retrieved.  <br/><br/>
+     *
+     * Does not give any guarantees on how often the calculator is called in case of multi-threading.
+     * @param calculator the closure that calculates the actual value.
+     * @return a LazilyCalculated value store
+     */
+    public static <T> LazilyCalculated<T> calculate(Supplier<T> calculator) {
+        return new LazilyCalculated<T>() {
+            private T value = null;
+
+            @Override
+            public T get() {
+                T result = value;
+                if (result == null) {
+                    result = calculator.get();
+                    value = result;
+                }
+                return result;
+            }
+        };
+    }
+
+    /**
+     * Constructs a lazily calculated value (of type T) the first time it is retrieved.  <br/><br/>
+     *
+     * This lazily calculated value will only trigger the calculator once at the costs of more locking an synchronisation.
+     * @param calculator the closure that calculates the actual value (take care not to call the get on yourself).
+     * @return a LazilyCalculated value store
+     */
+    public static <T> LazilyCalculated<T> calculateOnlyOnce(Supplier<T> calculator) {
+        return new LazilyCalculated<T>() {
+            private volatile T value = null; // volatile to get the correct memory/jvm caching behavior
+
+            @Override
+            public T get() {
+                T result = value;
+                if (result == null) {
+                    synchronized (this) {
+                        result = value;
+                        if (result == null) {
+                            // it is still null, so we are the ones to calculate the actual value
+                            result = calculator.get();
+                            value = result;
+                        }
+                    }
+                }
+                return result;
+            }
+        };
+    }
+}

--- a/core/src/main/java/io/parsingdata/metal/LazilyCalculated.java
+++ b/core/src/main/java/io/parsingdata/metal/LazilyCalculated.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 SWAT.engineering BV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.parsingdata.metal;
+
+/**
+ * A value that is only calculated the first time it is actually requested
+ * @param <T>
+ */
+public interface LazilyCalculated<T> {
+    /**
+     * Get the value that is lazily calculated. <br /><br/>
+     *
+     * In some implementations this can cause a block in case there are multiple threads requesting the first get at the same time.
+     * @return the value of type T that is the result of the calculation
+     */
+    T get();
+}

--- a/core/src/test/java/io/parsingdata/metal/LazilyCalculatedTest.java
+++ b/core/src/test/java/io/parsingdata/metal/LazilyCalculatedTest.java
@@ -1,0 +1,93 @@
+/*
+* Copyright 2017 SWAT.engineering BV
+*
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package io.parsingdata.metal;
+
+
+import org.junit.Test;
+
+import java.lang.ref.Reference;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Semaphore;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class LazilyCalculatedTest {
+
+    // as concurrent collections from null values, we have to wrap them
+    private static class NullableObjectReference {
+        private final Object value;
+
+        public NullableObjectReference(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            return ((NullableObjectReference)obj).value == this.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(value);
+        }
+    }
+
+    private Collection<Object> getMultithreaded(LazilyCalculated<Object> target, int threads, int tries) {
+        Semaphore wait = new Semaphore(0);
+        Semaphore done = new Semaphore(0);
+        final Collection<NullableObjectReference> result = new ConcurrentLinkedDeque<>();
+        for (int t = 0; t < threads; t++) {
+            new Thread(() -> {
+                try {
+                    wait.acquire();
+                    for (int i = 0; i < tries; i ++) {
+                        result.add(new NullableObjectReference(target.get()));
+                    }
+                }
+                catch (InterruptedException e) { }
+                finally {
+                    done.release();
+                }
+            }).start();
+        }
+        try {
+            wait.release(threads); // start all threads at the same time
+            done.acquire(threads); // wait for all threads to finish
+            assertEquals(threads * tries, result.size());
+            return result.stream().map(o -> o.value).collect(Collectors.toList());
+        }
+        catch (InterruptedException e) {
+            fail(e.toString());
+            return null; // dead code as fail throws exception
+        }
+    }
+
+    @Test
+    public void nonLockingCodeWorksWithMultipleThreads() {
+        Set<Object> seen = new HashSet<>(getMultithreaded(Lazily.calculate(Object::new), 50, 10));
+        assertFalse("The lazily loading value should never return null", seen.contains(null));
+        assertTrue("There should be at least one result", seen.size() > 0);
+    }
+
+    @Test
+    public void nonLockingCodeOnlyReturnsOneResult() {
+        Set<Object> seen = new HashSet<>(getMultithreaded(Lazily.calculateOnlyOnce(Object::new), 50, 10));
+        assertFalse("The lazily loading value should never return null", seen.contains(null));
+        assertTrue("There should be exactly one result", seen.size() == 1);
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/UtilityClassTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilityClassTest.java
@@ -42,6 +42,7 @@ public class UtilityClassTest {
         checkUtilityClass(ByType.class);
         checkUtilityClass(ConstantFactory.class);
         checkUtilityClass(Selection.class);
+        checkUtilityClass(Lazily.class);
     }
 
     // Metal uses enums to prevent the use of difficult to understand boolean arguments.


### PR DESCRIPTION
After a discussion with @jvdb about the recent pull-request #233 that solves issue #232, I proposed a different way to implement the cache of the `DataExpressionSource`.

In this PR I've created two implementations of this caching behaviour, one that is lock free, and one that locks only for the initial case. This is better than the current behaviour of `getValue` that locks on every invocation. Looking at the code and after a discussion with @jvdb it seems you might not even need a lock, as the edge case of sometimes calculating the array twice is not that expensive.