### PR TITLE
Parameterized parse verification

### DIFF
--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -44,26 +44,24 @@ import io.parsingdata.metal.util.ParameterizedParse;
 
 public class ParameterizedUntilTest extends ParameterizedParse {
 
-    private static final Token ABC = def("rest", 3, eq(con("abc")));
-
     @Parameters(name = "{0} ({4})")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab", seq(untilToken(0, 1, 6, con('c'), con("ab")), ABC), stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",  untilToken(3, 1, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=2,m=6 ab", seq(untilToken(0, 2, 6, con('c'), con("ab")), ABC), stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",  untilToken(1, 2, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(0, 3, 6, con('c'), con("")),         stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=0,m=6",        untilToken(0, 0, 6, con(""), con("")),          stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab", untilToken(6, -1, 0, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
-            { "[] i=0,s=-1,m=6",                  untilToken(0, -1, 6, con(""), con("")),         stream("", US_ASCII), enc(), false },
-            { "[] i=6,s=1,m=0",                   untilToken(6, 1, 0, con(""), con("")),          stream("", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=(0,0),s=3,m=6",    untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=(0,0),s=(3,3),m=6",untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
-            { "[] i=NaN",                         untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")), stream("", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=1 ab",     seq(untilToken(0, 1, con('c'), con("ab")), ABC),    stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0 ab",         seq(untilToken(0, con('c'), con("ab")), ABC),       stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",     untilTokenAlwaysTrueTerminator(2, 1, 6),        stream("a", US_ASCII), enc(), false },
+            { "[a,b,c] i=0,s=1,m=6 ab",            untilToken(0, 1, 3, con('c'), con("ab")),       stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",   untilToken(3, 1, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c] i=0,s=2,m=6 ab",            untilToken(0, 2, 3, con('c'), con("ab")),       stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",   untilToken(1, 2, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",         untilToken(0, 3, 6, con('c'), con("")),         stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=0,m=6",         untilToken(0, 0, 6, con(""), con("")),          stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab",  untilToken(6, -1, 0, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
+            { "[] i=0,s=-1,m=6",                   untilToken(0, -1, 6, con(""), con("")),         stream("", US_ASCII), enc(), false },
+            { "[] i=6,s=1,m=0",                    untilToken(6, 1, 0, con(""), con("")),          stream("", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=(0,0),s=3,m=6",     untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=(0,0),s=(3,3),m=6", untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
+            { "[] i=NaN",                          untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")), stream("", US_ASCII), enc(), false },
+            { "[a,b,c] i=0,s=1 ab",                untilToken(0, 1, con('c'), con("ab")),          stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c] i=0 ab",                    untilToken(0, con('c'), con("ab")),             stream("abc", US_ASCII), enc(), true },
+            { "[a] i=2,s=1,m=6 ab",                untilTokenAlwaysTrueTerminator(2, 1, 6),        stream("a", US_ASCII), enc(), false },
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -47,21 +47,21 @@ public class ParameterizedUntilTest extends ParameterizedParse {
     @Parameters(name = "{0} ({4})")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "[a,b,c] i=0,s=1,m=3 ab",            untilToken(0, 1, 3, con('c'), con("ab")),      stream("abc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",   untilToken(3, 1, 6, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c] i=0,s=2,m=3 ab",            untilToken(0, 2, 3, con('c'), con("ab")),      stream("abc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",   untilToken(1, 2, 6, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",         untilToken(0, 3, 6, con('c'), con("")),        stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=0,m=6",         untilToken(0, 0, 6, con(""), con("")),         stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab",  untilToken(6, -1, 0, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
-            { "[] i=0,s=-1,m=6",                   untilToken(0, -1, 6, con(""), con("")),        stream("", US_ASCII), enc(), false },
-            { "[] i=6,s=1,m=0",                    untilToken(6, 1, 0, con(""), con("")),         stream("", US_ASCII), enc(), false },
+            { "[a,b,c] i=0,s=1,m=3 ab",            untilToken(0, 1, 3, con('c'), con("ab")),     stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",   untilToken(3, 1, 6, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c] i=0,s=2,m=3 ab",            untilToken(0, 2, 3, con('c'), con("ab")),     stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",   untilToken(1, 2, 6, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",         untilToken(0, 3, 6, con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=0,m=6",         untilToken(0, 0, 6, con(""), con("")),        stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab",  untilToken(6, -1, 0, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
+            { "[] i=0,s=-1,m=6",                   untilToken(0, -1, 6, con(""), con("")),       stream("", US_ASCII), enc(), false },
+            { "[] i=6,s=1,m=0",                    untilToken(6, 1, 0, con(""), con("")),        stream("", US_ASCII), enc(), false },
             { "[a,b,c,a,b,c] i=(0,0),s=3,m=6",     untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
             { "[a,b,c,a,b,c] i=(0,0),s=(3,3),m=6", untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
             { "[] i=NaN",                          untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")), stream("", US_ASCII), enc(), false },
-            { "[a,b,c] i=0,s=1 ab",                untilToken(0, 1, con('c'), con("ab")),         stream("abc", US_ASCII), enc(), true },
-            { "[a,b,c] i=0 ab",                    untilToken(0, con('c'), con("ab")),            stream("abc", US_ASCII), enc(), true },
-            { "[a] i=2,s=1,m=6",                   untilTokenAlwaysTrueTerminator(2, 1, 6),       stream("a", US_ASCII), enc(), false },
+            { "[a,b,c] i=0,s=1 ab",                untilToken(0, 1, con('c'), con("ab")),        stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c] i=0 ab",                    untilToken(0, con('c'), con("ab")),           stream("abc", US_ASCII), enc(), true },
+            { "[a] i=2,s=1,m=6",                   untilTokenAlwaysTrueTerminator(2, 1, 6),      stream("a", US_ASCII), enc(), false },
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -16,6 +16,7 @@
 
 package io.parsingdata.metal.token;
 
+import static io.parsingdata.metal.Shorthand.seq;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import static io.parsingdata.metal.Shorthand.EMPTY;
@@ -43,24 +44,26 @@ import io.parsingdata.metal.util.ParameterizedParse;
 
 public class ParameterizedUntilTest extends ParameterizedParse {
 
+    private static final Token ABC = def("rest", 3, eq(con("abc")));
+
     @Parameters(name = "{0} ({4})")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",     untilToken(0, 1, 6, con('c'), con("ab")),     stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",  untilToken(3, 1, 6, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=2,m=6 ab",     untilToken(0, 2, 6, con('c'), con("ab")),     stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",  untilToken(1, 2, 6, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(0, 3, 6, con('c'), con("")),       stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=0,m=6",        untilToken(0, 0, 6, con(""), con("")),        stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab", untilToken(6, -1, 0, con('c'), con("abcab")), stream("abcabc", US_ASCII), enc(), true },
-            { "[] i=0,s=-1,m=6",                  untilToken(0, -1, 6, con(""), con("")),       stream("", US_ASCII), enc(), false },
-            { "[] i=6,s=1,m=0",                   untilToken(6, 1, 0, con(""), con("")),        stream("", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab", seq(untilToken(0, 1, 6, con('c'), con("ab")), ABC), stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",  untilToken(3, 1, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=2,m=6 ab", seq(untilToken(0, 2, 6, con('c'), con("ab")), ABC), stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",  untilToken(1, 2, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",        untilToken(0, 3, 6, con('c'), con("")),         stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=0,m=6",        untilToken(0, 0, 6, con(""), con("")),          stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab", untilToken(6, -1, 0, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
+            { "[] i=0,s=-1,m=6",                  untilToken(0, -1, 6, con(""), con("")),         stream("", US_ASCII), enc(), false },
+            { "[] i=6,s=1,m=0",                   untilToken(6, 1, 0, con(""), con("")),          stream("", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=(0,0),s=3,m=6",    untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=(0,0),s=(3,3),m=6",untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
             { "[] i=NaN",                         untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")), stream("", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=1 ab",         untilToken(0, 1, con('c'), con("ab")),        stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0 ab",             untilToken(0, con('c'), con("ab")),           stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",     untilTokenAlwaysTrueTerminator(2, 1, 6),      stream("a", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=1 ab",     seq(untilToken(0, 1, con('c'), con("ab")), ABC),    stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0 ab",         seq(untilToken(0, con('c'), con("ab")), ABC),       stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",     untilTokenAlwaysTrueTerminator(2, 1, 6),        stream("a", US_ASCII), enc(), false },
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -47,21 +47,21 @@ public class ParameterizedUntilTest extends ParameterizedParse {
     @Parameters(name = "{0} ({4})")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "[a,b,c] i=0,s=1,m=6 ab",            untilToken(0, 1, 3, con('c'), con("ab")),       stream("abc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",   untilToken(3, 1, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c] i=0,s=2,m=6 ab",            untilToken(0, 2, 3, con('c'), con("ab")),       stream("abc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",   untilToken(1, 2, 6, con('c'), con("abcab")),    stream("abcabc", US_ASCII), enc(), true },
-            { "[a,b,c,a,b,c] i=0,s=3,m=6",         untilToken(0, 3, 6, con('c'), con("")),         stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=0,s=0,m=6",         untilToken(0, 0, 6, con(""), con("")),          stream("abcabc", US_ASCII), enc(), false },
-            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab",  untilToken(6, -1, 0, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
-            { "[] i=0,s=-1,m=6",                   untilToken(0, -1, 6, con(""), con("")),         stream("", US_ASCII), enc(), false },
-            { "[] i=6,s=1,m=0",                    untilToken(6, 1, 0, con(""), con("")),          stream("", US_ASCII), enc(), false },
+            { "[a,b,c] i=0,s=1,m=3 ab",            untilToken(0, 1, 3, con('c'), con("ab")),      stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",   untilToken(3, 1, 6, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c] i=0,s=2,m=3 ab",            untilToken(0, 2, 3, con('c'), con("ab")),      stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=1,s=2,m=6 abcab",   untilToken(1, 2, 6, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },
+            { "[a,b,c,a,b,c] i=0,s=3,m=6",         untilToken(0, 3, 6, con('c'), con("")),        stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=0,s=0,m=6",         untilToken(0, 0, 6, con(""), con("")),         stream("abcabc", US_ASCII), enc(), false },
+            { "[a,b,c,a,b,c] i=6,s=-1,m=0 abcab",  untilToken(6, -1, 0, con('c'), con("abcab")),  stream("abcabc", US_ASCII), enc(), true },
+            { "[] i=0,s=-1,m=6",                   untilToken(0, -1, 6, con(""), con("")),        stream("", US_ASCII), enc(), false },
+            { "[] i=6,s=1,m=0",                    untilToken(6, 1, 0, con(""), con("")),         stream("", US_ASCII), enc(), false },
             { "[a,b,c,a,b,c] i=(0,0),s=3,m=6",     untilToken(exp(con(0), con(2)), con(3), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
             { "[a,b,c,a,b,c] i=(0,0),s=(3,3),m=6", untilToken(exp(con(0), con(2)), exp(con(3), con(2)), con(6), con('c'), con("")), stream("abcabc", US_ASCII), enc(), false },
             { "[] i=NaN",                          untilToken(div(con(1), con(0)), con(1), con(1), con(""), con("")), stream("", US_ASCII), enc(), false },
-            { "[a,b,c] i=0,s=1 ab",                untilToken(0, 1, con('c'), con("ab")),          stream("abc", US_ASCII), enc(), true },
-            { "[a,b,c] i=0 ab",                    untilToken(0, con('c'), con("ab")),             stream("abc", US_ASCII), enc(), true },
-            { "[a] i=2,s=1,m=6 ab",                untilTokenAlwaysTrueTerminator(2, 1, 6),        stream("a", US_ASCII), enc(), false },
+            { "[a,b,c] i=0,s=1 ab",                untilToken(0, 1, con('c'), con("ab")),         stream("abc", US_ASCII), enc(), true },
+            { "[a,b,c] i=0 ab",                    untilToken(0, con('c'), con("ab")),            stream("abc", US_ASCII), enc(), true },
+            { "[a] i=2,s=1,m=6",                   untilTokenAlwaysTrueTerminator(2, 1, 6),       stream("a", US_ASCII), enc(), false },
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
@@ -16,11 +16,14 @@
 
 package io.parsingdata.metal.util;
 
+import static java.math.BigInteger.ONE;
 import static org.junit.Assert.assertEquals;
 
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -44,7 +47,13 @@ public class ParameterizedParse {
 
     @Test
     public void test() throws IOException {
-        assertEquals(result, token.parse(env(parseState, encoding)).isPresent());
+        Optional<ParseState> endState = token.parse(env(parseState, encoding));
+        assertEquals(result, endState.isPresent());
+
+        endState.ifPresent(state -> {
+            // In case parsing succeeded we expect to have parsed the whole stream and we shouldn't be able to slice 1 byte.
+            assertFalse("The test has not parsed the whole stream. It ended at offset " + state.offset + ".", state.slice(ONE).isPresent());
+        });
     }
 
 }


### PR DESCRIPTION
During development of #241 and #242 this addition helped me a lot to check if the tests were in fact fully parsed. Decided to create a separate pull request for it.

Only had to improve the until tests, since there were 4 tests, that didn't parse until the end. For these tests I decreased the size of the stream.

Also adjusted some other descriptions within the until tests to correctly represent what the tests do.