### PR TITLE
Add SingleValueExpression to type ValueExpressions that always return a single value

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -91,7 +91,7 @@ import io.parsingdata.metal.token.While;
 public final class Shorthand {
 
     public static final Token EMPTY = def(EMPTY_NAME, 0L);
-    public static final ValueExpression SELF = new Self();
+    public static final SingleValueExpression SELF = new Self();
     public static final SingleValueExpression CURRENT_OFFSET = new CurrentOffset();
     public static final SingleValueExpression CURRENT_ITERATION = new CurrentIteration(con(0));
     public static final Expression TRUE = new True();

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -200,11 +200,11 @@ public final class Shorthand {
     public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
     public static SingleValueExpression count(final ValueExpression operand) { return new Count(operand); }
     public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }
-    public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) { return new FoldLeft(values, reducer, initial); }
+    public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldLeft(values, reducer, initial); }
     public static ValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldRight(values, reducer, null); }
-    public static ValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) { return new FoldRight(values, reducer, initial); }
+    public static ValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldRight(values, reducer, initial); }
     public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return foldRight(values, reducer); }
-    public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) { return foldRight(values, reducer, initial); }
+    public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return foldRight(values, reducer, initial); }
     public static ValueExpression rev(final ValueExpression values) { return new Reverse(values); }
     public static ValueExpression exp(final ValueExpression base, final SingleValueExpression count) { return new Expand(base, count); }
     public static BinaryValueExpression mapLeft(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression left, final ValueExpression rightExpand) { return func.apply(left, exp(rightExpand, count(left))); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -196,15 +196,15 @@ public final class Shorthand {
     public static SingleValueExpression iteration(final int level) { return iteration(con(level)); }
     public static SingleValueExpression iteration(final ValueExpression level) { return new CurrentIteration(level); }
     public static ValueExpression cat(final ValueExpression left, final ValueExpression right) { return new Cat(left, right); }
-    public static ValueExpression cat(final ValueExpression operand) { return new FoldCat(operand); }
+    public static SingleValueExpression cat(final ValueExpression operand) { return new FoldCat(operand); }
     public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
     public static SingleValueExpression count(final ValueExpression operand) { return new Count(operand); }
-    public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }
-    public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldLeft(values, reducer, initial); }
-    public static ValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldRight(values, reducer, null); }
-    public static ValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldRight(values, reducer, initial); }
-    public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return foldRight(values, reducer); }
-    public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return foldRight(values, reducer, initial); }
+    public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }
+    public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldLeft(values, reducer, initial); }
+    public static SingleValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldRight(values, reducer, null); }
+    public static SingleValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldRight(values, reducer, initial); }
+    public static SingleValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return foldRight(values, reducer); }
+    public static SingleValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return foldRight(values, reducer, initial); }
     public static ValueExpression rev(final ValueExpression values) { return new Reverse(values); }
     public static ValueExpression exp(final ValueExpression base, final SingleValueExpression count) { return new Expand(base, count); }
     public static BinaryValueExpression mapLeft(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression left, final ValueExpression rightExpand) { return func.apply(left, exp(rightExpand, count(left))); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -116,10 +116,10 @@ public final class Shorthand {
     public static Token rep(final String name, final Token token) { return rep(name, token, null); }
     public static Token rep(final Token token, final Encoding encoding) { return rep(NO_NAME, token, encoding); }
     public static Token rep(final Token token) { return rep(token, null); }
-    public static Token repn(final String name, final Token token, final ValueExpression n, final Encoding encoding) { return new RepN(name, token, n, encoding); }
-    public static Token repn(final String name, final Token token, final ValueExpression n) { return repn(name, token, n, null); }
-    public static Token repn(final Token token, final ValueExpression n, final Encoding encoding) { return repn(NO_NAME, token, n, encoding); }
-    public static Token repn(final Token token, final ValueExpression n) { return repn(token, n, null); }
+    public static Token repn(final String name, final Token token, final SingleValueExpression n, final Encoding encoding) { return new RepN(name, token, n, encoding); }
+    public static Token repn(final String name, final Token token, final SingleValueExpression n) { return repn(name, token, n, null); }
+    public static Token repn(final Token token, final SingleValueExpression n, final Encoding encoding) { return repn(NO_NAME, token, n, encoding); }
+    public static Token repn(final Token token, final SingleValueExpression n) { return repn(token, n, null); }
     public static Token seq(final String name, final Encoding encoding, final Token token1, final Token token2, final Token... tokens) { return new Seq(name, encoding, token1, token2, tokens); }
     public static Token seq(final String name, final Token token1, final Token token2, final Token... tokens) { return seq(name, null, token1, token2, tokens); }
     public static Token seq(final Encoding encoding, final Token token1, final Token token2, final Token... tokens) { return seq(NO_NAME, encoding, token1, token2, tokens); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -92,8 +92,8 @@ public final class Shorthand {
 
     public static final Token EMPTY = def(EMPTY_NAME, 0L);
     public static final ValueExpression SELF = new Self();
-    public static final ValueExpression CURRENT_OFFSET = new CurrentOffset();
-    public static final ValueExpression CURRENT_ITERATION = new CurrentIteration(con(0));
+    public static final SingleValueExpression CURRENT_OFFSET = new CurrentOffset();
+    public static final SingleValueExpression CURRENT_ITERATION = new CurrentIteration(con(0));
     public static final Expression TRUE = new True();
 
     private Shorthand() {}
@@ -187,18 +187,18 @@ public final class Shorthand {
     public static NameRef ref(final String name, final ValueExpression limit) { return new NameRef(name, limit); }
     public static DefinitionRef ref(final Token definition) { return ref(definition, null); }
     public static DefinitionRef ref(final Token definition, final ValueExpression limit) { return new DefinitionRef(definition, limit); }
-    public static ValueExpression first(final ValueExpression operand) { return new First(operand); }
+    public static SingleValueExpression first(final ValueExpression operand) { return new First(operand); }
     public static SingleValueExpression last(final ValueExpression operand) { return new Last(operand); }
     public static SingleValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, con(1))); }
     public static SingleValueExpression last(final DefinitionRef operand) { return new Last(new DefinitionRef(operand.reference, con(1))); }
     public static ValueExpression nth(final ValueExpression values, final ValueExpression indices) { return new Nth(values, indices); }
     public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
-    public static ValueExpression iteration(final int level) { return iteration(con(level)); }
-    public static ValueExpression iteration(final ValueExpression level) { return new CurrentIteration(level); }
+    public static SingleValueExpression iteration(final int level) { return iteration(con(level)); }
+    public static SingleValueExpression iteration(final ValueExpression level) { return new CurrentIteration(level); }
     public static ValueExpression cat(final ValueExpression left, final ValueExpression right) { return new Cat(left, right); }
     public static ValueExpression cat(final ValueExpression operand) { return new FoldCat(operand); }
     public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
-    public static ValueExpression count(final ValueExpression operand) { return new Count(operand); }
+    public static SingleValueExpression count(final ValueExpression operand) { return new Count(operand); }
     public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }
     public static ValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) { return new FoldLeft(values, reducer, initial); }
     public static ValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldRight(values, reducer, null); }
