### PR TITLE
Add CI on Windows with AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,26 @@
+version: "{branch} {build}"
+
+shallow_clone: true
+
+init:  
+  - git config --global core.autocrlf input 
+
+environment:
+  APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -mx0 -mmt=0 -snl -snh
+  MAVEN_OPTS: "-Dmaven.repo.local=C:/Users/appveyor/.m2"
+  JAVA_HOME: "C:/Program Files/Java/jdk1.8.0"
+
+cache:
+  - C:\Users\appveyor\.m2 -> pom.xml
+
+install:
+  - SET PATH=%JAVA_HOME%\bin;%PATH%
+  - java -version
+  - mvn -version
+
+build_script:
+  - mvn clean compile -DskipTests
+
+test_script:
+- mvn verify
+

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,8 @@ version: "{branch} {build}"
 
 shallow_clone: true
 
-init:  
-  - git config --global core.autocrlf input 
+init:
+  - git config --global core.autocrlf input
 
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -mx0 -mmt=0 -snl -snh

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,5 +24,5 @@ build_script:
   - mvn clean compile -DskipTests
 
 test_script:
-- mvn verify
+  - mvn verify
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,9 @@ init:
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -mx0 -mmt=0 -snl -snh
   MAVEN_OPTS: "-Dmaven.repo.local=C:/Users/appveyor/.m2"
-  JAVA_HOME: "C:/Program Files/Java/jdk1.8.0"
+  matrix:
+  - JAVA_HOME: "C:/Program Files/Java/jdk1.8.0"
+  - JAVA_HOME: "C:/Program Files/Java/jdk9"
 
 cache:
   - C:\Users\appveyor\.m2 -> pom.xml


### PR DESCRIPTION
@DavyLandman was kind enough to point me to his `.appveyor.yml` from `usethesource/rascal`, on which this file is based. The only thing I changed is that for Metal we also build on jdk9 just like our Travis config.

This resolves #137.