### PR TITLE
Introduce OneToManyValueExpression and OneToOneValueExpression

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -44,6 +44,7 @@ import io.parsingdata.metal.expression.value.Bytes;
 import io.parsingdata.metal.expression.value.Cat;
 import io.parsingdata.metal.expression.value.Const;
 import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.reference.CurrentIteration;
 import io.parsingdata.metal.expression.value.Elvis;
 import io.parsingdata.metal.expression.value.Expand;
@@ -51,7 +52,6 @@ import io.parsingdata.metal.expression.value.FoldLeft;
 import io.parsingdata.metal.expression.value.FoldRight;
 import io.parsingdata.metal.expression.value.FoldCat;
 import io.parsingdata.metal.expression.value.Reverse;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.expression.value.arithmetic.Add;
@@ -164,10 +164,10 @@ public final class Shorthand {
     public static BinaryValueExpression mul(final ValueExpression left, final ValueExpression right) { return new Mul(left, right); }
     public static BinaryValueExpression sub(final ValueExpression left, final ValueExpression right) { return new Sub(left, right); }
     public static BinaryValueExpression mod(final ValueExpression left, final ValueExpression right) { return new Mod(left, right); }
-    public static UnaryValueExpression neg(final ValueExpression operand) { return new Neg(operand); }
+    public static OneToManyValueExpression neg(final ValueExpression operand) { return new Neg(operand); }
     public static BinaryValueExpression and(final ValueExpression left, final ValueExpression right) { return new io.parsingdata.metal.expression.value.bitwise.And(left, right); }
     public static BinaryValueExpression or(final ValueExpression left, final ValueExpression right) { return new io.parsingdata.metal.expression.value.bitwise.Or(left, right); }
-    public static UnaryValueExpression not(final ValueExpression operand) { return new io.parsingdata.metal.expression.value.bitwise.Not(operand); }
+    public static OneToManyValueExpression not(final ValueExpression operand) { return new io.parsingdata.metal.expression.value.bitwise.Not(operand); }
     public static BinaryValueExpression shl(final ValueExpression left, final ValueExpression right) { return new ShiftLeft(left, right); }
     public static BinaryValueExpression shr(final ValueExpression left, final ValueExpression right) { return new ShiftRight(left, right); }
     public static ValueExpression con(final long value) { return con(value, new Encoding()); }

--- a/core/src/main/java/io/parsingdata/metal/Util.java
+++ b/core/src/main/java/io/parsingdata/metal/Util.java
@@ -27,7 +27,7 @@ import java.util.zip.Inflater;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.Slice;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -85,7 +85,7 @@ public final class Util {
     }
 
     public static ValueExpression inflate(final ValueExpression target) {
-        return new UnaryValueExpression(target) {
+        return new OneToManyValueExpression(target) {
             @Override
             public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
                 final Inflater inf = new Inflater(true);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -49,7 +49,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * handling the case of evaluating two values. This base class takes care of
  * evaluating the operands and handling list semantics.
  *
- * @see UnaryValueExpression
+ * @see OneToManyValueExpression
  */
 public abstract class BinaryValueExpression implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -16,8 +16,9 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static io.parsingdata.metal.data.Slice.createFromSource;
 import static java.math.BigInteger.ZERO;
+
+import static io.parsingdata.metal.data.Slice.createFromSource;
 
 import java.util.Optional;
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -16,14 +16,11 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.data.Slice.createFromSource;
 import static java.math.BigInteger.ZERO;
 
-import static io.parsingdata.metal.data.Slice.createFromSource;
-
-import java.util.Objects;
 import java.util.Optional;
 
-import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ConcatenatedValueSource;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
@@ -36,36 +33,17 @@ import io.parsingdata.metal.encoding.Encoding;
  * @see FoldLeft
  * @see Cat
  */
-public class FoldCat implements ValueExpression {
-
-    public final ValueExpression operand;
+public class FoldCat extends OneToOneValueExpression {
 
     public FoldCat(final ValueExpression operand) {
-        this.operand = operand;
+        super(operand);
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return ConcatenatedValueSource.create(operand.eval(parseState, encoding))
-            .flatMap(source -> createFromSource(source, ZERO, source.length))
-            .map(slice -> new ImmutableList<Optional<Value>>().add(Optional.of(new Value(slice, encoding))))
-            .orElseGet(() -> ImmutableList.create(Optional.empty()));
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((FoldCat)obj).operand);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getClass(), operand);
+    public Optional<Value> eval(final ImmutableList<Optional<Value>> list, final ParseState parseState, final Encoding encoding) {
+        return ConcatenatedValueSource.create(list)
+                .flatMap(source -> createFromSource(source, ZERO, source.length))
+                .map(slice -> new Value(slice, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/OneToManyValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/OneToManyValueExpression.java
@@ -33,23 +33,23 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * Base class for {@link ValueExpression}s with one operand.
  * <p>
- * A UnaryValueExpression implements a ValueExpression that has one
+ * A OneToManyValueExpression implements a ValueExpression that has one
  * <code>operand</code> (a {@link ValueExpression}). The operand is first
  * evaluated. If it evaluates to {@link Optional#empty()}, the result of the
  * ValueExpression itself will be that as well.
  * <p>
- * To implement a UnaryValueExpression, only the
+ * To implement a OneToManyValueExpression, only the
  * {@link #eval(Value, ParseState, Encoding)} must be implemented, handling
  * the case of evaluating one value. This base class takes care of evaluating
  * the operand and handling list semantics.
  *
  * @see BinaryValueExpression
  */
-public abstract class UnaryValueExpression implements ValueExpression {
+public abstract class OneToManyValueExpression implements ValueExpression {
 
     public final ValueExpression operand;
 
-    public UnaryValueExpression(final ValueExpression operand) {
+    public OneToManyValueExpression(final ValueExpression operand) {
         this.operand = checkNotNull(operand, "operand");
     }
 
@@ -75,7 +75,7 @@ public abstract class UnaryValueExpression implements ValueExpression {
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((UnaryValueExpression)obj).operand);
+            && Objects.equals(operand, ((OneToManyValueExpression)obj).operand);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
@@ -21,14 +21,14 @@ import java.util.Optional;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link UnaryValueExpression} that implements integer negation.
+ * A {@link OneToManyValueExpression} that implements integer negation.
  */
-public class Neg extends UnaryValueExpression {
+public class Neg extends OneToManyValueExpression {
 
     public Neg(final ValueExpression operand) {
         super(operand);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
@@ -22,14 +22,14 @@ import java.util.Optional;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link UnaryValueExpression} that implements the bitwise NOT operator.
+ * A {@link OneToManyValueExpression} that implements the bitwise NOT operator.
  */
-public class Not extends UnaryValueExpression {
+public class Not extends OneToManyValueExpression {
 
     public Not(final ValueExpression operand) {
         super(operand);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -16,17 +16,14 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.util.Objects;
 import java.util.Optional;
 
-import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.encoding.Sign;
 import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.OneToOneValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -34,38 +31,19 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * A {@link ValueExpression} that represents the amount of {@link Value}s
  * returned by evaluating its <code>operand</code>.
  */
-public class Count implements ValueExpression {
-
-    public final ValueExpression operand;
+public class Count extends OneToOneValueExpression {
 
     public Count(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+        super(operand);
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> values = operand.eval(parseState, encoding);
-        return ImmutableList.create(Optional.of(fromNumeric(values.size)));
+    public Optional<Value> eval(final ImmutableList<Optional<Value>> list, final ParseState parseState, final Encoding encoding) {
+        return Optional.of(fromNumeric(list.size));
     }
 
     private static Value fromNumeric(final long length) {
         return ConstantFactory.createFromNumeric(length, new Encoding(Sign.SIGNED));
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((Count)obj).operand);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -18,16 +18,14 @@ package io.parsingdata.metal.expression.value.reference;
 
 import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
-import static io.parsingdata.metal.Util.checkNotNull;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
-import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.OneToOneValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -35,38 +33,19 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * A {@link ValueExpression} that represents the first {@link Value} returned
  * by evaluating its <code>operand</code>.
  */
-public class First implements ValueExpression {
-
-    public final ValueExpression operand;
+public class First extends OneToOneValueExpression {
 
     public First(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+        super(operand);
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
-        return list.isEmpty() ? list : ImmutableList.create(getFirst(list).computeResult());
+    public Optional<Value> eval(final ImmutableList<Optional<Value>> list, final ParseState parseState, final Encoding encoding) {
+        return list.isEmpty() ? Optional.empty() : getFirst(list).computeResult();
     }
 
     private Trampoline<Optional<Value>> getFirst(final ImmutableList<Optional<Value>> values) {
         return values.tail.isEmpty() ? complete(() -> values.head) : intermediate(() -> getFirst(values.tail));
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((First)obj).operand);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -16,15 +16,12 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
-import static io.parsingdata.metal.Util.checkNotNull;
-
-import java.util.Objects;
 import java.util.Optional;
 
-import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.OneToOneValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -32,34 +29,15 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * A {@link ValueExpression} that represents the last {@link Value} returned
  * by evaluating its <code>operand</code>.
  */
-public class Last implements ValueExpression {
-
-    public final ValueExpression operand;
+public class Last extends OneToOneValueExpression {
 
     public Last(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+        super(operand);
     }
 
     @Override
-    public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
-        return list.isEmpty() ? list : ImmutableList.create(list.head);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((Last)obj).operand);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getClass(), operand);
+    public Optional<Value> eval(final ImmutableList<Optional<Value>> list, final ParseState parseState, final Encoding encoding) {
+        return list.isEmpty() ? Optional.empty() : list.head;
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
@@ -23,15 +23,15 @@ import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.encoding.Sign;
 import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link UnaryValueExpression} that represents the sizes (in bytes) of all
+ * A {@link OneToManyValueExpression} that represents the sizes (in bytes) of all
  * {@link Value}s returned by evaluating its <code>operand</code>.
  */
-public class Len extends UnaryValueExpression {
+public class Len extends OneToManyValueExpression {
 
     public Len(final ValueExpression operand) {
         super(operand);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -22,7 +22,7 @@ import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.value.ConstantFactory;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -34,7 +34,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * If a result does not have an offset (such as the {@link Value}s returned by
  * {@link io.parsingdata.metal.expression.value.Const}), empty is returned.
  */
-public class Offset extends UnaryValueExpression {
+public class Offset extends OneToManyValueExpression {
 
     public Offset(final ValueExpression operand) { super(operand); }
 

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -101,7 +101,7 @@ public class ArgumentsTest {
             // Derived from BinaryValueExpression
             { Cat.class, new Object[] { VALID_VE, null } },
             { Cat.class, new Object[] { null, VALID_VE } },
-            // Derived from UnaryValueExpression
+            // Derived from OneToManyValueExpression
             { Neg.class, new Object[] { null } },
             { Len.class, new Object[] { null } },
             // Derived from BinaryLogicalExpression

--- a/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
@@ -36,10 +36,10 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Arrays;
 import java.util.Collection;
 
-import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import org.junit.runners.Parameterized.Parameters;
 
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;

--- a/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
@@ -36,10 +36,10 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Arrays;
 import java.util.Collection;
 
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import org.junit.runners.Parameterized.Parameters;
 
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
@@ -102,7 +102,7 @@ public class ArithmeticValueExpressionSemanticsTest extends ParameterizedParse {
     private static final Token mul2 = binaryValueExpressionToken(mul(ref("a"), ref("b")), 2);
     private static final Token sub = binaryValueExpressionToken(sub(ref("a"), ref("b")), 1);
     private static final Token mod = binaryValueExpressionToken(mod(ref("a"), ref("b")), 1);
-    private static final Token neg = unaryValueExpressionToken(neg(ref("a")));
+    private static final Token neg = oneToManyValueExpression(neg(ref("a")));
 
     private static Token singleToken(final String firstName, final String secondName, final int resultSize, final ValueExpression valueExpression) {
         return seq(any(firstName),
@@ -114,7 +114,7 @@ public class ArithmeticValueExpressionSemanticsTest extends ParameterizedParse {
                    singleToken("b", "c", resultSize, binaryValueExpression));
     }
 
-    private static Token unaryValueExpressionToken(final UnaryValueExpression unaryValueExpression) {
+    private static Token oneToManyValueExpression(final OneToManyValueExpression unaryValueExpression) {
         return singleToken("a", "b", 1, unaryValueExpression);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -33,13 +33,13 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.io.IOException;
 import java.util.Optional;
 
-import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.token.Token;
 

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -33,13 +33,13 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.io.IOException;
 import java.util.Optional;
 
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.token.Token;
 
@@ -63,7 +63,7 @@ public class ValueExpressionSemanticsTest {
     @Test
     public void callback() throws IOException {
         final ParseState data = stream(1, 2, 3, 4);
-        def("a", 4, eq(new UnaryValueExpression(ref("a")) {
+        def("a", 4, eq(new OneToManyValueExpression(ref("a")) {
             @Override
             public Optional<Value> eval(Value value, ParseState parseState, Encoding encoding) {
                 return Optional.of(value);

--- a/formats/src/main/java/io/parsingdata/metal/format/Callback.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/Callback.java
@@ -23,7 +23,7 @@ import java.util.zip.CRC32;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.OneToManyValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -32,7 +32,7 @@ public final class Callback {
     private Callback() {}
 
     public static ValueExpression crc32(final ValueExpression target) {
-        return new UnaryValueExpression(target) {
+        return new OneToManyValueExpression(target) {
             @Override
             public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {
                 final CRC32 crc = new CRC32();


### PR DESCRIPTION
This removes duplicated code in these `ValueExpressions`: `Last`, `First`, `Count` and `FoldCat`. This is achieved by introducing a new abstract base class `OneToOneValueExpression`. The four classes look pretty clean now!

The old `UnaryValueExpression` has been renamed to `OneToManyValueExpression`.

The names of these classes are still open to debate, not too sure if these are the best names.
* one-to-one meaning: one operand leads to a one (optional) value
* one-to-many meaning: one operand leads to many (optional) values

I found that the `Bytes` class still contains this exact code, but is not a match for either base class, since we "expand" each result of the operand into multiple values.