@@ -206,7 +206,7 @@ public final class Shorthand {
     public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return foldRight(values, reducer); }
     public static ValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) { return foldRight(values, reducer, initial); }
     public static ValueExpression rev(final ValueExpression values) { return new Reverse(values); }
-    public static ValueExpression exp(final ValueExpression base, final ValueExpression count) { return new Expand(base, count); }
+    public static ValueExpression exp(final ValueExpression base, final SingleValueExpression count) { return new Expand(base, count); }
     public static BinaryValueExpression mapLeft(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression left, final ValueExpression rightExpand) { return func.apply(left, exp(rightExpand, count(left))); }
     public static BinaryValueExpression mapRight(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression leftExpand, final ValueExpression right) { return func.apply(exp(leftExpand, count(right)), right); }
     public static ValueExpression bytes(final ValueExpression operand) { return new Bytes(operand); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -52,6 +52,7 @@ import io.parsingdata.metal.expression.value.FoldCat;
 import io.parsingdata.metal.expression.value.FoldLeft;
 import io.parsingdata.metal.expression.value.FoldRight;
 import io.parsingdata.metal.expression.value.Reverse;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -97,15 +98,15 @@ public final class Shorthand {
 
     private Shorthand() {}
 
-    public static Token def(final String name, final ValueExpression size, final Expression predicate, final Encoding encoding) { return post(def(name, size, encoding), predicate); }
-    public static Token def(final String name, final ValueExpression size, final Expression predicate) { return def(name, size, predicate, null); }
-    public static Token def(final String name, final ValueExpression size, final Encoding encoding) { return new Def(name, size, encoding); }
-    public static Token def(final String name, final ValueExpression size) { return def(name, size, (Encoding)null); }
+    public static Token def(final String name, final SingleValueExpression size, final Expression predicate, final Encoding encoding) { return post(def(name, size, encoding), predicate); }
+    public static Token def(final String name, final SingleValueExpression size, final Expression predicate) { return def(name, size, predicate, null); }
+    public static Token def(final String name, final SingleValueExpression size, final Encoding encoding) { return new Def(name, size, encoding); }
+    public static Token def(final String name, final SingleValueExpression size) { return def(name, size, (Encoding)null); }
     public static Token def(final String name, final long size, final Expression predicate, final Encoding encoding) { return def(name, con(size), predicate, encoding); }
     public static Token def(final String name, final long size, final Expression predicate) { return def(name, size, predicate, null); }
     public static Token def(final String name, final long size, final Encoding encoding) { return def(name, con(size), encoding); }
     public static Token def(final String name, final long size) { return def(name, size, (Encoding)null); }
-    public static Token nod(final ValueExpression size) { return def(EMPTY_NAME, size); }
+    public static Token nod(final SingleValueExpression size) { return def(EMPTY_NAME, size); }
     public static Token nod(final long size) { return nod(con(size)); }
     public static Token cho(final String name, final Encoding encoding, final Token token1, final Token token2, final Token... tokens) { return new Cho(name, encoding, token1, token2, tokens); }
     public static Token cho(final String name, final Token token1, final Token token2, final Token... tokens) { return cho(name, null, token1, token2, tokens); }
@@ -172,24 +173,24 @@ public final class Shorthand {
     public static UnaryValueExpression not(final ValueExpression operand) { return new io.parsingdata.metal.expression.value.bitwise.Not(operand); }
     public static BinaryValueExpression shl(final ValueExpression left, final ValueExpression right) { return new ShiftLeft(left, right); }
     public static BinaryValueExpression shr(final ValueExpression left, final ValueExpression right) { return new ShiftRight(left, right); }
-    public static ValueExpression con(final long value) { return con(value, DEFAULT_ENCODING); }
-    public static ValueExpression con(final long value, final Encoding encoding) { return con(ConstantFactory.createFromNumeric(value, encoding)); }
-    public static ValueExpression con(final String value) { return con(value, DEFAULT_ENCODING); }
-    public static ValueExpression con(final String value, final Encoding encoding) { return con(ConstantFactory.createFromString(value, encoding)); }
-    public static ValueExpression con(final Value value) { return new Const(value); }
-    public static ValueExpression con(final Encoding encoding, final int... values) { return new Const(new CoreValue(createFromBytes(toByteArray(values)), encoding)); }
-    public static ValueExpression con(final int... values) { return con(DEFAULT_ENCODING, values); }
-    public static ValueExpression con(final byte[] value) { return con(value, DEFAULT_ENCODING); }
-    public static ValueExpression con(final byte[] value, final Encoding encoding) { return con(ConstantFactory.createFromBytes(value, encoding)); }
+    public static SingleValueExpression con(final long value) { return con(value, DEFAULT_ENCODING); }
+    public static SingleValueExpression con(final long value, final Encoding encoding) { return con(ConstantFactory.createFromNumeric(value, encoding)); }
+    public static SingleValueExpression con(final String value) { return con(value, DEFAULT_ENCODING); }
+    public static SingleValueExpression con(final String value, final Encoding encoding) { return con(ConstantFactory.createFromString(value, encoding)); }
+    public static SingleValueExpression con(final Value value) { return new Const(value); }
+    public static SingleValueExpression con(final Encoding encoding, final int... values) { return new Const(new CoreValue(createFromBytes(toByteArray(values)), encoding)); }
+    public static SingleValueExpression con(final int... values) { return con(DEFAULT_ENCODING, values); }
+    public static SingleValueExpression con(final byte[] value) { return con(value, DEFAULT_ENCODING); }
+    public static SingleValueExpression con(final byte[] value, final Encoding encoding) { return con(ConstantFactory.createFromBytes(value, encoding)); }
     public static ValueExpression len(final ValueExpression operand) { return new Len(operand); }
     public static NameRef ref(final String name) { return ref(name, null); }
     public static NameRef ref(final String name, final ValueExpression limit) { return new NameRef(name, limit); }
     public static DefinitionRef ref(final Token definition) { return ref(definition, null); }
     public static DefinitionRef ref(final Token definition, final ValueExpression limit) { return new DefinitionRef(definition, limit); }
     public static ValueExpression first(final ValueExpression operand) { return new First(operand); }
-    public static ValueExpression last(final ValueExpression operand) { return new Last(operand); }
-    public static ValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, con(1))); }
-    public static ValueExpression last(final DefinitionRef operand) { return new Last(new DefinitionRef(operand.reference, con(1))); }
+    public static SingleValueExpression last(final ValueExpression operand) { return new Last(operand); }
+    public static SingleValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, con(1))); }
+    public static SingleValueExpression last(final DefinitionRef operand) { return new Last(new DefinitionRef(operand.reference, con(1))); }
     public static ValueExpression nth(final ValueExpression values, final ValueExpression indices) { return new Nth(values, indices); }
     public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
     public static ValueExpression iteration(final int level) { return iteration(con(level)); }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Const.java
