### PR TITLE
Unify ValueExpression instance naming and update JavaDoc

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -33,16 +33,16 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * Base class for {@link ValueExpression}s with two operands.
  * <p>
- * A BinaryValueExpression implements a ValueExpression that has two operands:
+ * A BinaryValueExpression implements a ValueExpression that has two fields:
  * <code>lefts</code> and <code>rights</code> (both {@link ValueExpression}s).
- * Both operands are themselves first evaluated. If at least one of the
- * operands evaluates to {@link Optional#empty()}, the result of the
- * ValueExpression itself will be empty as well.
+ * Both fields are first evaluated. If at least one of the operands evaluates to
+ * {@link Optional#empty()}, the result of the ValueExpression itself will be
+ * empty as well.
  * <p>
- * For lists, values with the same index are evaluated in this manner. If
- * lists are of unequal length, the result is a list with evaluated values the
- * same size as the shortest list, appended with empty values to match the
- * size of the longest list.
+ * For lists, values with the same index are evaluated in this manner. If lists
+ * are of unequal length, the result is a list with evaluated values the same
+ * size as the shortest list, appended with empty values to match the size of the
+ * longest list.
  * <p>
  * To implement a BinaryValueExpression, only the
  * {@link #eval(Value, Value, ParseState, Encoding)} method must be implemented,

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -34,7 +34,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * Base class for {@link ValueExpression}s with two operands.
  * <p>
  * A BinaryValueExpression implements a ValueExpression that has two operands:
- * <code>left</code> and <code>right</code> (both {@link ValueExpression}s).
+ * <code>lefts</code> and <code>rights</code> (both {@link ValueExpression}s).
  * Both operands are themselves first evaluated. If at least one of the
  * operands evaluates to {@link Optional#empty()}, the result of the
  * ValueExpression itself will be empty as well.
@@ -45,7 +45,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * size of the longest list.
  * <p>
  * To implement a BinaryValueExpression, only the
- * {@link #eval(Value, Value, ParseState, Encoding)} must be implemented,
+ * {@link #eval(Value, Value, ParseState, Encoding)} method must be implemented,
  * handling the case of evaluating two values. This base class takes care of
  * evaluating the operands and handling list semantics.
  *
@@ -53,19 +53,19 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public abstract class BinaryValueExpression implements ValueExpression {
 
-    public final ValueExpression left;
-    public final ValueExpression right;
+    public final ValueExpression lefts;
+    public final ValueExpression rights;
 
-    public BinaryValueExpression(final ValueExpression left, final ValueExpression right) {
-        this.left = checkNotNull(left, "left");
-        this.right = checkNotNull(right, "right");
+    public BinaryValueExpression(final ValueExpression lefts, final ValueExpression rights) {
+        this.lefts = checkNotNull(lefts, "lefts");
+        this.rights = checkNotNull(rights, "rights");
     }
 
-    public abstract Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding);
+    public abstract Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding);
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return evalLists(left.eval(parseState, encoding), right.eval(parseState, encoding), parseState, encoding);
+        return evalLists(lefts.eval(parseState, encoding), rights.eval(parseState, encoding), parseState, encoding);
     }
 
     private ImmutableList<Optional<Value>> evalLists(final ImmutableList<Optional<Value>> leftValues, final ImmutableList<Optional<Value>> rightValues, final ParseState parseState, final Encoding encoding) {
@@ -88,19 +88,19 @@ public abstract class BinaryValueExpression implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + left + "," + right + ")";
+        return getClass().getSimpleName() + "(" + lefts + "," + rights + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(left, ((BinaryValueExpression)obj).left)
-            && Objects.equals(right, ((BinaryValueExpression)obj).right);
+            && Objects.equals(lefts, ((BinaryValueExpression)obj).lefts)
+            && Objects.equals(rights, ((BinaryValueExpression)obj).rights);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), left, right);
+        return Objects.hash(getClass(), lefts, rights);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -34,7 +34,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * Base class for {@link ValueExpression}s with two operands.
  * <p>
  * A BinaryValueExpression implements a ValueExpression that has two operands:
- * <code>lefts</code> and <code>rights</code> (both {@link ValueExpression}s).
+ * <code>left</code> and <code>right</code> (both {@link ValueExpression}s).
  * Both operands are first evaluated. If at least one of the operands evaluates to
  * {@link Optional#empty()}, the result of the ValueExpression itself will be
  * empty as well.
@@ -53,19 +53,19 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public abstract class BinaryValueExpression implements ValueExpression {
 
-    public final ValueExpression lefts;
-    public final ValueExpression rights;
+    public final ValueExpression left;
+    public final ValueExpression right;
 
-    public BinaryValueExpression(final ValueExpression lefts, final ValueExpression rights) {
-        this.lefts = checkNotNull(lefts, "lefts");
-        this.rights = checkNotNull(rights, "rights");
+    public BinaryValueExpression(final ValueExpression left, final ValueExpression right) {
+        this.left = checkNotNull(left, "left");
+        this.right = checkNotNull(right, "right");
     }
 
     public abstract Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding);
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return evalLists(lefts.eval(parseState, encoding), rights.eval(parseState, encoding), parseState, encoding);
+        return evalLists(left.eval(parseState, encoding), right.eval(parseState, encoding), parseState, encoding);
     }
 
     private ImmutableList<Optional<Value>> evalLists(final ImmutableList<Optional<Value>> leftValues, final ImmutableList<Optional<Value>> rightValues, final ParseState parseState, final Encoding encoding) {
@@ -88,19 +88,19 @@ public abstract class BinaryValueExpression implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + lefts + "," + rights + ")";
+        return getClass().getSimpleName() + "(" + left + "," + right + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(lefts, ((BinaryValueExpression)obj).lefts)
-            && Objects.equals(rights, ((BinaryValueExpression)obj).rights);
+            && Objects.equals(left, ((BinaryValueExpression)obj).left)
+            && Objects.equals(right, ((BinaryValueExpression)obj).right);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), lefts, rights);
+        return Objects.hash(getClass(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/BinaryValueExpression.java
@@ -33,9 +33,9 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * Base class for {@link ValueExpression}s with two operands.
  * <p>
- * A BinaryValueExpression implements a ValueExpression that has two fields:
+ * A BinaryValueExpression implements a ValueExpression that has two operands:
  * <code>lefts</code> and <code>rights</code> (both {@link ValueExpression}s).
- * Both fields are first evaluated. If at least one of the operands evaluates to
+ * Both operands are first evaluated. If at least one of the operands evaluates to
  * {@link Optional#empty()}, the result of the ValueExpression itself will be
  * empty as well.
  * <p>

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -35,9 +35,9 @@ import io.parsingdata.metal.encoding.Encoding;
 
 /**
  * A {@link ValueExpression} that splits the results of evaluating its
- * <code>operands</code> field into individual bytes.
+ * <code>operands</code> into individual bytes.
  * <p>
- * A Bytes expression has a single <code>operands</code> field (a
+ * A Bytes expression has a single <code>operands</code> (a
  * {@link ValueExpression}). When evaluated, it evaluates <code>operands</code>
  * and instead of returning the list of results, each result is split into
  * {@link Value} objects representing each individual byte of the original

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -58,11 +58,11 @@ public class Bytes implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> evaluatedOperands = operand.eval(parseState, encoding);
-        if (evaluatedOperands.isEmpty()) {
-            return evaluatedOperands;
+        final ImmutableList<Optional<Value>> evaluatedOperand = operand.eval(parseState, encoding);
+        if (evaluatedOperand.isEmpty()) {
+            return evaluatedOperand;
         }
-        return toByteValues(new ImmutableList<>(), evaluatedOperands.head, evaluatedOperands.tail, encoding).computeResult();
+        return toByteValues(new ImmutableList<>(), evaluatedOperand.head, evaluatedOperand.tail, encoding).computeResult();
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> toByteValues(final ImmutableList<Optional<Value>> output, final Optional<Value> head, final ImmutableList<Optional<Value>> tail, final Encoding encoding) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -34,34 +34,35 @@ import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
- * A {@link ValueExpression} that splits the results of evaluating its operand
- * into individual bytes.
+ * A {@link ValueExpression} that splits the results of evaluating its
+ * <code>operands</code> field into individual bytes.
  * <p>
- * A Bytes expression has a single <code>operand</code> (a
- * {@link ValueExpression}). When evaluated, it evaluates <code>operand</code>
+ * A Bytes expression has a single <code>operands</code> field (a
+ * {@link ValueExpression}). When evaluated, it evaluates <code>operands</code>
  * and instead of returning the list of results, each result is split into
  * {@link Value} objects representing each individual byte of the original
  * result.
  * <p>
- * For example, if <code>operand</code> evaluates to a list of two values, of
- * 2 and 3 bytes respectively, the Bytes expression turns this into a list of
- * 5 values, representing the individual bytes of the original results.
+ * For example, if <code>operands</code> evaluates to a list of two values, of
+ * 2 and 3 bytes respectively, the <code>Bytes</code> expression turns this
+ * into a list of 5 values, representing the individual bytes of the original
+ * results.
  */
 public class Bytes implements ValueExpression {
 
-    public final ValueExpression operand;
+    public final ValueExpression operands;
 
-    public Bytes(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+    public Bytes(final ValueExpression operands) {
+        this.operands = checkNotNull(operands, "operands");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> input = operand.eval(parseState, encoding);
-        if (input.isEmpty()) {
-            return input;
+        final ImmutableList<Optional<Value>> evaluatedOperands = operands.eval(parseState, encoding);
+        if (evaluatedOperands.isEmpty()) {
+            return evaluatedOperands;
         }
-        return toByteValues(new ImmutableList<>(), input.head, input.tail, encoding).computeResult();
+        return toByteValues(new ImmutableList<>(), evaluatedOperands.head, evaluatedOperands.tail, encoding).computeResult();
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> toByteValues(final ImmutableList<Optional<Value>> output, final Optional<Value> head, final ImmutableList<Optional<Value>> tail, final Encoding encoding) {
@@ -80,18 +81,18 @@ public class Bytes implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
+        return getClass().getSimpleName() + "(" + operands + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((Bytes)obj).operand);
+            && Objects.equals(operands, ((Bytes)obj).operands);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operand);
+        return Objects.hash(getClass(), operands);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Bytes.java
@@ -35,30 +35,30 @@ import io.parsingdata.metal.encoding.Encoding;
 
 /**
  * A {@link ValueExpression} that splits the results of evaluating its
- * <code>operands</code> into individual bytes.
+ * <code>operand</code> into individual bytes.
  * <p>
- * A Bytes expression has a single <code>operands</code> (a
- * {@link ValueExpression}). When evaluated, it evaluates <code>operands</code>
+ * A Bytes expression has a single <code>operand</code> (a
+ * {@link ValueExpression}). When evaluated, it evaluates <code>operand</code>
  * and instead of returning the list of results, each result is split into
  * {@link Value} objects representing each individual byte of the original
  * result.
  * <p>
- * For example, if <code>operands</code> evaluates to a list of two values, of
+ * For example, if <code>operand</code> evaluates to a list of two values, of
  * 2 and 3 bytes respectively, the <code>Bytes</code> expression turns this
  * into a list of 5 values, representing the individual bytes of the original
  * results.
  */
 public class Bytes implements ValueExpression {
 
-    public final ValueExpression operands;
+    public final ValueExpression operand;
 
-    public Bytes(final ValueExpression operands) {
-        this.operands = checkNotNull(operands, "operands");
+    public Bytes(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> evaluatedOperands = operands.eval(parseState, encoding);
+        final ImmutableList<Optional<Value>> evaluatedOperands = operand.eval(parseState, encoding);
         if (evaluatedOperands.isEmpty()) {
             return evaluatedOperands;
         }
@@ -81,18 +81,18 @@ public class Bytes implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operands + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operands, ((Bytes)obj).operands);
+            && Objects.equals(operand, ((Bytes)obj).operand);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operands);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -32,14 +32,14 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public class Cat extends BinaryValueExpression {
 
-    public Cat(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Cat(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        return ConcatenatedValueSource.create(ImmutableList.create(Optional.of(left)).add(Optional.of(right)))
-            .flatMap(source -> createFromSource(source, ZERO, left.getLength().add(right.getLength())))
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        return ConcatenatedValueSource.create(ImmutableList.create(Optional.of(leftValue)).add(Optional.of(rightValue)))
+            .flatMap(source -> createFromSource(source, ZERO, leftValue.getLength().add(rightValue.getLength())))
             .map(source -> new Value(source, encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Cat.java
@@ -32,8 +32,8 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public class Cat extends BinaryValueExpression {
 
-    public Cat(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public Cat(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -27,7 +27,7 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * A {@link ValueExpression} representing a constant value.
  * <p>
- * Const has a single field called <code>value</code> (a {@link Value}). When
+ * Const has a single operand called <code>value</code> (a {@link Value}). When
  * evaluated, this value is returned.
  */
 public class Const implements ValueExpression {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -27,7 +27,7 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * A {@link ValueExpression} representing a constant value.
  * <p>
- * Const has a single operand <code>value</code> (a {@link Value}). When
+ * Const has a single field called <code>value</code> (a {@link Value}). When
  * evaluated, this value is returned.
  */
 public class Const implements ValueExpression {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -34,8 +34,8 @@ import io.parsingdata.metal.encoding.Encoding;
  * A {@link ValueExpression} that implements the Elvis operator:
  * <pre>?:</pre>.
  * <p>
- * An Elvis expression has two fields: <code>lefts</code> and <code>rights</code>
- * (both {@link ValueExpression}s). Both fields are evaluated. The return value is
+ * An Elvis expression has two operands: <code>lefts</code> and <code>rights</code>
+ * (both {@link ValueExpression}s). Both operands are evaluated. The return value is
  * a list with the size of the longest list returned by the two evaluations. At
  * each index, the value at that index in the result returned by evaluating
  * <code>lefts</code> is placed, except if it does not exist or is {@link Optional#empty()},

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -34,27 +34,27 @@ import io.parsingdata.metal.encoding.Encoding;
  * A {@link ValueExpression} that implements the Elvis operator:
  * <pre>?:</pre>.
  * <p>
- * An Elvis expression has two operands: <code>lefts</code> and <code>rights</code>
+ * An Elvis expression has two operands: <code>left</code> and <code>right</code>
  * (both {@link ValueExpression}s). Both operands are evaluated. The return value is
  * a list with the size of the longest list returned by the two evaluations. At
  * each index, the value at that index in the result returned by evaluating
- * <code>lefts</code> is placed, except if it does not exist or is {@link Optional#empty()},
- * in which case the value at that index in the result returned by evaluating rights is
+ * <code>left</code> is placed, except if it does not exist or is {@link Optional#empty()},
+ * in which case the value at that index in the result returned by evaluating right is
  * placed there.
  */
 public class Elvis implements ValueExpression {
 
-    public final ValueExpression lefts;
-    public final ValueExpression rights;
+    public final ValueExpression left;
+    public final ValueExpression right;
 
-    public Elvis(final ValueExpression lefts, final ValueExpression rights) {
-        this.lefts = checkNotNull(lefts, "lefts");
-        this.rights = checkNotNull(rights, "rights");
+    public Elvis(final ValueExpression left, final ValueExpression right) {
+        this.left = checkNotNull(left, "left");
+        this.right = checkNotNull(right, "right");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return reverse(eval(new ImmutableList<>(), lefts.eval(parseState, encoding), rights.eval(parseState, encoding)).computeResult());
+        return reverse(eval(new ImmutableList<>(), left.eval(parseState, encoding), right.eval(parseState, encoding)).computeResult());
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> result, final ImmutableList<Optional<Value>> leftValues, final ImmutableList<Optional<Value>> rightValues) {
@@ -69,19 +69,19 @@ public class Elvis implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + lefts + "," + rights + ")";
+        return getClass().getSimpleName() + "(" + left + "," + right + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(lefts, ((Elvis)obj).lefts)
-            && Objects.equals(rights, ((Elvis)obj).rights);
+            && Objects.equals(left, ((Elvis)obj).left)
+            && Objects.equals(right, ((Elvis)obj).right);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), lefts, rights);
+        return Objects.hash(getClass(), left, right);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -34,27 +34,27 @@ import io.parsingdata.metal.encoding.Encoding;
  * A {@link ValueExpression} that implements the Elvis operator:
  * <pre>?:</pre>.
  * <p>
- * An Elvis expression has two operands: <code>left</code> and
- * <code>right</code> (both {@link ValueExpression}s). Both operands are
+ * An Elvis expression has two operands: <code>lefts</code> and
+ * <code>rights</code> (both {@link ValueExpression}s). Both operands are
  * evaluated. The return value is a list with the size of the longest list
  * returned by the two evaluations. At each index, the value at that index in
- * the result returned by evaluating <code>left</code> is placed, except if it
+ * the result returned by evaluating <code>lefts</code> is placed, except if it
  * does not exist or is {@link Optional#empty()}, in which case the value at
- * that index in the result returned by evaluating right is placed there.
+ * that index in the result returned by evaluating rights is placed there.
  */
 public class Elvis implements ValueExpression {
 
-    public final ValueExpression left;
-    public final ValueExpression right;
+    public final ValueExpression lefts;
+    public final ValueExpression rights;
 
-    public Elvis(final ValueExpression left, final ValueExpression right) {
-        this.left = checkNotNull(left, "left");
-        this.right = checkNotNull(right, "right");
+    public Elvis(final ValueExpression lefts, final ValueExpression rights) {
+        this.lefts = checkNotNull(lefts, "lefts");
+        this.rights = checkNotNull(rights, "rights");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return reverse(eval(new ImmutableList<>(), left.eval(parseState, encoding), right.eval(parseState, encoding)).computeResult());
+        return reverse(eval(new ImmutableList<>(), lefts.eval(parseState, encoding), rights.eval(parseState, encoding)).computeResult());
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> result, final ImmutableList<Optional<Value>> leftValues, final ImmutableList<Optional<Value>> rightValues) {
@@ -69,19 +69,19 @@ public class Elvis implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + left + "," + right + ")";
+        return getClass().getSimpleName() + "(" + lefts + "," + rights + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(left, ((Elvis)obj).left)
-            && Objects.equals(right, ((Elvis)obj).right);
+            && Objects.equals(lefts, ((Elvis)obj).lefts)
+            && Objects.equals(rights, ((Elvis)obj).rights);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), left, right);
+        return Objects.hash(getClass(), lefts, rights);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Elvis.java
@@ -34,13 +34,13 @@ import io.parsingdata.metal.encoding.Encoding;
  * A {@link ValueExpression} that implements the Elvis operator:
  * <pre>?:</pre>.
  * <p>
- * An Elvis expression has two operands: <code>lefts</code> and
- * <code>rights</code> (both {@link ValueExpression}s). Both operands are
- * evaluated. The return value is a list with the size of the longest list
- * returned by the two evaluations. At each index, the value at that index in
- * the result returned by evaluating <code>lefts</code> is placed, except if it
- * does not exist or is {@link Optional#empty()}, in which case the value at
- * that index in the result returned by evaluating rights is placed there.
+ * An Elvis expression has two fields: <code>lefts</code> and <code>rights</code>
+ * (both {@link ValueExpression}s). Both fields are evaluated. The return value is
+ * a list with the size of the longest list returned by the two evaluations. At
+ * each index, the value at that index in the result returned by evaluating
+ * <code>lefts</code> is placed, except if it does not exist or is {@link Optional#empty()},
+ * in which case the value at that index in the result returned by evaluating rights is
+ * placed there.
  */
 public class Elvis implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -33,12 +33,12 @@ import io.parsingdata.metal.encoding.Encoding;
  * A {@link ValueExpression} that expands a result by copying and concatenating
  * it a specified amount of times.
  * <p>
- * An Expand expression has two operands: <code>bases</code> and
- * <code>count</code> (both {@link ValueExpression}s). Both operands are
- * evaluated. An <code>IllegalStateException</code> is thrown if evaluating
- * <code>count</code> yields more than a single value. Multiple copies of the
- * result of evaluating <code>bases</code> are concatenated. The amount of copies
- * equals the result of evaluating <code>count</code>.
+ * An Expand expression has two fields: <code>bases</code> and <code>count</code>
+ * (both {@link ValueExpression}s). Both fields are evaluated. An
+ * <code>IllegalStateException</code> is thrown if evaluating <code>count</code> yields
+ * more than a single value. Multiple copies of the result of evaluating
+ * <code>bases</code> are concatenated. The amount of copies equals the result of
+ * evaluating <code>count</code>.
  */
 public class Expand implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -33,8 +33,8 @@ import io.parsingdata.metal.encoding.Encoding;
  * A {@link ValueExpression} that expands a result by copying and concatenating
  * it a specified amount of times.
  * <p>
- * An Expand expression has two fields: <code>bases</code> and <code>count</code>
- * (both {@link ValueExpression}s). Both fields are evaluated. An
+ * An Expand expression has two operands: <code>bases</code> and <code>count</code>
+ * (both {@link ValueExpression}s). Both operands are evaluated. An
  * <code>IllegalStateException</code> is thrown if evaluating <code>count</code> yields
  * more than a single value. Multiple copies of the result of evaluating
  * <code>bases</code> are concatenated. The amount of copies equals the result of

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -33,58 +33,58 @@ import io.parsingdata.metal.encoding.Encoding;
  * A {@link ValueExpression} that expands a result by copying and concatenating
  * it a specified amount of times.
  * <p>
- * An Expand expression has two operands: <code>base</code> and
+ * An Expand expression has two operands: <code>bases</code> and
  * <code>count</code> (both {@link ValueExpression}s). Both operands are
  * evaluated. An <code>IllegalStateException</code> is thrown if evaluating
  * <code>count</code> yields more than a single value. Multiple copies of the
- * result of evaluating <code>base</code> are concatenated. The amount of copies
+ * result of evaluating <code>bases</code> are concatenated. The amount of copies
  * equals the result of evaluating <code>count</code>.
  */
 public class Expand implements ValueExpression {
 
-    public final ValueExpression base;
+    public final ValueExpression bases;
     public final ValueExpression count;
 
-    public Expand(final ValueExpression base, final ValueExpression count) {
-        this.base = checkNotNull(base, "base");
+    public Expand(final ValueExpression bases, final ValueExpression count) {
+        this.bases = checkNotNull(bases, "bases");
         this.count = checkNotNull(count, "count");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> base = this.base.eval(parseState, encoding);
-        if (base.isEmpty()) {
-            return base;
+        final ImmutableList<Optional<Value>> evaluatedBases = bases.eval(parseState, encoding);
+        if (evaluatedBases.isEmpty()) {
+            return evaluatedBases;
         }
-        final ImmutableList<Optional<Value>> count = this.count.eval(parseState, encoding);
-        if (count.size != 1 || !count.head.isPresent()) {
+        final ImmutableList<Optional<Value>> evaluatedCount = count.eval(parseState, encoding);
+        if (evaluatedCount.size != 1 || !evaluatedCount.head.isPresent()) {
             throw new IllegalArgumentException("Count must evaluate to a single non-empty value.");
         }
-        return expand(base, count.head.get().asNumeric().intValueExact(), new ImmutableList<>()).computeResult();
+        return expand(evaluatedBases, evaluatedCount.head.get().asNumeric().intValueExact(), new ImmutableList<>()).computeResult();
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> expand(final ImmutableList<Optional<Value>> base, final int count, final ImmutableList<Optional<Value>> aggregate) {
-        if (count < 1) {
+    private Trampoline<ImmutableList<Optional<Value>>> expand(final ImmutableList<Optional<Value>> baseValues, final int countValue, final ImmutableList<Optional<Value>> aggregate) {
+        if (countValue < 1) {
             return complete(() -> aggregate);
         }
-        return intermediate(() -> expand(base, count - 1, aggregate.add(base)));
+        return intermediate(() -> expand(baseValues, countValue - 1, aggregate.add(baseValues)));
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + base + "," + count + ")";
+        return getClass().getSimpleName() + "(" + bases + "," + count + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(base, ((Expand)obj).base)
+            && Objects.equals(bases, ((Expand)obj).bases)
             && Objects.equals(count, ((Expand)obj).count);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), base, count);
+        return Objects.hash(getClass(), bases, count);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -33,7 +33,7 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * Base class for {@link ValueExpression} implementations of the Fold operation.
  * <p>
- * Fold has three fields: <code>values</code> (a {@link ValueExpression}),
+ * Fold has three operands: <code>values</code> (a {@link ValueExpression}),
  * <code>reducer</code> (a {@link BinaryOperator}) and <code>initial</code> (a
  * {@link ValueExpression}). First <code>initial</code> is evaluated. If it does not
  * return a single value, the final result is an empty list. Next, <code>values</code>

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -58,18 +58,18 @@ public abstract class Fold implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> initial = this.initial != null ? this.initial.eval(parseState, encoding) : new ImmutableList<>();
-        if (initial.size > 1) {
+        final ImmutableList<Optional<Value>> evaluatedInitial = initial != null ? initial.eval(parseState, encoding) : new ImmutableList<>();
+        if (evaluatedInitial.size > 1) {
             return new ImmutableList<>();
         }
-        final ImmutableList<Optional<Value>> values = prepareValues(this.values.eval(parseState, encoding));
-        if (values.isEmpty() || containsEmpty(values).computeResult()) {
-            return initial;
+        final ImmutableList<Optional<Value>> preparedValues = prepareValues(this.values.eval(parseState, encoding));
+        if (preparedValues.isEmpty() || containsEmpty(preparedValues).computeResult()) {
+            return evaluatedInitial;
         }
-        if (!initial.isEmpty()) {
-            return ImmutableList.create(fold(parseState, encoding, reducer, initial.head, values).computeResult());
+        if (!evaluatedInitial.isEmpty()) {
+            return ImmutableList.create(fold(parseState, encoding, reducer, evaluatedInitial.head, preparedValues).computeResult());
         }
-        return ImmutableList.create(fold(parseState, encoding, reducer, values.head, values.tail).computeResult());
+        return ImmutableList.create(fold(parseState, encoding, reducer, preparedValues.head, preparedValues.tail).computeResult());
     }
 
     private Trampoline<Optional<Value>> fold(final ParseState parseState, final Encoding encoding, final BinaryOperator<ValueExpression> reducer, final Optional<Value> head, final ImmutableList<Optional<Value>> tail) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Fold.java
@@ -31,18 +31,17 @@ import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
- * Base class for {@link ValueExpression} implementations of the Fold
- * operation.
+ * Base class for {@link ValueExpression} implementations of the Fold operation.
  * <p>
- * Fold has three operands: <code>values</code> (a {@link ValueExpression}),
+ * Fold has three fields: <code>values</code> (a {@link ValueExpression}),
  * <code>reducer</code> (a {@link BinaryOperator}) and <code>initial</code> (a
- * {@link ValueExpression}). First <code>initial</code> is evaluated. If it
- * does not return a single value, the final result is an empty list. Next,
- * <code>values</code> is evaluated and its result is passed to the abstract
- * {@link #prepareValues(ImmutableList)} method. The returned list is prefixed
- * by the value returned by evaluating <code>initial</code>. On this list, the
- * <code>reducer</code> is applied to the first two values until a single
- * value remains, which is then returned.
+ * {@link ValueExpression}). First <code>initial</code> is evaluated. If it does not
+ * return a single value, the final result is an empty list. Next, <code>values</code>
+ * is evaluated and its result is passed to the abstract
+ * {@link #prepareValues(ImmutableList)} method. The returned list is prefixed by the
+ * value returned by evaluating <code>initial</code>. On this list, the
+ * <code>reducer</code> is applied to the first two values until a single value remains,
+ * which is then returned.
  */
 public abstract class Fold implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -18,6 +18,7 @@ package io.parsingdata.metal.expression.value;
 
 import static java.math.BigInteger.ZERO;
 
+import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
 import java.util.Objects;
@@ -38,15 +39,15 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public class FoldCat implements ValueExpression {
 
-    public final ValueExpression operand;
+    public final ValueExpression operands;
 
-    public FoldCat(final ValueExpression operand) {
-        this.operand = operand;
+    public FoldCat(final ValueExpression operands) {
+        this.operands = checkNotNull(operands, "operands");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return ConcatenatedValueSource.create(operand.eval(parseState, encoding))
+        return ConcatenatedValueSource.create(operands.eval(parseState, encoding))
             .flatMap(source -> createFromSource(source, ZERO, source.length))
             .map(slice -> new ImmutableList<Optional<Value>>().add(Optional.of(new Value(slice, encoding))))
             .orElseGet(() -> ImmutableList.create(Optional.empty()));
@@ -54,18 +55,18 @@ public class FoldCat implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
+        return getClass().getSimpleName() + "(" + operands + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((FoldCat)obj).operand);
+            && Objects.equals(operands, ((FoldCat)obj).operands);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operand);
+        return Objects.hash(getClass(), operands);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -39,15 +39,15 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public class FoldCat implements ValueExpression {
 
-    public final ValueExpression operands;
+    public final ValueExpression operand;
 
-    public FoldCat(final ValueExpression operands) {
-        this.operands = checkNotNull(operands, "operands");
+    public FoldCat(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return ConcatenatedValueSource.create(operands.eval(parseState, encoding))
+        return ConcatenatedValueSource.create(operand.eval(parseState, encoding))
             .flatMap(source -> createFromSource(source, ZERO, source.length))
             .map(slice -> new ImmutableList<Optional<Value>>().add(Optional.of(new Value(slice, encoding))))
             .orElseGet(() -> ImmutableList.create(Optional.empty()));
@@ -55,18 +55,18 @@ public class FoldCat implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operands + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operands, ((FoldCat)obj).operands);
+            && Objects.equals(operand, ((FoldCat)obj).operand);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operands);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
@@ -16,6 +16,7 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.data.Selection.reverse;
 
 import java.util.Objects;
@@ -38,7 +39,7 @@ public class Reverse implements ValueExpression {
     public final ValueExpression values;
 
     public Reverse(final ValueExpression values) {
-        this.values = values;
+        this.values = checkNotNull(values, "values");
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
@@ -30,7 +30,7 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * A {@link ValueExpression} that reverses the results of its operand.
  * <p>
- * Reverse has a single field <code>values</code> (a {@link ValueExpression}).
+ * Reverse has a single operand <code>values</code> (a {@link ValueExpression}).
  * When evaluated, it evaluates <code>values</code> and then reverses and returns
  * the result.
  */

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Reverse.java
@@ -30,9 +30,9 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * A {@link ValueExpression} that reverses the results of its operand.
  * <p>
- * Reverse has a single operand <code>values</code> (a
- * {@link ValueExpression}). When evaluated, it evaluates <code>values</code>
- * and then reverses and returns the result.
+ * Reverse has a single field <code>values</code> (a {@link ValueExpression}).
+ * When evaluated, it evaluates <code>values</code> and then reverses and returns
+ * the result.
  */
 public class Reverse implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -33,16 +33,13 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * Base class for {@link ValueExpression}s with one operand.
  * <p>
- * A UnaryValueExpression implements a ValueExpression that has a single
- * <code>operands</code> field (a {@link ValueExpression}).
- * <code>operands</code>is first evaluated. If it evaluates to
- * {@link Optional#empty()}, the result of the ValueExpression itself will be
- * that as well.
+ * A UnaryValueExpression implements a ValueExpression that has a single <code>operands</code>
+ * field (a {@link ValueExpression}). <code>operands</code> is first evaluated. If it evaluates
+ * to {@link Optional#empty()}, the result of the ValueExpression itself will be that as well.
  * <p>
- * To implement a UnaryValueExpression, only the
- * {@link #eval(Value, ParseState, Encoding)} must be implemented, handling
- * the case of evaluating one value. This base class takes care of evaluating
- * the operand and handling list semantics.
+ * To implement a UnaryValueExpression, only the {@link #eval(Value, ParseState, Encoding)}
+ * must be implemented, handling the case of evaluating one value. This base class takes care
+ * of evaluating the field and handling list semantics.
  *
  * @see BinaryValueExpression
  */

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -34,7 +34,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * Base class for {@link ValueExpression}s with one operand.
  * <p>
  * A UnaryValueExpression implements a ValueExpression that has a single <code>operands</code>
- * field (a {@link ValueExpression}). <code>operands</code> is first evaluated. If it evaluates
+ * (a {@link ValueExpression}). <code>operands</code> is first evaluated. If it evaluates
  * to {@link Optional#empty()}, the result of the ValueExpression itself will be that as well.
  * <p>
  * To implement a UnaryValueExpression, only the {@link #eval(Value, ParseState, Encoding)}

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -33,10 +33,11 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * Base class for {@link ValueExpression}s with one operand.
  * <p>
- * A UnaryValueExpression implements a ValueExpression that has one
- * <code>operand</code> (a {@link ValueExpression}). The operand is first
- * evaluated. If it evaluates to {@link Optional#empty()}, the result of the
- * ValueExpression itself will be that as well.
+ * A UnaryValueExpression implements a ValueExpression that has a single
+ * <code>operands</code> field (a {@link ValueExpression}).
+ * <code>operands</code>is first evaluated. If it evaluates to
+ * {@link Optional#empty()}, the result of the ValueExpression itself will be
+ * that as well.
  * <p>
  * To implement a UnaryValueExpression, only the
  * {@link #eval(Value, ParseState, Encoding)} must be implemented, handling
@@ -47,40 +48,40 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public abstract class UnaryValueExpression implements ValueExpression {
 
-    public final ValueExpression operand;
+    public final ValueExpression operands;
 
-    public UnaryValueExpression(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+    public UnaryValueExpression(final ValueExpression operands) {
+        this.operands = checkNotNull(operands, "operands");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return reverse(eval(operand.eval(parseState, encoding), parseState, encoding, new ImmutableList<>()).computeResult());
+        return reverse(eval(operands.eval(parseState, encoding), parseState, encoding, new ImmutableList<>()).computeResult());
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ParseState parseState, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
-        if (values.isEmpty()) {
+    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> evaluatedValues, final ParseState parseState, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
+        if (evaluatedValues.isEmpty()) {
             return complete(() -> result);
         }
-        return intermediate(() -> eval(values.tail, parseState, encoding, result.add(values.head.flatMap(value -> eval(value, parseState, encoding)))));
+        return intermediate(() -> eval(evaluatedValues.tail, parseState, encoding, result.add(evaluatedValues.head.flatMap(value -> eval(value, parseState, encoding)))));
     }
 
     public abstract Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding);
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
+        return getClass().getSimpleName() + "(" + operands + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((UnaryValueExpression)obj).operand);
+            && Objects.equals(operands, ((UnaryValueExpression)obj).operands);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operand);
+        return Objects.hash(getClass(), operands);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -33,8 +33,8 @@ import io.parsingdata.metal.encoding.Encoding;
 /**
  * Base class for {@link ValueExpression}s with one operand.
  * <p>
- * A UnaryValueExpression implements a ValueExpression that has a single <code>operands</code>
- * (a {@link ValueExpression}). <code>operands</code> is first evaluated. If it evaluates
+ * A UnaryValueExpression implements a ValueExpression that has a single <code>operand</code>
+ * (a {@link ValueExpression}). <code>operand</code> is first evaluated. If it evaluates
  * to {@link Optional#empty()}, the result of the ValueExpression itself will be that as well.
  * <p>
  * To implement a UnaryValueExpression, only the {@link #eval(Value, ParseState, Encoding)}
@@ -45,15 +45,15 @@ import io.parsingdata.metal.encoding.Encoding;
  */
 public abstract class UnaryValueExpression implements ValueExpression {
 
-    public final ValueExpression operands;
+    public final ValueExpression operand;
 
-    public UnaryValueExpression(final ValueExpression operands) {
-        this.operands = checkNotNull(operands, "operands");
+    public UnaryValueExpression(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        return reverse(eval(operands.eval(parseState, encoding), parseState, encoding, new ImmutableList<>()).computeResult());
+        return reverse(eval(operand.eval(parseState, encoding), parseState, encoding, new ImmutableList<>()).computeResult());
     }
 
     private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> evaluatedValues, final ParseState parseState, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
@@ -67,18 +67,18 @@ public abstract class UnaryValueExpression implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operands + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operands, ((UnaryValueExpression)obj).operands);
+            && Objects.equals(operand, ((UnaryValueExpression)obj).operand);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operands);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/UnaryValueExpression.java
@@ -56,11 +56,11 @@ public abstract class UnaryValueExpression implements ValueExpression {
         return reverse(eval(operand.eval(parseState, encoding), parseState, encoding, new ImmutableList<>()).computeResult());
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> evaluatedValues, final ParseState parseState, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
-        if (evaluatedValues.isEmpty()) {
+    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> valuesList, final ParseState parseState, final Encoding encoding, final ImmutableList<Optional<Value>> result) {
+        if (valuesList.isEmpty()) {
             return complete(() -> result);
         }
-        return intermediate(() -> eval(evaluatedValues.tail, parseState, encoding, result.add(evaluatedValues.head.flatMap(value -> eval(value, parseState, encoding)))));
+        return intermediate(() -> eval(valuesList.tail, parseState, encoding, result.add(valuesList.head.flatMap(value -> eval(value, parseState, encoding)))));
     }
 
     public abstract Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding);

--- a/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/ValueExpression.java
@@ -26,12 +26,11 @@ import io.parsingdata.metal.encoding.Encoding;
  * Interface for all ValueExpression implementations.
  * <p>
  * A ValueExpression is an expression that is evaluated by executing its
- * {@link #eval(ParseState, Encoding)} method. It yields a list of
- * {@link Value} objects encapsulated in {@link Optional} objects (to guard
- * against <code>null</code>s).
+ * {@link #eval(ParseState, Encoding)} method. It yields a list of {@link Value} objects
+ * encapsulated in {@link Optional} objects (to guard against <code>null</code>s).
  * <p>
- * As context, it receives the current <code>parseState</code> object that as
- * well as the current <code>encoding</code> object.
+ * As context, it receives the current {@link ParseState} object that as well as
+ * the current {@link Encoding} object.
  */
 @FunctionalInterface
 public interface ValueExpression {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Add extends BinaryValueExpression {
 
-    public Add(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Add(final ValueExpression augends, final ValueExpression addends) {
+        super(augends, addends);
     }
 
     @Override
-    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
-        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().add(rightValue.asNumeric()), encoding));
+    public Optional<Value> eval(final Value augend, final Value addend, final ParseState parseState, final Encoding encoding) {
+        return Optional.of(ConstantFactory.createFromNumeric(augend.asNumeric().add(addend.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
@@ -30,8 +30,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Add extends BinaryValueExpression {
 
-    public Add(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public Add(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Add.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Add extends BinaryValueExpression {
 
-    public Add(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Add(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().add(right.asNumeric()), encoding));
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().add(rightValue.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
@@ -30,21 +30,21 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link BinaryValueExpression} that implements integer division.
  * <p>
- * If the value of the <code>right</code> operand is equal to zero, the result
- * is empty.
+ * If one of the values resulting from evaluating <code>rights</code> is equal
+ * to zero, the associated result will be empty.
  */
 public class Div extends BinaryValueExpression {
 
-    public Div(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Div(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        if (right.asNumeric().equals(ZERO)) {
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        if (rightValue.asNumeric().equals(ZERO)) {
             return Optional.empty();
         }
-        return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().divide(right.asNumeric()), encoding));
+        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().divide(rightValue.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
@@ -30,21 +30,21 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link BinaryValueExpression} that implements integer division.
  * <p>
- * If one of the values resulting from evaluating <code>right</code> is equal
+ * If one of the values resulting from evaluating <code>divisors</code> is equal
  * to zero, the associated result will be empty.
  */
 public class Div extends BinaryValueExpression {
 
-    public Div(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Div(final ValueExpression dividends, final ValueExpression divisors) {
+        super(dividends, divisors);
     }
 
     @Override
-    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
-        if (rightValue.asNumeric().equals(ZERO)) {
+    public Optional<Value> eval(final Value dividend, final Value divisor, final ParseState parseState, final Encoding encoding) {
+        if (divisor.asNumeric().equals(ZERO)) {
             return Optional.empty();
         }
-        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().divide(rightValue.asNumeric()), encoding));
+        return Optional.of(ConstantFactory.createFromNumeric(dividend.asNumeric().divide(divisor.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Div.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link BinaryValueExpression} that implements integer division.
  * <p>
- * If one of the values resulting from evaluating <code>rights</code> is equal
+ * If one of the values resulting from evaluating <code>right</code> is equal
  * to zero, the associated result will be empty.
  */
 public class Div extends BinaryValueExpression {
 
-    public Div(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public Div(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
@@ -30,21 +30,21 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link BinaryValueExpression} that implements the modulo operation.
  * <p>
- * If one of the values resulting from evaluating <code>right</code> is equal
+ * If one of the values resulting from evaluating <code>divisors</code> is equal
  * to or small than zero, the associated result will be empty.
  */
 public class Mod extends BinaryValueExpression {
 
-    public Mod(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Mod(final ValueExpression dividends, final ValueExpression divisors) {
+        super(dividends, divisors);
     }
 
     @Override
-    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
-        if (rightValue.asNumeric().compareTo(ZERO) <= 0) {
+    public Optional<Value> eval(final Value dividend, final Value divisor, final ParseState parseState, final Encoding encoding) {
+        if (divisor.asNumeric().compareTo(ZERO) <= 0) {
             return Optional.empty();
         }
-        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().mod(rightValue.asNumeric()), encoding));
+        return Optional.of(ConstantFactory.createFromNumeric(dividend.asNumeric().mod(divisor.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
@@ -30,21 +30,21 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link BinaryValueExpression} that implements the modulo operation.
  * <p>
- * If the value of the <code>right</code> operand is equal to or smaller than
- * zero, the result is empty.
+ * If one of the values resulting from evaluating <code>rights</code> is equal
+ * to or small than zero, the associated result will be empty.
  */
 public class Mod extends BinaryValueExpression {
 
-    public Mod(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Mod(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        if (right.asNumeric().compareTo(ZERO) <= 0) {
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        if (rightValue.asNumeric().compareTo(ZERO) <= 0) {
             return Optional.empty();
         }
-        return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().mod(right.asNumeric()), encoding));
+        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().mod(rightValue.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mod.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link BinaryValueExpression} that implements the modulo operation.
  * <p>
- * If one of the values resulting from evaluating <code>rights</code> is equal
+ * If one of the values resulting from evaluating <code>right</code> is equal
  * to or small than zero, the associated result will be empty.
  */
 public class Mod extends BinaryValueExpression {
 
-    public Mod(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public Mod(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
@@ -30,8 +30,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Mul extends BinaryValueExpression {
 
-    public Mul(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public Mul(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Mul extends BinaryValueExpression {
 
-    public Mul(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Mul(final ValueExpression multipliers, final ValueExpression multiplicands) {
+        super(multipliers, multiplicands);
     }
 
     @Override
-    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
-        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().multiply(rightValue.asNumeric()), encoding));
+    public Optional<Value> eval(final Value multiplier, final Value multiplicand, final ParseState parseState, final Encoding encoding) {
+        return Optional.of(ConstantFactory.createFromNumeric(multiplier.asNumeric().multiply(multiplicand.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Mul.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Mul extends BinaryValueExpression {
 
-    public Mul(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Mul(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().multiply(right.asNumeric()), encoding));
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().multiply(rightValue.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
@@ -30,8 +30,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Neg extends UnaryValueExpression {
 
-    public Neg(final ValueExpression operand) {
-        super(operand);
+    public Neg(final ValueExpression operands) {
+        super(operands);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Neg.java
@@ -30,8 +30,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Neg extends UnaryValueExpression {
 
-    public Neg(final ValueExpression operands) {
-        super(operands);
+    public Neg(final ValueExpression operand) {
+        super(operand);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Sub extends BinaryValueExpression {
 
-    public Sub(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Sub(final ValueExpression minuends, final ValueExpression subtrahends) {
+        super(minuends, subtrahends);
     }
 
     @Override
-    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
-        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().subtract(rightValue.asNumeric()), encoding));
+    public Optional<Value> eval(final Value minuend, final Value subtrahend, final ParseState parseState, final Encoding encoding) {
+        return Optional.of(ConstantFactory.createFromNumeric(minuend.asNumeric().subtract(subtrahend.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
@@ -30,13 +30,13 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Sub extends BinaryValueExpression {
 
-    public Sub(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Sub(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        return Optional.of(ConstantFactory.createFromNumeric(left.asNumeric().subtract(right.asNumeric()), encoding));
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        return Optional.of(ConstantFactory.createFromNumeric(leftValue.asNumeric().subtract(rightValue.asNumeric()), encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/arithmetic/Sub.java
@@ -30,8 +30,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Sub extends BinaryValueExpression {
 
-    public Sub(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public Sub(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
@@ -31,8 +31,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class And extends BinaryValueExpression {
 
-    public And(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public And(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/And.java
@@ -31,15 +31,15 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class And extends BinaryValueExpression {
 
-    public And(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public And(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        final BitSet leftBits = left.asBitSet();
-        leftBits.and(right.asBitSet());
-        return Optional.of(ConstantFactory.createFromBitSet(leftBits, left.getValue().length, encoding));
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        final BitSet leftBits = leftValue.asBitSet();
+        leftBits.and(rightValue.asBitSet());
+        return Optional.of(ConstantFactory.createFromBitSet(leftBits, leftValue.getValue().length, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
@@ -31,8 +31,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Not extends UnaryValueExpression {
 
-    public Not(final ValueExpression operand) {
-        super(operand);
+    public Not(final ValueExpression operands) {
+        super(operands);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Not.java
@@ -31,8 +31,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Not extends UnaryValueExpression {
 
-    public Not(final ValueExpression operands) {
-        super(operands);
+    public Not(final ValueExpression operand) {
+        super(operand);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
@@ -31,15 +31,15 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Or extends BinaryValueExpression {
 
-    public Or(final ValueExpression left, final ValueExpression right) {
-        super(left, right);
+    public Or(final ValueExpression lefts, final ValueExpression rights) {
+        super(lefts, rights);
     }
 
     @Override
-    public Optional<Value> eval(final Value left, final Value right, final ParseState parseState, final Encoding encoding) {
-        final BitSet leftBits = left.asBitSet();
-        leftBits.or(right.asBitSet());
-        final int minSize = Math.max(left.getValue().length, right.getValue().length);
+    public Optional<Value> eval(final Value leftValue, final Value rightValue, final ParseState parseState, final Encoding encoding) {
+        final BitSet leftBits = leftValue.asBitSet();
+        leftBits.or(rightValue.asBitSet());
+        final int minSize = Math.max(leftValue.getValue().length, rightValue.getValue().length);
         return Optional.of(ConstantFactory.createFromBitSet(leftBits, minSize, encoding));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/Or.java
@@ -31,8 +31,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Or extends BinaryValueExpression {
 
-    public Or(final ValueExpression lefts, final ValueExpression rights) {
-        super(lefts, rights);
+    public Or(final ValueExpression left, final ValueExpression right) {
+        super(left, right);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
@@ -32,8 +32,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class ShiftLeft extends BinaryValueExpression {
 
-    public ShiftLeft(final ValueExpression operands, final ValueExpression positions) {
-        super(operands, positions);
+    public ShiftLeft(final ValueExpression operand, final ValueExpression positions) {
+        super(operand, positions);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftLeft.java
@@ -32,14 +32,14 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class ShiftLeft extends BinaryValueExpression {
 
-    public ShiftLeft(final ValueExpression operand, final ValueExpression positions) {
-        super(operand, positions);
+    public ShiftLeft(final ValueExpression operands, final ValueExpression positions) {
+        super(operands, positions);
     }
 
     @Override
-    public Optional<Value> eval(final Value operand, final Value positions, final ParseState parseState, final Encoding encoding) {
-        final BitSet leftBits = operand.asBitSet();
-        final int shiftLeft = positions.asNumeric().intValueExact();
+    public Optional<Value> eval(final Value operandValue, final Value positionsValue, final ParseState parseState, final Encoding encoding) {
+        final BitSet leftBits = operandValue.asBitSet();
+        final int shiftLeft = positionsValue.asNumeric().intValueExact();
         final int bitCount = leftBits.length() + shiftLeft;
         final BitSet out = new BitSet(bitCount);
         for (int i = leftBits.nextSetBit(0); i >= 0; i = leftBits.nextSetBit(i+1)) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
@@ -32,15 +32,15 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class ShiftRight extends BinaryValueExpression {
 
-    public ShiftRight(final ValueExpression operand, final ValueExpression positions) {
-        super(operand, positions);
+    public ShiftRight(final ValueExpression operands, final ValueExpression positions) {
+        super(operands, positions);
     }
 
     @Override
-    public Optional<Value> eval(final Value operand, final Value positions, final ParseState parseState, final Encoding encoding) {
-        final BitSet leftBits = operand.asBitSet();
-        final int shift = positions.asNumeric().intValueExact();
-        return Optional.of(ConstantFactory.createFromBitSet(leftBits.get(shift, Math.max(shift, leftBits.length())), operand.getValue().length, encoding));
+    public Optional<Value> eval(final Value operandValue, final Value positionsValue, final ParseState parseState, final Encoding encoding) {
+        final BitSet leftBits = operandValue.asBitSet();
+        final int shift = positionsValue.asNumeric().intValueExact();
+        return Optional.of(ConstantFactory.createFromBitSet(leftBits.get(shift, Math.max(shift, leftBits.length())), operandValue.getValue().length, encoding));
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/bitwise/ShiftRight.java
@@ -32,8 +32,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class ShiftRight extends BinaryValueExpression {
 
-    public ShiftRight(final ValueExpression operands, final ValueExpression positions) {
-        super(operands, positions);
+    public ShiftRight(final ValueExpression operand, final ValueExpression positions) {
+        super(operand, positions);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -32,7 +32,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the amount of {@link Value}s
- * returned by evaluating its <code>operands</code> field.
+ * returned by evaluating its <code>operands</code>.
  */
 public class Count implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -32,19 +32,19 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the amount of {@link Value}s
- * returned by evaluating its <code>operands</code>.
+ * returned by evaluating its <code>operand</code>.
  */
 public class Count implements ValueExpression {
 
-    public final ValueExpression operands;
+    public final ValueExpression operand;
 
-    public Count(final ValueExpression operands) {
-        this.operands = checkNotNull(operands, "operands");
+    public Count(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> evaluatedOperands = operands.eval(parseState, encoding);
+        final ImmutableList<Optional<Value>> evaluatedOperands = operand.eval(parseState, encoding);
         return ImmutableList.create(Optional.of(fromNumeric(evaluatedOperands.size)));
     }
 
@@ -54,18 +54,18 @@ public class Count implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operands + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operands, ((Count)obj).operands);
+            && Objects.equals(operand, ((Count)obj).operand);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operands);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -32,20 +32,20 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the amount of {@link Value}s
- * returned by evaluating its <code>operand</code>.
+ * returned by evaluating its <code>operands</code> field.
  */
 public class Count implements ValueExpression {
 
-    public final ValueExpression operand;
+    public final ValueExpression operands;
 
-    public Count(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+    public Count(final ValueExpression operands) {
+        this.operands = checkNotNull(operands, "operands");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> values = operand.eval(parseState, encoding);
-        return ImmutableList.create(Optional.of(fromNumeric(values.size)));
+        final ImmutableList<Optional<Value>> evaluatedOperands = operands.eval(parseState, encoding);
+        return ImmutableList.create(Optional.of(fromNumeric(evaluatedOperands.size)));
     }
 
     private static Value fromNumeric(final long length) {
@@ -54,18 +54,18 @@ public class Count implements ValueExpression {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
+        return getClass().getSimpleName() + "(" + operands + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((Count)obj).operand);
+            && Objects.equals(operands, ((Count)obj).operands);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operand);
+        return Objects.hash(getClass(), operands);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -44,8 +44,8 @@ public class Count implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> evaluatedOperands = operand.eval(parseState, encoding);
-        return ImmutableList.create(Optional.of(fromNumeric(evaluatedOperands.size)));
+        final ImmutableList<Optional<Value>> evaluatedOperand = operand.eval(parseState, encoding);
+        return ImmutableList.create(Optional.of(fromNumeric(evaluatedOperand.size)));
     }
 
     private static Value fromNumeric(final long length) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
@@ -47,7 +47,7 @@ import io.parsingdata.metal.token.While;
  * iterable {@link Token} (when {@link Token#isIterable()} returns true, e.g. when
  * inside a {@link Rep}, {@link RepN}) or {@link While}).
  *
- * The <code>level</code> field must evaluate to a single value that represents the
+ * The <code>level</code> operand must evaluate to a single value that represents the
  * relative nesting level from the current parsing position in the {@link ParseState}.
  */
 public class CurrentIteration implements ValueExpression {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
@@ -46,6 +46,9 @@ import io.parsingdata.metal.token.While;
  * A {@link ValueExpression} that represents the zero-based current iteration in an
  * iterable {@link Token} (when {@link Token#isIterable()} returns true, e.g. when
  * inside a {@link Rep}, {@link RepN}) or {@link While}).
+ *
+ * The <code>level</code> field must evaluate to a single value that represents the
+ * relative nesting level from the current parsing position in the {@link ParseState}.
  */
 public class CurrentIteration implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
@@ -43,7 +43,7 @@ import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.While;
 
 /**
- * A {@link ValueExpression} that represents the 0-based current iteration in an
+ * A {@link ValueExpression} that represents the zero-based current iteration in an
  * iterable {@link Token} (when {@link Token#isIterable()} returns true, e.g. when
  * inside a {@link Rep}, {@link RepN}) or {@link While}).
  */
@@ -61,11 +61,11 @@ public class CurrentIteration implements ValueExpression {
     }
 
     private Optional<Value> getIteration(final ParseState parseState, final Encoding encoding) {
-        final BigInteger level = getLevel(parseState, encoding);
-        if (parseState.iterations.size <= level.longValue()) {
+        final BigInteger levelValue = getLevel(parseState, encoding);
+        if (parseState.iterations.size <= levelValue.longValue()) {
             return Optional.empty();
         }
-        return getIterationRecursive(parseState.iterations, level).computeResult();
+        return getIterationRecursive(parseState.iterations, levelValue).computeResult();
     }
 
     private BigInteger getLevel(final ParseState parseState, final Encoding encoding) {
@@ -76,11 +76,11 @@ public class CurrentIteration implements ValueExpression {
         return evaluatedLevel.head.get().asNumeric();
     }
 
-    private Trampoline<Optional<Value>> getIterationRecursive(final ImmutableList<ImmutablePair<Token, BigInteger>> iterations, final BigInteger level) {
-        if (level.compareTo(ZERO) == 0) {
+    private Trampoline<Optional<Value>> getIterationRecursive(final ImmutableList<ImmutablePair<Token, BigInteger>> iterations, final BigInteger levelValue) {
+        if (levelValue.compareTo(ZERO) == 0) {
             return complete(() -> Optional.of(createFromNumeric(iterations.head.right, DEFAULT_ENCODING)));
         }
-        return intermediate(() -> getIterationRecursive(iterations.tail, level.subtract(ONE)));
+        return intermediate(() -> getIterationRecursive(iterations.tail, levelValue.subtract(ONE)));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
@@ -29,8 +29,7 @@ import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link ValueExpression} that represents the current offset in the
- * {@link ParseState}.
+ * A {@link ValueExpression} that represents the current offset in the {@link ParseState}.
  */
 public class CurrentOffset implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -33,40 +33,40 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the first {@link Value} returned
- * by evaluating its <code>operand</code>.
+ * by evaluating its <code>operands</code> field.
  */
 public class First implements ValueExpression {
 
-    public final ValueExpression operand;
+    public final ValueExpression operands;
 
-    public First(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+    public First(final ValueExpression operands) {
+        this.operands = checkNotNull(operands, "operands");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
-        return list.isEmpty() ? list : ImmutableList.create(getFirst(list).computeResult());
+        final ImmutableList<Optional<Value>> evaluatedOperands = operands.eval(parseState, encoding);
+        return evaluatedOperands.isEmpty() ? evaluatedOperands : ImmutableList.create(getFirst(evaluatedOperands).computeResult());
     }
 
-    private Trampoline<Optional<Value>> getFirst(final ImmutableList<Optional<Value>> values) {
-        return values.tail.isEmpty() ? complete(() -> values.head) : intermediate(() -> getFirst(values.tail));
+    private Trampoline<Optional<Value>> getFirst(final ImmutableList<Optional<Value>> operandsValues) {
+        return operandsValues.tail.isEmpty() ? complete(() -> operandsValues.head) : intermediate(() -> getFirst(operandsValues.tail));
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
+        return getClass().getSimpleName() + "(" + operands + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((First)obj).operand);
+            && Objects.equals(operands, ((First)obj).operands);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operand);
+        return Objects.hash(getClass(), operands);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -33,7 +33,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the first {@link Value} returned
- * by evaluating its <code>operands</code> field.
+ * by evaluating its <code>operands</code>.
  */
 public class First implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -33,40 +33,40 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the first {@link Value} returned
- * by evaluating its <code>operands</code>.
+ * by evaluating its <code>operand</code>.
  */
 public class First implements ValueExpression {
 
-    public final ValueExpression operands;
+    public final ValueExpression operand;
 
-    public First(final ValueExpression operands) {
-        this.operands = checkNotNull(operands, "operands");
+    public First(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> evaluatedOperands = operands.eval(parseState, encoding);
+        final ImmutableList<Optional<Value>> evaluatedOperands = operand.eval(parseState, encoding);
         return evaluatedOperands.isEmpty() ? evaluatedOperands : ImmutableList.create(getFirst(evaluatedOperands).computeResult());
     }
 
-    private Trampoline<Optional<Value>> getFirst(final ImmutableList<Optional<Value>> operandsValues) {
-        return operandsValues.tail.isEmpty() ? complete(() -> operandsValues.head) : intermediate(() -> getFirst(operandsValues.tail));
+    private Trampoline<Optional<Value>> getFirst(final ImmutableList<Optional<Value>> operandValues) {
+        return operandValues.tail.isEmpty() ? complete(() -> operandValues.head) : intermediate(() -> getFirst(operandValues.tail));
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operands + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operands, ((First)obj).operands);
+            && Objects.equals(operand, ((First)obj).operand);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operands);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -45,8 +45,8 @@ public class First implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> evaluatedOperands = operand.eval(parseState, encoding);
-        return evaluatedOperands.isEmpty() ? evaluatedOperands : ImmutableList.create(getFirst(evaluatedOperands).computeResult());
+        final ImmutableList<Optional<Value>> evaluatedOperand = operand.eval(parseState, encoding);
+        return evaluatedOperand.isEmpty() ? evaluatedOperand : ImmutableList.create(getFirst(evaluatedOperand).computeResult());
     }
 
     private Trampoline<Optional<Value>> getFirst(final ImmutableList<Optional<Value>> operandValues) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -30,36 +30,36 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the last {@link Value} returned
- * by evaluating its <code>operand</code>.
+ * by evaluating its <code>operands</code> field.
  */
 public class Last implements ValueExpression {
 
-    public final ValueExpression operand;
+    public final ValueExpression operands;
 
-    public Last(final ValueExpression operand) {
-        this.operand = checkNotNull(operand, "operand");
+    public Last(final ValueExpression operands) {
+        this.operands = checkNotNull(operands, "operands");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
+        final ImmutableList<Optional<Value>> list = operands.eval(parseState, encoding);
         return list.isEmpty() ? list : ImmutableList.create(list.head);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operand + ")";
+        return getClass().getSimpleName() + "(" + operands + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operand, ((Last)obj).operand);
+            && Objects.equals(operands, ((Last)obj).operands);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operand);
+        return Objects.hash(getClass(), operands);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -42,8 +42,8 @@ public class Last implements ValueExpression {
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
-        return list.isEmpty() ? list : ImmutableList.create(list.head);
+        final ImmutableList<Optional<Value>> evaluatedOperand = operand.eval(parseState, encoding);
+        return evaluatedOperand.isEmpty() ? evaluatedOperand : ImmutableList.create(evaluatedOperand.head);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -30,36 +30,36 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the last {@link Value} returned
- * by evaluating its <code>operands</code>.
+ * by evaluating its <code>operand</code>.
  */
 public class Last implements ValueExpression {
 
-    public final ValueExpression operands;
+    public final ValueExpression operand;
 
-    public Last(final ValueExpression operands) {
-        this.operands = checkNotNull(operands, "operands");
+    public Last(final ValueExpression operand) {
+        this.operand = checkNotNull(operand, "operand");
     }
 
     @Override
     public ImmutableList<Optional<Value>> eval(final ParseState parseState, final Encoding encoding) {
-        final ImmutableList<Optional<Value>> list = operands.eval(parseState, encoding);
+        final ImmutableList<Optional<Value>> list = operand.eval(parseState, encoding);
         return list.isEmpty() ? list : ImmutableList.create(list.head);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + operands + ")";
+        return getClass().getSimpleName() + "(" + operand + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return Util.notNullAndSameClass(this, obj)
-            && Objects.equals(operands, ((Last)obj).operands);
+            && Objects.equals(operand, ((Last)obj).operand);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getClass(), operands);
+        return Objects.hash(getClass(), operand);
     }
 
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -30,7 +30,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the last {@link Value} returned
- * by evaluating its <code>operands</code> field.
+ * by evaluating its <code>operands</code>.
  */
 public class Last implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
@@ -29,12 +29,12 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link UnaryValueExpression} that represents the sizes (in bytes) of all
- * {@link Value}s returned by evaluating its <code>operand</code>.
+ * {@link Value}s returned by evaluating its <code>operands</code> field.
  */
 public class Len extends UnaryValueExpression {
 
-    public Len(final ValueExpression operand) {
-        super(operand);
+    public Len(final ValueExpression operands) {
+        super(operands);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
@@ -29,7 +29,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link UnaryValueExpression} that represents the sizes (in bytes) of all
- * {@link Value}s returned by evaluating its <code>operands</code> field.
+ * {@link Value}s returned by evaluating its <code>operands</code>.
  */
 public class Len extends UnaryValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Len.java
@@ -29,12 +29,12 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link UnaryValueExpression} that represents the sizes (in bytes) of all
- * {@link Value}s returned by evaluating its <code>operands</code>.
+ * {@link Value}s returned by evaluating its <code>operand</code>.
  */
 public class Len extends UnaryValueExpression {
 
-    public Len(final ValueExpression operands) {
-        super(operands);
+    public Len(final ValueExpression operand) {
+        super(operand);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -39,7 +39,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link ValueExpression} that returns an indexed list of {@link Value}s.
  * <p>
- * The Nth ValueExpression has two fields, <code>values</code> and
+ * The Nth ValueExpression has two operands, <code>values</code> and
  * <code>indices</code> (both {@link ValueExpression}s). Both operands are
  * evaluated. Next, the resulting values of evaluating <code>indices</code> is
  * used as a list of integer indices into the results of evaluating

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -62,22 +62,22 @@ public class Nth implements ValueExpression {
         return reverse(eval(values.eval(parseState, encoding), indices.eval(parseState, encoding), new ImmutableList<>()).computeResult());
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ImmutableList<Optional<Value>> indicesValues, final ImmutableList<Optional<Value>> result) {
-        if (indicesValues.isEmpty()) {
+    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> valuesList, final ImmutableList<Optional<Value>> indicesList, final ImmutableList<Optional<Value>> result) {
+        if (indicesList.isEmpty()) {
             return complete(() -> result);
         }
-        final BigInteger valueCount = BigInteger.valueOf(values.size);
-        final Optional<Value> nextResult = indicesValues.head
+        final BigInteger valueCount = BigInteger.valueOf(valuesList.size);
+        final Optional<Value> nextResult = indicesList.head
             .filter(index -> index.asNumeric().compareTo(valueCount) < 0 && index.asNumeric().compareTo(ZERO) >= 0)
-            .flatMap(index -> nth(values, valueCount.subtract(index.asNumeric()).subtract(ONE)).computeResult());
-        return intermediate(() -> eval(values, indicesValues.tail, result.add(nextResult)));
+            .flatMap(index -> nth(valuesList, valueCount.subtract(index.asNumeric()).subtract(ONE)).computeResult());
+        return intermediate(() -> eval(valuesList, indicesList.tail, result.add(nextResult)));
     }
 
-    private Trampoline<Optional<Value>> nth(final ImmutableList<Optional<Value>> values, final BigInteger indexValue) {
+    private Trampoline<Optional<Value>> nth(final ImmutableList<Optional<Value>> valuesList, final BigInteger indexValue) {
         if (indexValue.equals(ZERO)) {
-            return complete(() -> values.head);
+            return complete(() -> valuesList.head);
         }
-        return intermediate(() -> nth(values.tail, indexValue.subtract(ONE)));
+        return intermediate(() -> nth(valuesList.tail, indexValue.subtract(ONE)));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -39,7 +39,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 /**
  * A {@link ValueExpression} that returns an indexed list of {@link Value}s.
  * <p>
- * The Nth ValueExpression has two operands, <code>values</code> and
+ * The Nth ValueExpression has two fields, <code>values</code> and
  * <code>indices</code> (both {@link ValueExpression}s). Both operands are
  * evaluated. Next, the resulting values of evaluating <code>indices</code> is
  * used as a list of integer indices into the results of evaluating

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -62,22 +62,22 @@ public class Nth implements ValueExpression {
         return reverse(eval(values.eval(parseState, encoding), indices.eval(parseState, encoding), new ImmutableList<>()).computeResult());
     }
 
-    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ImmutableList<Optional<Value>> indices, final ImmutableList<Optional<Value>> result) {
-        if (indices.isEmpty()) {
+    private Trampoline<ImmutableList<Optional<Value>>> eval(final ImmutableList<Optional<Value>> values, final ImmutableList<Optional<Value>> indicesValues, final ImmutableList<Optional<Value>> result) {
+        if (indicesValues.isEmpty()) {
             return complete(() -> result);
         }
         final BigInteger valueCount = BigInteger.valueOf(values.size);
-        final Optional<Value> nextResult = indices.head
+        final Optional<Value> nextResult = indicesValues.head
             .filter(index -> index.asNumeric().compareTo(valueCount) < 0 && index.asNumeric().compareTo(ZERO) >= 0)
             .flatMap(index -> nth(values, valueCount.subtract(index.asNumeric()).subtract(ONE)).computeResult());
-        return intermediate(() -> eval(values, indices.tail, result.add(nextResult)));
+        return intermediate(() -> eval(values, indicesValues.tail, result.add(nextResult)));
     }
 
-    private Trampoline<Optional<Value>> nth(final ImmutableList<Optional<Value>> values, final BigInteger index) {
-        if (index.equals(ZERO)) {
+    private Trampoline<Optional<Value>> nth(final ImmutableList<Optional<Value>> values, final BigInteger indexValue) {
+        if (indexValue.equals(ZERO)) {
             return complete(() -> values.head);
         }
-        return intermediate(() -> nth(values.tail, index.subtract(ONE)));
+        return intermediate(() -> nth(values.tail, indexValue.subtract(ONE)));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.Const;
 import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
@@ -32,7 +33,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * <p>
  * Only {@link ParseValue}s have an offset, since they originate in the input.
  * If a result does not have an offset (such as the {@link Value}s returned by
- * {@link io.parsingdata.metal.expression.value.Const}), empty is returned.
+ * {@link Const}), empty is returned.
  */
 public class Offset extends UnaryValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -28,7 +28,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the offset of the {@link Value}s
- * returned by evaluating its <code>operand</code>.
+ * returned by evaluating its <code>operands</code> field.
  * <p>
  * Only {@link ParseValue}s have an offset, since they originate in the input.
  * If a result does not have an offset (such as the {@link Value}s returned by
@@ -36,7 +36,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Offset extends UnaryValueExpression {
 
-    public Offset(final ValueExpression operand) { super(operand); }
+    public Offset(final ValueExpression operands) { super(operands); }
 
     @Override
     public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Offset.java
@@ -29,7 +29,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
  * A {@link ValueExpression} that represents the offset of the {@link Value}s
- * returned by evaluating its <code>operands</code> field.
+ * returned by evaluating its <code>operand</code>.
  * <p>
  * Only {@link ParseValue}s have an offset, since they originate in the input.
  * If a result does not have an offset (such as the {@link Value}s returned by
@@ -37,7 +37,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  */
 public class Offset extends UnaryValueExpression {
 
-    public Offset(final ValueExpression operands) { super(operands); }
+    public Offset(final ValueExpression operand) { super(operand); }
 
     @Override
     public Optional<Value> eval(final Value value, final ParseState parseState, final Encoding encoding) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -41,7 +41,7 @@ import io.parsingdata.metal.token.Token;
  * state that match a provided object. This class only has a private
  * constructor and instead must be instantiated through one of its subclasses:
  * {@link NameRef} (to match on name) and {@link DefinitionRef} (to match on
- * definition). The <code>limit</code> field is optional and is used to specify
+ * definition). The <code>limit</code> operand is optional and is used to specify
  * an upper bound to the amount of returned results.
  *
  * @param <T> The type of reference to match on.

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -41,8 +41,9 @@ import io.parsingdata.metal.token.Token;
  * state that match a provided object. This class only has a private
  * constructor and instead must be instantiated through one of its subclasses:
  * {@link NameRef} (to match on name) and {@link DefinitionRef} (to match on
- * definition). A limit argument may be provided to specify an upper bound to
- * the amount of returned results.
+ * definition). The <code>limit</code> field is optional and is used to specify
+ * an upper bound to the amount of returned results.
+ *
  * @param <T> The type of reference to match on.
  */
 public class Ref<T> implements ValueExpression {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -79,8 +79,8 @@ public class Ref<T> implements ValueExpression {
         return evalImpl(parseState, evaluatedLimit.head.get().asNumeric().intValueExact());
     }
 
-    private ImmutableList<Optional<Value>> evalImpl(final ParseState parseState, final int limit) {
-        return wrap(getAllValues(parseState.order, predicate, limit), new ImmutableList<Optional<Value>>()).computeResult();
+    private ImmutableList<Optional<Value>> evalImpl(final ParseState parseState, final int limitValue) {
+        return wrap(getAllValues(parseState.order, predicate, limitValue), new ImmutableList<Optional<Value>>()).computeResult();
     }
 
     private static <T, U extends T> Trampoline<ImmutableList<Optional<T>>> wrap(final ImmutableList<U> input, final ImmutableList<Optional<T>> output) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -28,8 +28,7 @@ import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link ValueExpression} that represents the
- * {@link io.parsingdata.metal.expression.value.Value} most recently added to
+ * A {@link ValueExpression} that represents the {@link Value} most recently added to
  * the parse state.
  */
 public class Self implements ValueExpression {

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -58,20 +58,20 @@ public class Def extends Token {
 
     @Override
     protected Optional<ParseState> parseImpl(final Environment environment) {
-        final ImmutableList<Optional<Value>> sizes = size.eval(environment.parseState, environment.encoding);
-        if (sizes.size != 1 || !sizes.head.isPresent()) {
+        final ImmutableList<Optional<Value>> evaluatedSize = size.eval(environment.parseState, environment.encoding);
+        if (evaluatedSize.size != 1 || !evaluatedSize.head.isPresent()) {
             return failure();
         }
-        return sizes.head
+        return evaluatedSize.head
             .filter(dataSize -> dataSize.asNumeric().compareTo(ZERO) != 0)
             .map(dataSize -> slice(environment, dataSize.asNumeric()))
             .orElseGet(() -> success(environment.parseState));
     }
 
-    private Optional<ParseState> slice(final Environment environment, final BigInteger dataSize) {
+    private Optional<ParseState> slice(final Environment environment, final BigInteger sizeValue) {
         return environment.parseState
-            .slice(dataSize)
-            .map(slice -> environment.parseState.add(new ParseValue(environment.scope, this, slice, environment.encoding)).seek(dataSize.add(environment.parseState.offset)))
+            .slice(sizeValue)
+            .map(slice -> environment.parseState.add(new ParseValue(environment.scope, this, slice, environment.encoding)).seek(sizeValue.add(environment.parseState.offset)))
             .orElseGet(Util::failure);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -53,12 +53,12 @@ public class RepN extends IterableToken {
 
     @Override
     protected Optional<ParseState> parseImpl(final Environment environment) {
-        final ImmutableList<Optional<Value>> counts = n.eval(environment.parseState, environment.encoding);
-        if (counts.size != 1 || !counts.head.isPresent()) {
+        final ImmutableList<Optional<Value>> evaluatedN = n.eval(environment.parseState, environment.encoding);
+        if (evaluatedN.size != 1 || !evaluatedN.head.isPresent()) {
             return failure();
         }
-        final BigInteger count = counts.head.get().asNumeric();
-        return parse(environment, env -> env.parseState.iterations.head.right.compareTo(count) >= 0, env -> failure());
+        final BigInteger nValue = evaluatedN.head.get().asNumeric();
+        return parse(environment, env -> env.parseState.iterations.head.right.compareTo(nValue) >= 0, env -> failure());
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Sub.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Sub.java
@@ -38,15 +38,15 @@ import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link Token} that specifies a token to be parsed at a specific location
+ * A {@link Token} that specifies a token to be parsed at specific locations
  * in the input.
  * <p>
  * A Sub consists of a <code>token</code> (a {@link Token}) and an
- * <code>address</code> (a {@link ValueExpression}). First
- * <code>address</code> is evaluated. Then each resulting value is used as a
+ * <code>offsets</code> (a {@link ValueExpression}). First
+ * <code>offsets</code> is evaluated. Then each resulting value is used as a
  * location in the input to parse <code>token</code> at. Sub succeeds if all
  * parses of <code>token</code> at all locations succeed. Sub fails if
- * <code>address</code> evaluates to a list of locations that is either empty
+ * <code>offsets</code> evaluates to a list of locations that is either empty
  * or contains an invalid value.
  *
  * @see ValueExpression
@@ -54,41 +54,41 @@ import io.parsingdata.metal.expression.value.ValueExpression;
 public class Sub extends Token {
 
     public final Token token;
-    public final ValueExpression address;
+    public final ValueExpression offsets;
 
-    public Sub(final String name, final Token token, final ValueExpression address, final Encoding encoding) {
+    public Sub(final String name, final Token token, final ValueExpression offsets, final Encoding encoding) {
         super(name, encoding);
         this.token = checkNotNull(token, "token");
-        this.address = checkNotNull(address, "address");
+        this.offsets = checkNotNull(offsets, "offsets");
     }
 
     @Override
     protected Optional<ParseState> parseImpl(final Environment environment) {
-        final ImmutableList<Optional<Value>> addresses = address.eval(environment.parseState, environment.encoding);
-        if (addresses.isEmpty()) {
+        final ImmutableList<Optional<Value>> evaluatedOffsets = offsets.eval(environment.parseState, environment.encoding);
+        if (evaluatedOffsets.isEmpty()) {
             return failure();
         }
-        return iterate(environment.addBranch(this), addresses)
+        return iterate(environment.addBranch(this), evaluatedOffsets)
             .computeResult()
             .flatMap(nextParseState -> nextParseState.seek(environment.parseState.offset));
     }
 
-    private Trampoline<Optional<ParseState>> iterate(final Environment environment, final ImmutableList<Optional<Value>> addresses) {
-        if (addresses.isEmpty()) {
+    private Trampoline<Optional<ParseState>> iterate(final Environment environment, final ImmutableList<Optional<Value>> offsetValues) {
+        if (offsetValues.isEmpty()) {
             return complete(() -> success(environment.parseState.closeBranch(this)));
         }
-        return addresses.head
-            .flatMap(address -> parse(environment, address.asNumeric()))
-            .map(nextParseState -> intermediate(() -> iterate(environment.withParseState(nextParseState), addresses.tail)))
+        return offsetValues.head
+            .flatMap(offsetValue -> parse(environment, offsetValue.asNumeric()))
+            .map(nextParseState -> intermediate(() -> iterate(environment.withParseState(nextParseState), offsetValues.tail)))
             .orElseGet(() -> complete(Util::failure));
     }
 
-    private Optional<ParseState> parse(final Environment environment, final BigInteger offset) {
-        if (hasRootAtOffset(environment.parseState.order, token.getCanonical(environment.parseState), offset, environment.parseState.source)) {
-            return success(environment.parseState.add(new ParseReference(offset, environment.parseState.source, token.getCanonical(environment.parseState))));
+    private Optional<ParseState> parse(final Environment environment, final BigInteger offsetValue) {
+        if (hasRootAtOffset(environment.parseState.order, token.getCanonical(environment.parseState), offsetValue, environment.parseState.source)) {
+            return success(environment.parseState.add(new ParseReference(offsetValue, environment.parseState.source, token.getCanonical(environment.parseState))));
         }
         return environment.parseState
-            .seek(offset)
+            .seek(offsetValue)
             .map(newParseState -> token.parse(environment.withParseState(newParseState)))
             .orElseGet(Util::failure);
     }
@@ -100,19 +100,19 @@ public class Sub extends Token {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + address + ")";
+        return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + offsets + ")";
     }
 
     @Override
     public boolean equals(final Object obj) {
         return super.equals(obj)
             && Objects.equals(token, ((Sub)obj).token)
-            && Objects.equals(address, ((Sub)obj).address);
+            && Objects.equals(offsets, ((Sub)obj).offsets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), token, address);
+        return Objects.hash(super.hashCode(), token, offsets);
     }
 
 }


### PR DESCRIPTION
Implemented the naming scheme as proposed in #274.

~~Additionally, when updating the JavaDoc to reflect the new names, also updated it. Most important change there is that in places where constructor arguments/fields are referred to as _operand(s)_, this has been changed to _field()s_ since that word is more accurate in the context of the Java code it describes.~~ <- Undoing this because it just makes it more unreadable...