### PR TITLE
Small gardening changes for the 7.1 release.

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -152,6 +152,10 @@ public final class Shorthand {
     public static Token until(final String name, final ValueExpression initialSize, final Token terminator) { return until(name, initialSize, null, terminator, null); }
     public static Token until(final String name, final Token terminator, final Encoding encoding) { return until(name, null, terminator, encoding); }
     public static Token until(final String name, final Token terminator) { return until(name, terminator, null); }
+    public static Token when(final String name, final Token token, final Expression predicate, final Encoding encoding) { return cho(name, encoding, pre(def(EMPTY_NAME, 0), not(predicate)), token); }
+    public static Token when(final String name, final Token token, final Expression predicate) { return when(name, token, predicate, null); }
+    public static Token when(final Token token, final Expression predicate, final Encoding encoding) { return when(EMPTY_NAME, token, predicate, encoding); }
+    public static Token when(final Token token, final Expression predicate) { return when(token, predicate, null); }
 
     public static BinaryValueExpression add(final ValueExpression left, final ValueExpression right) { return new Add(left, right); }
     public static BinaryValueExpression div(final ValueExpression left, final ValueExpression right) { return new Div(left, right); }

--- a/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
@@ -22,7 +22,6 @@ import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.data.Slice.createFromSource;
 
 import java.math.BigInteger;
 import java.util.Objects;

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -76,7 +76,7 @@ public class DataExpressionSource extends Source {
                 .map(Value::getValue)
                 .orElseThrow(() -> new IllegalStateException("ValueExpression dataExpression yields empty Value at index " + index + "."));
         }
-        return cache.clone();
+        return cache;
     }
 
     private Trampoline<Optional<Value>> getValueAtIndex(final ImmutableList<Optional<Value>> results, final int index, final int current) {

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -22,7 +22,6 @@ import static io.parsingdata.metal.Util.checkNotNegative;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -20,7 +20,6 @@ import static java.math.BigInteger.ZERO;
 
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
-import java.math.BigInteger;
 import java.util.Optional;
 
 import io.parsingdata.metal.data.ConcatenatedValueSource;

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -18,20 +18,15 @@ package io.parsingdata.metal.expression.value;
 
 import static java.math.BigInteger.ZERO;
 
-import static io.parsingdata.metal.Trampoline.complete;
-import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
-import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
 
-import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ConcatenatedValueSource;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.Slice;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -64,6 +64,7 @@ import org.junit.rules.ExpectedException;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.data.Selection;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.token.Cho;
 import io.parsingdata.metal.token.Seq;
@@ -231,6 +232,7 @@ public class ShorthandsTest {
         Optional<ParseState> result = when(def("name", con(1), eq(con(1))), TRUE).parse(env(stream(1)));
         assertTrue(result.isPresent());
         assertEquals(1, result.get().offset.intValueExact());
+        assertEquals(1, Selection.getAllValues(result.get().order, parseValue -> parseValue.matches("name") && parseValue.getValue().length == 1 && parseValue.getValue()[0] == 1).size);
     }
 
     @Test
@@ -241,6 +243,7 @@ public class ShorthandsTest {
                 def("name2", con(1), eq(con(2)))).parse(env(stream(2)));
         assertTrue(result.isPresent());
         assertEquals(1, result.get().offset.intValueExact());
+        assertEquals(1, Selection.getAllValues(result.get().order, parseValue -> parseValue.matches("name2") && parseValue.getValue().length == 1 && parseValue.getValue()[0] == 2).size);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -37,6 +37,7 @@ import static io.parsingdata.metal.Shorthand.ltEqNum;
 import static io.parsingdata.metal.Shorthand.ltNum;
 import static io.parsingdata.metal.Shorthand.mapLeft;
 import static io.parsingdata.metal.Shorthand.mapRight;
+import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.opt;
 import static io.parsingdata.metal.Shorthand.pre;
 import static io.parsingdata.metal.Shorthand.ref;
@@ -45,6 +46,7 @@ import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
+import static io.parsingdata.metal.Shorthand.when;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.expression.value.ExpandTest.createParseValue;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
@@ -53,7 +55,6 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static junit.framework.TestCase.assertFalse;
 
-import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.Rule;
@@ -76,12 +77,12 @@ public class ShorthandsTest {
             def("c", con(1), eq(con(3))));
 
     @Test
-    public void sequenceMultiMatch() throws IOException {
+    public void sequenceMultiMatch() {
         assertTrue(multiSequence.parse(env(stream(1, 2, 3))).isPresent());
     }
 
     @Test
-    public void sequenceMultiNoMatch() throws IOException {
+    public void sequenceMultiNoMatch() {
         assertFalse(multiSequence.parse(env(stream(1, 2, 2))).isPresent());
     }
 
@@ -91,17 +92,17 @@ public class ShorthandsTest {
             def("c", con(1), gtNum(con(0))));
 
     @Test
-    public void choiceMultiMatchA() throws IOException {
+    public void choiceMultiMatchA() {
         runChoice(3, "a");
     }
 
     @Test
-    public void choiceMultiMatchB() throws IOException {
+    public void choiceMultiMatchB() {
         runChoice(2, "b");
     }
 
     @Test
-    public void choiceMultiMatchC() throws IOException {
+    public void choiceMultiMatchC() {
         runChoice(1, "c");
     }
 
@@ -112,7 +113,7 @@ public class ShorthandsTest {
     }
 
     @Test
-    public void choiceMultiNoMatch() throws IOException {
+    public void choiceMultiNoMatch() {
         assertFalse(multiChoice.parse(env(stream(0))).isPresent());
     }
 
@@ -130,37 +131,37 @@ public class ShorthandsTest {
         );
 
     @Test
-    public void nonLocalCompare() throws IOException {
+    public void nonLocalCompare() {
         assertTrue(nonLocalCompare.parse(env(stream(1, 'a', 'b', 'c', 0, 0))).isPresent());
     }
 
     @Test
-    public void allTokensNamed() throws IOException {
+    public void allTokensNamed() {
         final Optional<ParseState> result =
-            rep("rep",
-                repn("repn",
-                    seq("seq",
-                        pre("pre",
-                            opt("opt",
-                                any("a")),
-                            TRUE),
-                        cho("cho",
-                            def("def0", con(1), eq(con(0))),
-                            def("def1", con(1), eq(con(1)))),
-                        sub("sub",
-                            def("def2", con(1), eq(con(2))),
-                            con(2)),
-                        tie("tie",
-                            def("def3", con(1), eq(con(1))),
-                            last(ref("def1")))
-                    ), con(1)
-                )
-            ).parse(env(stream(2, 1, 2)));
+            when("when",
+                rep("rep",
+                    repn("repn",
+                        seq("seq",
+                            pre("pre",
+                                opt("opt",
+                                    any("a")), TRUE),
+                            cho("cho",
+                                def("def0", con(1), eq(con(0))),
+                                def("def1", con(1), eq(con(1)))),
+                            sub("sub",
+                                def("def2", con(1), eq(con(2))),
+                                con(2)),
+                            tie("tie",
+                                def("def3", con(1), eq(con(1))),
+                                last(ref("def1")))
+                        ), con(1)
+                    )
+                ), TRUE).parse(env(stream(2, 1, 2)));
         assertTrue(result.isPresent());
-        checkNameAndValue("rep.repn.seq.pre.opt.a", 2, result.get());
-        checkNameAndValue("rep.repn.seq.cho.def1", 1, result.get());
-        checkNameAndValue("rep.repn.seq.sub.def2", 2, result.get());
-        checkNameAndValue("rep.repn.seq.tie.def3", 1, result.get());
+        checkNameAndValue("when.rep.repn.seq.pre.opt.a", 2, result.get());
+        checkNameAndValue("when.rep.repn.seq.cho.def1", 1, result.get());
+        checkNameAndValue("when.rep.repn.seq.sub.def2", 2, result.get());
+        checkNameAndValue("when.rep.repn.seq.tie.def3", 1, result.get());
     }
 
     private void checkNameAndValue(final String name, final int value, final ParseState parseState) {
@@ -180,32 +181,32 @@ public class ShorthandsTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    public static final Token DEFA = any("a");
-    public static final Token DEFB = any("b");
+    public static final Token DEF_A = any("a");
+    public static final Token DEF_B = any("b");
 
     @Test
     public void checkChoTokens() {
-        final Token choToken = cho(DEFA, DEFB);
+        final Token choToken = cho(DEF_A, DEF_B);
         final Cho cho = (Cho)choToken;
         assertEquals(2, cho.tokens.size);
-        assertEquals(DEFA, cho.tokens.head);
-        assertEquals(DEFB, cho.tokens.tail.head);
+        assertEquals(DEF_A, cho.tokens.head);
+        assertEquals(DEF_B, cho.tokens.tail.head);
     }
 
     @Test
     public void checkSeqTokens() {
-        final Token seqToken = seq(DEFA, DEFB);
+        final Token seqToken = seq(DEF_A, DEF_B);
         final Seq seq = (Seq)seqToken;
         assertEquals(2, seq.tokens.size);
-        assertEquals(DEFA, seq.tokens.head);
-        assertEquals(DEFB, seq.tokens.tail.head);
+        assertEquals(DEF_A, seq.tokens.head);
+        assertEquals(DEF_B, seq.tokens.tail.head);
     }
 
-    final ParseState PARSESTATE = createFromByteStream(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42));
+    final ParseState PARSE_STATE = createFromByteStream(DUMMY_STREAM).add(createParseValue("a", 126)).add(createParseValue("a", 84)).add(createParseValue("a", 42));
 
     @Test
     public void mapLeftWithSub() {
-        ImmutableList<Optional<Value>> result = mapLeft(Shorthand::sub, ref("a"), con(2)).eval(PARSESTATE, enc());
+        ImmutableList<Optional<Value>> result = mapLeft(Shorthand::sub, ref("a"), con(2)).eval(PARSE_STATE, enc());
         assertEquals(3, result.size);
         for (int i = 0; i < 3; i++) {
             assertTrue(result.head.isPresent());
@@ -216,13 +217,30 @@ public class ShorthandsTest {
 
     @Test
     public void mapRightWithSub() {
-        ImmutableList<Optional<Value>> result = mapRight(Shorthand::sub, con(126), ref("a")).eval(PARSESTATE, enc());
+        ImmutableList<Optional<Value>> result = mapRight(Shorthand::sub, con(126), ref("a")).eval(PARSE_STATE, enc());
         assertEquals(3, result.size);
         for (int i = 0; i < 3; i++) {
             assertTrue(result.head.isPresent());
             assertEquals(((3 - i) * 42) - 42, result.head.get().asNumeric().intValueExact());
             result = result.tail;
         }
+    }
+
+    @Test
+    public void whenTrue() {
+        Optional<ParseState> result = when(def("name", con(1), eq(con(1))), TRUE).parse(env(stream(1)));
+        assertTrue(result.isPresent());
+        assertEquals(1, result.get().offset.intValueExact());
+    }
+
+    @Test
+    public void whenFalse() {
+        Optional<ParseState> result =
+            seq(
+                when(def("name1", con(1), eq(con(1))), not(TRUE)),
+                def("name2", con(1), eq(con(2)))).parse(env(stream(2)));
+        assertTrue(result.isPresent());
+        assertEquals(1, result.get().offset.intValueExact());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -25,7 +25,6 @@ import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.and;
 import static io.parsingdata.metal.Shorthand.bytes;
 import static io.parsingdata.metal.Shorthand.cat;
-import static io.parsingdata.metal.Shorthand.cat;
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.count;

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
@@ -16,15 +16,9 @@
 
 package io.parsingdata.metal.data;
 
-import static java.math.BigInteger.ONE;
-import static java.math.BigInteger.TEN;
-import static java.math.BigInteger.ZERO;
-
 import static org.junit.Assert.assertFalse;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ConcatenatedValueSourceErrorTest {
 


### PR DESCRIPTION
Resolves #211: The original `Pre` behaviour is back as a shorthand called `when`.

The other changes are the removal of an unneeded `.clone()` call and some unused imports.