@@ -17,19 +17,19 @@
 package io.parsingdata.metal.expression.value;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
- * A {@link ValueExpression} representing a constant value.
+ * A {@link SingleValueExpression} representing a constant value.
  * <p>
  * Const has a single operand <code>value</code> (a {@link Value}). When
  * evaluated, this value is returned.
  */
-public class Const implements ValueExpression {
+public class Const implements SingleValueExpression {
 
     public final Value value;
 
@@ -38,8 +38,8 @@ public class Const implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
-        return ImmutableList.create(value);
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
+        return Optional.of(value);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/CoreValue.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/CoreValue.java
@@ -18,7 +18,6 @@ package io.parsingdata.metal.expression.value;
 
 import static io.parsingdata.metal.Util.bytesToHexString;
 import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.encoding.Encoding.DEFAULT_ENCODING;
 
 import java.math.BigInteger;
 import java.util.BitSet;

--- a/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Expand.java
@@ -22,7 +22,6 @@ import static io.parsingdata.metal.Util.checkNotNull;
 import static io.parsingdata.metal.expression.value.NotAValue.NOT_A_VALUE;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
@@ -40,7 +39,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * of the result of evaluating <code>bases</code> are concatenated. The amount
  * of copies equals the result of evaluating <code>count</code>. If
  * <code>count</code> evaluated to an empty value or <code>NOT_A_VALUE</code>,
- * an IllegalArgumentException is thrown.
+ * an {@link IllegalArgumentException} is thrown.
  */
 public class Expand implements ValueExpression {
 
@@ -58,11 +57,10 @@ public class Expand implements ValueExpression {
         if (baseList.isEmpty()) {
             return baseList;
         }
-        final Optional<Value> countValue = count.evalSingle(parseState, encoding);
-        if (!countValue.isPresent() || countValue.get().equals(NOT_A_VALUE)) {
-            throw new IllegalArgumentException("Count must evaluate to a non-empty countable value.");
-        }
-        return expand(baseList, countValue.get().asNumeric().intValueExact(), new ImmutableList<>()).computeResult();
+        return count.evalSingle(parseState, encoding)
+            .filter(countValue -> !countValue.equals(NOT_A_VALUE))
+            .map(countValue -> expand(baseList, countValue.asNumeric().intValueExact(), new ImmutableList<>()).computeResult())
+            .orElseThrow(() -> new IllegalArgumentException("Count must evaluate to a non-empty countable value."));
     }
 
     private Trampoline<ImmutableList<Value>> expand(final ImmutableList<Value> baseList, final int countValue, final ImmutableList<Value> aggregate) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldCat.java
@@ -21,21 +21,21 @@ import static java.math.BigInteger.ZERO;
 import static io.parsingdata.metal.data.Slice.createFromSource;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ConcatenatedValueSource;
-import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 
 /**
- * A {@link ValueExpression} that represents an optimized version of a
+ * A {@link SingleValueExpression} that represents an optimized version of a
  * {@link FoldLeft} operation with a {@link Cat} ValueExpression as reducer.
  *
  * @see FoldLeft
  * @see Cat
  */
-public class FoldCat implements ValueExpression {
+public class FoldCat implements SingleValueExpression {
 
     public final ValueExpression operand;
 
@@ -44,11 +44,10 @@ public class FoldCat implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
         return ConcatenatedValueSource.create(operand.eval(parseState, encoding))
             .flatMap(source -> createFromSource(source, ZERO, source.length))
-            .map(slice -> ImmutableList.<Value>create(new CoreValue(slice, encoding)))
-            .orElseGet(ImmutableList::new);
+            .map(slice -> new CoreValue(slice, encoding));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
@@ -24,7 +24,7 @@ import java.util.function.BinaryOperator;
 import io.parsingdata.metal.data.ImmutableList;
 
 /**
- * A {@link ValueExpression} implementation of the FoldLeft operation.
+ * A {@link SingleValueExpression} implementation of the FoldLeft operation.
  * <p>
  * FoldLeft differs from {@link FoldRight} in that the reduce operation is
  * applied from left to right (i.e., starting at the top).

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
@@ -33,7 +33,7 @@ import io.parsingdata.metal.data.ImmutableList;
  */
 public class FoldLeft extends Fold {
 
-    public FoldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) {
+    public FoldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) {
         super(values, reducer, initial);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
@@ -32,7 +32,7 @@ import io.parsingdata.metal.data.ImmutableList;
  */
 public class FoldRight extends Fold {
 
-    public FoldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final ValueExpression initial) {
+    public FoldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) {
         super(values, reducer, initial);
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
@@ -23,7 +23,7 @@ import java.util.function.BinaryOperator;
 import io.parsingdata.metal.data.ImmutableList;
 
 /**
- * A {@link ValueExpression} implementation of the FoldRight operation.
+ * A {@link SingleValueExpression} implementation of the FoldRight operation.
  * <p>
  * FoldRight differs from {@link FoldLeft} in that the reduce operation is
  * applied from right to left (i.e., starting at the bottom).

--- a/core/src/main/java/io/parsingdata/metal/expression/value/SingleValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/SingleValueExpression.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value;
+
+import java.util.Optional;
+
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.encoding.Encoding;
+
+/**
+ * Interface for all SingleValueExpression implementations.
+ * <p>
+ * A SingleValueExpression is an expression that is evaluated by executing its
+ * {@link #eval(ParseState, Encoding)} method. It yields an {@link Optional}
+ * {@link Value} object.
+ * <p>
+ * As context, it receives the current <code>ParseState</code> object as
+ * well as the current <code>Encoding</code> object.
+ */
+@SuppressWarnings("FunctionalInterfaceMethodChanged") // What we do is in line with error-prone's advice
+@FunctionalInterface
+public interface SingleValueExpression extends ValueExpression {
+
+    Optional<Value> evalSingle(ParseState parseState, Encoding encoding);
+
+    @Override
+    default ImmutableList<Value> eval(ParseState parseState, Encoding encoding) {
+        return evalSingle(parseState, encoding).map(ImmutableList::create).orElseGet(ImmutableList::new);
+    }
+
+}

--- a/core/src/main/java/io/parsingdata/metal/expression/value/SingleValueExpression.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/SingleValueExpression.java
@@ -26,7 +26,7 @@ import io.parsingdata.metal.encoding.Encoding;
  * Interface for all SingleValueExpression implementations.
  * <p>
  * A SingleValueExpression is an expression that is evaluated by executing its
- * {@link #eval(ParseState, Encoding)} method. It yields an {@link Optional}
+ * {@link #evalSingle(ParseState, Encoding)} method. It yields an {@link Optional}
  * {@link Value} object.
  * <p>
  * As context, it receives the current <code>ParseState</code> object as

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Count.java
@@ -19,21 +19,22 @@ package io.parsingdata.metal.expression.value.reference;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.encoding.Sign;
 import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link ValueExpression} that represents the amount of {@link Value}s
+ * A {@link SingleValueExpression} that represents the amount of {@link Value}s
  * returned by evaluating its <code>operand</code>.
  */
-public class Count implements ValueExpression {
+public class Count implements SingleValueExpression {
 
     public final ValueExpression operand;
 
@@ -42,8 +43,8 @@ public class Count implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
-        return ImmutableList.create(fromNumeric(operand.eval(parseState, encoding).size));
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
+        return Optional.of(fromNumeric(operand.eval(parseState, encoding).size));
     }
 
     private static Value fromNumeric(final long length) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentIteration.java
@@ -36,6 +36,7 @@ import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ImmutablePair;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Rep;
@@ -44,11 +45,11 @@ import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.While;
 
 /**
- * A {@link ValueExpression} that represents the 0-based current iteration in an
+ * A {@link SingleValueExpression} that represents the 0-based current iteration in an
  * iterable {@link Token} (when {@link Token#isIterable()} returns true, e.g. when
  * inside a {@link Rep}, {@link RepN}) or {@link While}).
  */
-public class CurrentIteration implements ValueExpression {
+public class CurrentIteration implements SingleValueExpression {
 
     private final ValueExpression level;
 
@@ -57,13 +58,7 @@ public class CurrentIteration implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
-        return getIteration(parseState, encoding)
-            .map(ImmutableList::create)
-            .orElseGet(ImmutableList::new);
-    }
-
-    private Optional<Value> getIteration(final ParseState parseState, final Encoding encoding) {
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
         final BigInteger levelValue = getLevel(parseState, encoding);
         if (parseState.iterations.size <= levelValue.longValue()) {
             return Optional.empty();

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/CurrentOffset.java
@@ -19,22 +19,23 @@ package io.parsingdata.metal.expression.value.reference;
 import static io.parsingdata.metal.encoding.Encoding.DEFAULT_ENCODING;
 import static io.parsingdata.metal.expression.value.ConstantFactory.createFromNumeric;
 
+import java.util.Optional;
+
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link ValueExpression} that represents the current offset in the
+ * A {@link SingleValueExpression} that represents the current offset in the
  * {@link ParseState}.
  */
-public class CurrentOffset implements ValueExpression {
+public class CurrentOffset implements SingleValueExpression {
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
-        return ImmutableList.create(createFromNumeric(parseState.offset, DEFAULT_ENCODING));
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
+        return Optional.of(createFromNumeric(parseState.offset, DEFAULT_ENCODING));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/First.java
@@ -21,20 +21,22 @@ import static io.parsingdata.metal.Trampoline.intermediate;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link ValueExpression} that represents the first {@link Value} returned
+ * A {@link SingleValueExpression} that represents the first {@link Value} returned
  * by evaluating its <code>operand</code>.
  */
-public class First implements ValueExpression {
+public class First implements SingleValueExpression {
 
     public final ValueExpression operand;
 
@@ -43,9 +45,9 @@ public class First implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
         final ImmutableList<Value> values = operand.eval(parseState, encoding);
-        return values.isEmpty() ? values : ImmutableList.create(getFirst(values).computeResult());
+        return values.isEmpty() ? Optional.empty() : Optional.of(getFirst(values).computeResult());
     }
 
     private Trampoline<Value> getFirst(final ImmutableList<Value> values) {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Last.java
@@ -19,19 +19,21 @@ package io.parsingdata.metal.expression.value.reference;
 import static io.parsingdata.metal.Util.checkNotNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link ValueExpression} that represents the last {@link Value} returned
+ * A {@link SingleValueExpression} that represents the last {@link Value} returned
  * by evaluating its <code>operand</code>.
  */
-public class Last implements ValueExpression {
+public class Last implements SingleValueExpression {
 
     public final ValueExpression operand;
 
@@ -40,9 +42,9 @@ public class Last implements ValueExpression {
     }
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
         final ImmutableList<Value> values = operand.eval(parseState, encoding);
-        return values.isEmpty() ? values : ImmutableList.create(values.head);
+        return values.isEmpty() ? Optional.empty() : Optional.of(values.head);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -27,7 +27,6 @@ import static io.parsingdata.metal.expression.value.NotAValue.NOT_A_VALUE;
 
 import java.math.BigInteger;
 import java.util.Objects;
-import java.util.Optional;
 
 import io.parsingdata.metal.Trampoline;
 import io.parsingdata.metal.Util;
@@ -44,9 +43,9 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * <code>indices</code> (both {@link ValueExpression}s). Both operands are
  * evaluated. Next, the resulting values of evaluating <code>indices</code> is
  * used as a list of integer indices into the results of evaluating
- * <code>values</code>. For every invalid index (such as
- * {@link Optional#empty()}, a negative value or an index that is out of
- * bounds) empty is returned.
+ * <code>values</code>. For every invalid index (<code>NOT_A_VALUE</code>, a
+ * negative value or an index that is out of bounds) <code>NOT_A_VALUE</code>
+ * is returned.
  */
 public class Nth implements ValueExpression {
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Nth.java
@@ -33,6 +33,7 @@ import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.NotAValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -43,8 +44,8 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * <code>indices</code> (both {@link ValueExpression}s). Both operands are
  * evaluated. Next, the resulting values of evaluating <code>indices</code> is
  * used as a list of integer indices into the results of evaluating
- * <code>values</code>. For every invalid index (<code>NOT_A_VALUE</code>, a
- * negative value or an index that is out of bounds) <code>NOT_A_VALUE</code>
+ * <code>values</code>. For every invalid index ({@link NotAValue#NOT_A_VALUE}, a
+ * negative value or an index that is out of bounds) {@link NotAValue#NOT_A_VALUE}
  * is returned.
  */
 public class Nth implements ValueExpression {

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -16,6 +16,8 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
+import static java.util.function.Function.identity;
+
 import java.util.Optional;
 
 import io.parsingdata.metal.Util;
@@ -32,7 +34,7 @@ public class Self implements SingleValueExpression {
 
     @Override
     public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
-        return parseState.order.current().flatMap(Optional::of);
+        return parseState.order.current().map(identity());
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Self.java
@@ -16,22 +16,23 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
+import java.util.Optional;
+
 import io.parsingdata.metal.Util;
-import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
 
 /**
- * A {@link ValueExpression} that represents the {@link Value} most recently
+ * A {@link SingleValueExpression} that represents the {@link Value} most recently
  * added to the parse state.
  */
-public class Self implements ValueExpression {
+public class Self implements SingleValueExpression {
 
     @Override
-    public ImmutableList<Value> eval(final ParseState parseState, final Encoding encoding) {
-        return parseState.order.current().map(ImmutableList::<Value>create).orElseGet(ImmutableList::new);
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
+        return parseState.order.current().flatMap(Optional::of);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -56,8 +56,8 @@ public class Def extends Token {
     @Override
     protected Optional<ParseState> parseImpl(final Environment environment) {
         return size.evalSingle(environment.parseState, environment.encoding)
-            .filter(size -> !size.equals(NOT_A_VALUE))
-            .flatMap(size -> size.asNumeric().compareTo(ZERO) != 0 ? slice(environment, size.asNumeric()) : success(environment.parseState));
+            .filter(sizeValue -> !sizeValue.equals(NOT_A_VALUE))
+            .flatMap(sizeValue -> sizeValue.asNumeric().compareTo(ZERO) != 0 ? slice(environment, sizeValue.asNumeric()) : success(environment.parseState));
     }
 
     private Optional<ParseState> slice(final Environment environment, final BigInteger dataSize) {

--- a/core/src/main/java/io/parsingdata/metal/token/Def.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Def.java
@@ -20,7 +20,6 @@ import static java.math.BigInteger.ZERO;
 
 import static io.parsingdata.metal.Util.checkNotEmpty;
 import static io.parsingdata.metal.Util.checkNotNull;
-import static io.parsingdata.metal.Util.failure;
 import static io.parsingdata.metal.Util.success;
 import static io.parsingdata.metal.expression.value.NotAValue.NOT_A_VALUE;
 
@@ -28,49 +27,43 @@ import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Optional;
 
-import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.Environment;
-import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.Value;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 
 /**
  * A {@link Token} that specifies a value to parse in the input.
  * <p>
- * A Def consists of a <code>size</code> (a {@link ValueExpression}.
+ * A Def consists of a <code>size</code> (a {@link SingleValueExpression}.
  * <p>
- * Parsing will succeed if <code>size</code> evaluates to a single value and if
+ * Parsing will succeed if <code>size</code> evaluates to a value and if
  * that many bytes are available in the input. This means that a size of zero
  * will lead to a successful parse, but will not produce a value.
  *
- * @see ValueExpression
+ * @see SingleValueExpression
  */
 public class Def extends Token {
 
-    public final ValueExpression size;
+    public final SingleValueExpression size;
 
-    public Def(final String name, final ValueExpression size, final Encoding encoding) {
+    public Def(final String name, final SingleValueExpression size, final Encoding encoding) {
         super(checkNotEmpty(name, "name"), encoding);
         this.size = checkNotNull(size, "size");
     }
 
     @Override
     protected Optional<ParseState> parseImpl(final Environment environment) {
-        final ImmutableList<Value> sizes = size.eval(environment.parseState, environment.encoding);
-        if (sizes.size != 1 || sizes.head.equals(NOT_A_VALUE)) {
-            return failure();
-        }
-        return sizes.head.asNumeric().compareTo(ZERO) != 0 ? slice(environment, sizes.head.asNumeric()) : success(environment.parseState);
+        return size.evalSingle(environment.parseState, environment.encoding)
+            .filter(size -> !size.equals(NOT_A_VALUE))
+            .flatMap(size -> size.asNumeric().compareTo(ZERO) != 0 ? slice(environment, size.asNumeric()) : success(environment.parseState));
     }
 
     private Optional<ParseState> slice(final Environment environment, final BigInteger dataSize) {
         return environment.parseState
             .slice(dataSize)
-            .map(slice -> environment.parseState.add(new ParseValue(environment.scope, this, slice, environment.encoding)).seek(dataSize.add(environment.parseState.offset)))
-            .orElseGet(Util::failure);
+            .flatMap(slice -> environment.parseState.add(new ParseValue(environment.scope, this, slice, environment.encoding)).seek(dataSize.add(environment.parseState.offset)));
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/RepN.java
+++ b/core/src/main/java/io/parsingdata/metal/token/RepN.java
@@ -55,7 +55,7 @@ public class RepN extends IterableToken {
             .filter(count -> !count.equals(NOT_A_VALUE))
             .flatMap(count -> parse(environment, env -> env.parseState.iterations.head.right.compareTo(count.asNumeric()) >= 0, env -> failure()));
     }
-    
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + makeNameFragment() + token + "," + n + ")";

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotEquals;
 
 import static io.parsingdata.metal.Shorthand.TRUE;
 import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.exp;
 import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.data.ByteStreamSourceTest.DUMMY_BYTE_STREAM_SOURCE;
@@ -87,6 +88,7 @@ import io.parsingdata.metal.expression.value.FoldCat;
 import io.parsingdata.metal.expression.value.FoldLeft;
 import io.parsingdata.metal.expression.value.FoldRight;
 import io.parsingdata.metal.expression.value.Reverse;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.expression.value.arithmetic.Add;
@@ -147,7 +149,8 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> ENCODINGS = Arrays.asList(EncodingFactory::enc, EncodingFactory::signed, EncodingFactory::le, () -> new Encoding(Charset.forName("UTF-8")));
     private static final List<Supplier<Object>> TOKENS = Arrays.asList(() -> any("a"), () -> any("b"));
     private static final List<Supplier<Object>> TOKEN_ARRAYS = Arrays.asList(() -> new Token[] { any("a"), any("b")}, () -> new Token[] { any("b"), any("c") }, () -> new Token[] { any("a"), any("b"), any("c") });
-    private static final List<Supplier<Object>> VALUE_EXPRESSIONS = Arrays.asList(() -> con(1), () -> con(2));
+    private static final List<Supplier<Object>> SINGLE_VALUE_EXPRESSIONS = Arrays.asList(() -> con(1), () -> con(2));
+    private static final List<Supplier<Object>> VALUE_EXPRESSIONS = Arrays.asList(() -> con(1), () -> exp(con(1), con(2)));
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()), () -> NOT_A_VALUE);
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
@@ -170,6 +173,7 @@ public class AutoEqualityTest {
         result.put(Encoding.class, ENCODINGS);
         result.put(Token.class, TOKENS);
         result.put(Token[].class, TOKEN_ARRAYS);
+        result.put(SingleValueExpression.class, SINGLE_VALUE_EXPRESSIONS);
         result.put(ValueExpression.class, VALUE_EXPRESSIONS);
         result.put(Expression.class, EXPRESSIONS);
         result.put(Value.class, VALUES);

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.len;
 import static io.parsingdata.metal.Shorthand.ltNum;
 import static io.parsingdata.metal.Shorthand.ref;
@@ -53,8 +54,8 @@ public class ByteLengthTest {
     // but Len will become useful when Let is implemented
     private static final Token STRING = seq(
         def("length", 1),
-        def("text1", ref("length")),
-        def("text2", len(ref("text1"))));
+        def("text1", last(ref("length"))),
+        def("text2", last(len(ref("text1")))));
     //  let("hasText", con(true), ltNum(len(ref("text1")), con(0))));
 
     private static final Token NAME =

--- a/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
@@ -24,6 +24,7 @@ import static io.parsingdata.metal.Shorthand.EMPTY;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
@@ -32,8 +33,7 @@ import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
-import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_VE;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
+import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_SVE;
 
 import java.util.Optional;
 
@@ -48,7 +48,7 @@ public class DefSizeTest {
     public static final Token FORMAT =
         seq(
             def("length", con(4)),
-            def("data", ref("length"))
+            def("data", last(ref("length")))
         );
 
     @Test
@@ -78,10 +78,8 @@ public class DefSizeTest {
     }
 
     @Test
-    public void testEmptyLengthInList() {
-        assertFalse(def("a", EMPTY_VE).parse(env(stream(1, 2, 3, 4))).isPresent());
-        final Token aList = seq(any("a"), any("a"));
-        assertFalse(seq(aList, def("b", ref("a"))).parse(env(stream(1, 2, 3, 4))).isPresent());
+    public void testLengthNotAValue() {
+        assertFalse(def("a", EMPTY_SVE).parse(env(stream(1, 2, 3, 4))).isPresent());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -74,18 +74,6 @@ public class ErrorsTest {
     }
 
     @Test
-    public void multiValueInRepN() {
-        final Token dummy = any("a");
-        final Token multiRepN =
-            seq(any("b"),
-                any("b"),
-                repn(dummy, ref("b"))
-            );
-       Optional<ParseState> result = multiRepN.parse(env(stream(2, 2, 2, 2)));
-       assertFalse(result.isPresent());
-    }
-
-    @Test
     public void parseStateWithNegativeOffset() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Argument offset may not be negative.");

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -26,23 +26,17 @@ import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.mul;
 import static io.parsingdata.metal.Shorthand.neg;
-import static io.parsingdata.metal.Shorthand.ref;
-import static io.parsingdata.metal.Shorthand.repn;
-import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
-import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.math.BigInteger;
-import java.util.Optional;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.token.Token;
 
 public class ErrorsTest {

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -23,6 +23,7 @@ import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.mul;
 import static io.parsingdata.metal.Shorthand.neg;
 import static io.parsingdata.metal.Shorthand.ref;
@@ -53,22 +54,22 @@ public class ErrorsTest {
     public void noValueForSize() {
         thrown = ExpectedException.none();
         // Basic division by zero.
-        final Token nanSize = def("a", div(con(1), con(0)));
+        final Token nanSize = def("a", last(div(con(1), con(0))));
         assertFalse(nanSize.parse(env(stream(1))).isPresent());
         // Try to negate division by zero.
-        final Token negNanSize = def("a", neg(div(con(1), con(0))));
+        final Token negNanSize = def("a", last(neg(div(con(1), con(0)))));
         assertFalse(negNanSize.parse(env(stream(1))).isPresent());
         // Add one to division by zero.
-        final Token addNanSize = def("a", add(div(con(1), con(0)), con(1)));
+        final Token addNanSize = def("a", last(add(div(con(1), con(0)), con(1))));
         assertFalse(addNanSize.parse(env(stream(1))).isPresent());
         // Add division by zero to one.
-        final Token addNanSize2 = def("a", add(con(1), div(con(1), con(0))));
+        final Token addNanSize2 = def("a", last(add(con(1), div(con(1), con(0)))));
         assertFalse(addNanSize2.parse(env(stream(1))).isPresent());
         // Subtract one from division by zero.
-        final Token subNanSize = def("a", sub(div(con(1), con(0)), con(1)));
+        final Token subNanSize = def("a", last(sub(div(con(1), con(0)), con(1))));
         assertFalse(subNanSize.parse(env(stream(1))).isPresent());
         // Multiply division by zero with one.
-        final Token mulNanSize = def("a", mul(div(con(1), con(0)), con(1)));
+        final Token mulNanSize = def("a", last(mul(div(con(1), con(0)), con(1))));
         assertFalse(mulNanSize.parse(env(stream(1))).isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/IterateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/IterateTest.java
@@ -21,6 +21,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.gtNum;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
@@ -41,11 +42,11 @@ public class IterateTest extends ParameterizedParse {
 
     private static final Token repNToken =
         seq(any("n"),
-            repn(def("x", con(1), gtNum(con(1))), ref("n")),
+            repn(def("x", con(1), gtNum(con(1))), last(ref("n"))),
             def("f", con(1), eq(con(42))));
 
     private static final Token repBrokenNToken =
-        seq(repn(any("x"), div(con(1), con(0))),
+        seq(repn(any("x"), last(div(con(1), con(0)))),
             def("f", con(1), eq(con(42))));
 
     @Parameters(name = "{0} ({4})")

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
@@ -46,7 +47,7 @@ public class SubStructTableTest {
 
     private final Token table =
         seq(def("tableSize", con(1)),
-            repn(def("pointer", con(1)), ref("tableSize")),
+            repn(def("pointer", con(1)), last(ref("tableSize"))),
             sub(struct, ref("pointer")));
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -107,7 +107,7 @@ public class ToStringTest {
     @Test
     public void validateToStringImplementation() {
         final Expression e = not(and(eq(v(), v()), or(eqNum(v()), and(eqStr(v()), or(gtEqNum(v()), or(gtNum(v()), or(ltEqNum(v()), ltNum(v()))))))));
-        final Token t = until("untilName", v(), v(), v(), post(repn(sub(opt(pre(rep(cho(token("refName"), any(n()), seq(nod(10), tie(def(n(), last(v())), v()), whl(def(n(), con(1), e), e), tie(t(), con(1))))), e)), v()), v()), e));
+        final Token t = until("untilName", v(), v(), v(), post(repn(sub(opt(pre(rep(cho(token("refName"), any(n()), seq(nod(10), tie(def(n(), last(v())), v()), whl(def(n(), con(1), e), e), tie(t(), con(1))))), e)), v()), last(v())), e));
         final String output = t.toString();
         for (int i = 0; i < count; i++) {
             assertTrue(output.contains(prefix + i));

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -124,7 +124,7 @@ public class ToStringTest {
     }
 
     private ValueExpression v() {
-        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(cat(last(ref(n()))), first(nth(exp(ref(n()), con(NOT_A_VALUE)), con(1)))), sub(CURRENT_ITERATION, con(1))), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, ref(n())), Shorthand::add), Shorthand::add, ref(n()));
+        return fold(foldLeft(foldRight(rev(bytes(neg(add(div(mod(mul(sub(cat(last(ref(n()))), first(nth(exp(ref(n()), con(NOT_A_VALUE)), con(1)))), sub(CURRENT_ITERATION, con(1))), cat(ref(n()), ref(t()))), add(SELF, add(offset(ref(n())), add(CURRENT_OFFSET, count(ref(n())))))), elvis(ref(n()), ref(n())))))), Shorthand::add, last(ref(n()))), Shorthand::add), Shorthand::add, last(ref(n())));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -107,7 +107,7 @@ public class ToStringTest {
     @Test
     public void validateToStringImplementation() {
         final Expression e = not(and(eq(v(), v()), or(eqNum(v()), and(eqStr(v()), or(gtEqNum(v()), or(gtNum(v()), or(ltEqNum(v()), ltNum(v()))))))));
-        final Token t = until("untilName", v(), v(), v(), post(repn(sub(opt(pre(rep(cho(token("refName"), any(n()), seq(nod(10), tie(def(n(), v()), v()), whl(def(n(), con(1), e), e), tie(t(), con(1))))), e)), v()), v()), e));
+        final Token t = until("untilName", v(), v(), v(), post(repn(sub(opt(pre(rep(cho(token("refName"), any(n()), seq(nod(10), tie(def(n(), last(v())), v()), whl(def(n(), con(1), e), e), tie(t(), con(1))))), e)), v()), v()), e));
         final String output = t.toString();
         for (int i = 0; i < count; i++) {
             assertTrue(output.contains(prefix + i));

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -73,9 +73,9 @@ public class SliceTest {
         final ReadTrackingByteStream stream = new ReadTrackingByteStream(new InMemoryByteStream(toByteArray(1, 2, 3, 0, 0, 0, 4, 1)));
         final Optional<ParseState> result =
             seq(def("a", con(3)),
-                post(def("b", len(last(ref("a")))), eq(con(0, 0, 0))),
+                post(def("b", last(len(last(ref("a"))))), eq(con(0, 0, 0))),
                 def("c", con(1)),
-                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(env(createFromByteStream(stream), enc()));
+                post(def("d", last(len(last(ref("c"))))), eq(con(1)))).parse(env(createFromByteStream(stream), enc()));
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 5, 7));
         assertTrue(stream.containsNone(0, 1, 2, 6));

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -23,6 +23,7 @@ import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.exp;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
@@ -55,17 +56,17 @@ public class ExpandTest {
     }
 
     @Test
-    public void expandEmptyTimes() {
+    public void expandNotAValueTimes() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Count must evaluate to a single non-empty value.");
-        exp(con(1), div(con(1), con(0))).eval(EMPTY_PARSE_STATE, enc());
+        thrown.expectMessage("Count must evaluate to a non-empty countable value.");
+        exp(con(1), last(div(con(1), con(0)))).eval(EMPTY_PARSE_STATE, enc());
     }
 
     @Test
-    public void expandListTimes() {
+    public void expandEmptyTimes() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Count must evaluate to a single non-empty value.");
-        exp(con(1), ref("a")).eval(createFromByteStream(DUMMY_STREAM).add(PARSEVALUE_1).add(PARSEVALUE_2), enc());
+        thrown.expectMessage("Count must evaluate to a non-empty countable value.");
+        exp(con(1), last(ref("a"))).eval(EMPTY_PARSE_STATE, enc());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -84,29 +84,6 @@ public class FoldEdgeCaseTest {
     }
 
     @Test
-    public void multipleInits() {
-        final Optional<ParseState> parseResult =
-            seq(
-                def("init", 1),
-                def("init", 1),
-                def("toFold", 1),
-                def("toFold", 1),
-                cho(
-                    def("folded", 1, eq(foldLeft(ref("toFold"), Shorthand::add, ref("init")))),
-                    def("folded", 1, eq(foldRight(ref("toFold"), Shorthand::add, ref("init"))))
-                )
-            ).parse(env(stream(1, 2, 1, 2, 3)));
-        assertFalse(parseResult.isPresent());
-    }
-
-    @Test
-    public void twoInits() {
-        final ImmutableList<Value> result = fold(exp(con(1), con(2)), Shorthand::add, exp(con(1), con(2))).eval(EMPTY_PARSE_STATE, DEFAULT_ENCODING);
-        assertEquals(1, result.size);
-        assertEquals(NOT_A_VALUE, result.head);
-    }
-
-    @Test
     public void notAValueInit() {
         final ImmutableList<Value> result = fold(exp(con(1), con(2)), Shorthand::add, con(NOT_A_VALUE)).eval(EMPTY_PARSE_STATE, DEFAULT_ENCODING);
         assertEquals(1, result.size);

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.nth;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.repn;
@@ -47,11 +48,11 @@ public class NthExpressionTest {
             any("valueCount"),
             repn(
                  any("value"),
-                 ref("valueCount")),
+                 last(ref("valueCount"))),
             any("indexCount"),
             repn(
                  any("index"),
-                 ref("indexCount")));
+                 last(ref("indexCount"))));
 
     private final ValueExpression nth = nth(ref("value"), ref("index"));
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationTest.java
@@ -23,6 +23,7 @@ import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.eqNum;
 import static io.parsingdata.metal.Shorthand.iteration;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.nth;
 import static io.parsingdata.metal.Shorthand.ref;
@@ -62,7 +63,7 @@ public class CurrentIterationTest extends ParameterizedParse {
             { "[0] CURRENT_ITERATION", VALUE_EQ_ITERATION, stream(0), enc(), false },
             { "[0, 1] seq(!CURRENT_ITERATION, ...)", seq(VALUE_NOT_EQ_ITERATION, VALUE_NOT_EQ_ITERATION), stream(0, 1), enc(), true },
             { "[0] !CURRENT_ITERATION", VALUE_NOT_EQ_ITERATION, stream(0), enc(), true },
-            { "[0 | 0, 1 | 0, 0, 2 | 0, 0, 0, 3] rep(CURRENT_ITERATION)", rep(def("value", add(CURRENT_ITERATION, con(1)), eqNum(CURRENT_ITERATION))), stream(0, 0, 1, 0, 0, 2, 0, 0, 0, 3), enc(), true },
+            { "[0 | 0, 1 | 0, 0, 2 | 0, 0, 0, 3] rep(CURRENT_ITERATION)", rep(def("value", last(add(CURRENT_ITERATION, con(1))), eqNum(CURRENT_ITERATION))), stream(0, 0, 1, 0, 0, 2, 0, 0, 0, 3), enc(), true },
             { "[1, 1, 0, 1 | 0 | 1 | 3] repn=4(def(size)), repn=4(if(sizeRef(CURRENT_ITERATION) != 0, def(CURRENT_ITERATION)))", seq(repn(def("size", 1), con(4)), repn(when(def("value", con(1), eq(CURRENT_ITERATION)), not(eq(nth(ref("size"), CURRENT_ITERATION), con(0)))), con(4))), stream(1, 1, 0, 1, 0, 1, 3), enc(), true },
         });
     }

--- a/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
+++ b/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
@@ -19,16 +19,19 @@ package io.parsingdata.metal.util;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.not;
 import static io.parsingdata.metal.Shorthand.ref;
 
 import io.parsingdata.metal.Shorthand;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 
 public class TokenDefinitions {
 
     public static final ValueExpression EMPTY_VE = div(con(1), con(0)); // division by zero to wrap empty value
+    public static final SingleValueExpression EMPTY_SVE = last(EMPTY_VE); // same for SingleValueExpression
 
     private TokenDefinitions() {}
 

--- a/formats/src/main/java/io/parsingdata/metal/format/JPEG.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/JPEG.java
@@ -61,14 +61,14 @@ public final class JPEG {
                 def(MARKER, con(1), eq(con(0xff))),
                 def(IDENTIFIER, con(1), or(ltNum(con(0xd8)), gtNum(con(0xda)))),
                 def(LENGTH, con(2)),
-                def(PAYLOAD, sub(last(ref(LENGTH)), con(2))));
+                def(PAYLOAD, last(sub(last(ref(LENGTH)), con(2)))));
 
     private static final Token SCAN_SEGMENT =
             seq("scan segment",
                 def(MARKER, con(1), eq(con(0xff))),
                 def(IDENTIFIER, con(1), eq(con(0xda))),
                 def(LENGTH, con(2)),
-                def(PAYLOAD, sub(last(ref(LENGTH)), con(2))),
+                def(PAYLOAD, last(sub(last(ref(LENGTH)), con(2)))),
                 rep(cho(def("scandata", con(1), not(eq(con(0xff)))),
                         def("escape", con(2), or(eq(con(0xff00)), and(gtNum(con(0xffcf)), ltNum(con(0xffd8))))))));
 

--- a/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
@@ -50,7 +50,7 @@ public class VarIntTest extends ParameterizedParse {
         repn(
             seq(
                 varInt("varInt"),
-                post(def("decoded", len(decodeVarInt(last(ref("varInt"))))), eq(decodeVarInt(last(ref("varInt")))))
+                post(def("decoded", last(len(decodeVarInt(last(ref("varInt")))))), eq(decodeVarInt(last(ref("varInt")))))
             ), con(4));
 
     @Parameterized.Parameters(name = "{0} ({4})")


### PR DESCRIPTION
This PR merges to the branch of #282. So please review that first.

Introduces `SingleValueExpression` as proposed in #70.

Instead of the `ImmutableList<Value>` that is returned by `ValueExpression.eval(...)`, `SingleValueExpression` has a `evalSingle(...)` method with the same arguments that returns an `Optional<Value>`. `SingleValueExpression` extends `ValueExpression`, so that it can be used wherever a `ValueExpression` is required.

The default implementation of the `eval(...)` method on `SingleValueExpression` converts an empty result of `evalSingle(...)` to an empty list, otherwise the returned value is stored as single value in the returned list.

Converted to `SingleValueExpression` are:

1. `Token` arguments:
   1. the `size` argument of `Def`
   2. the `size` argument of `Nod` (essentially just a proxy for `Def`)
   2. the `n` argument of `RepN`
2. `ValueExpression` implementations:
   1. `CurrentOffset`
   2. `CurrentIteration`
   3. `Const`
   4. `First`
   5. `Last`
   6. `Count`
   7. `Self`
3. `ValueExpression` arguments:
   1. the `count` argument of `Expand`
   2. the `initial` argument of `Fold`

Tasks:
 - [x] The `Fold` implementations themselves should also be converted, not just (some of) the argument(s).
 - [x] Resolve static analysis tools results.

The unaddressed tasks that was in the list concerning refactoring the type of `Fold`'s `reducer` argument now has its own issue: #284.

This PR resolves #70.