### PR TITLE
Changed ByteStream.isAvailable(...)'s length argument to BigInteger to allow Defs of arbitrary size

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
@@ -23,6 +23,6 @@ public interface ByteStream {
 
     byte[] read(BigInteger offset, int length) throws IOException;
 
-    boolean isAvailable(BigInteger offset, int length);
+    boolean isAvailable(BigInteger offset, BigInteger length);
 
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -49,7 +49,7 @@ public class ByteStreamSource extends Source {
 
     @Override
     protected boolean isAvailable(final BigInteger offset, final BigInteger length) {
-        return input.isAvailable(checkNotNegative(offset, "offset"), checkNotNegative(length, "length").intValueExact());
+        return input.isAvailable(checkNotNegative(offset, "offset"), checkNotNegative(length, "length"));
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -138,7 +138,7 @@ public class AutoEqualityTest {
 
     public static final ByteStream DUMMY_STREAM = new ByteStream() {
         @Override public byte[] read(BigInteger offset, int length) { return new byte[0]; }
-        @Override public boolean isAvailable(BigInteger offset, int length) { return false; }
+        @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
     };
 
     private static final ParseValue PARSE_VALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());

--- a/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
@@ -31,7 +31,7 @@ public class ByteStreamSourceTest {
 
     public static final ByteStreamSource DUMMY_BYTE_STREAM_SOURCE = new ByteStreamSource(new ByteStream() {
         @Override public byte[] read(BigInteger offset, int length) throws IOException { throw new IOException("Always fails."); }
-        @Override public boolean isAvailable(BigInteger offset, int length) { return true; }
+        @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return true; }
     });
 
     @Rule

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -34,15 +34,15 @@ public class InMemoryByteStream implements ByteStream {
 
     @Override
     public byte[] read(final BigInteger offset, final int length) throws IOException {
-        if (!isAvailable(offset, length)) { throw new IOException("Data to read is not available."); }
+        if (!isAvailable(offset, BigInteger.valueOf(length))) { throw new IOException("Data to read is not available."); }
         byte[] data = new byte[length];
         System.arraycopy(this.data, offset.intValueExact(), data, 0, length);
         return data;
     }
 
     @Override
-    public boolean isAvailable(final BigInteger offset, final int length) {
-        return offset.intValueExact() + length <= data.length;
+    public boolean isAvailable(final BigInteger offset, final BigInteger length) {
+        return offset.intValueExact() + length.intValueExact() <= data.length;
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -42,7 +42,7 @@ public class InMemoryByteStream implements ByteStream {
 
     @Override
     public boolean isAvailable(final BigInteger offset, final BigInteger length) {
-        return offset.intValueExact() + length.intValueExact() <= data.length;
+        return offset.add(length).compareTo(BigInteger.valueOf(data.length)) <= 0;
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
@@ -61,7 +61,7 @@ public class ReadTrackingByteStream implements ByteStream {
     }
 
     @Override
-    public boolean isAvailable(final BigInteger offset, final int length) {
+    public boolean isAvailable(final BigInteger offset, final BigInteger length) {
         return byteStream.isAvailable(offset, length);
     }
 


### PR DESCRIPTION
Resolves #310.

Changed `ByteStream.isAvailable(...)`'s `length` argument from `int` to `BigInteger`. Even though when you start reading data the maximum length is bound by what fits into a `byte[]`, this change allows us to lazily handle larger sizes.