### PR TITLE
Improve API usability by adding SingleValueExpression-typed versions of common ValueExpressions

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -216,12 +216,12 @@ public final class Shorthand {
     public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
     public static SingleValueExpression elvis(final SingleValueExpression left, final SingleValueExpression right) { return last(new Elvis(left, right)); }
     public static SingleValueExpression count(final ValueExpression operand) { return new Count(operand); }
-    public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }
-    public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldLeft(values, reducer, initial); }
-    public static SingleValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldRight(values, reducer, null); }
-    public static SingleValueExpression foldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldRight(values, reducer, initial); }
-    public static SingleValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return foldRight(values, reducer); }
-    public static SingleValueExpression fold(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return foldRight(values, reducer, initial); }
+    public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer) { return new FoldLeft(values, reducer, null); }
+    public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer, final SingleValueExpression initial) { return new FoldLeft(values, reducer, initial); }
+    public static SingleValueExpression foldRight(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer) { return new FoldRight(values, reducer, null); }
+    public static SingleValueExpression foldRight(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer, final SingleValueExpression initial) { return new FoldRight(values, reducer, initial); }
+    public static SingleValueExpression fold(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer) { return foldRight(values, reducer); }
+    public static SingleValueExpression fold(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer, final SingleValueExpression initial) { return foldRight(values, reducer, initial); }
     public static ValueExpression rev(final ValueExpression values) { return new Reverse(values); }
     public static ValueExpression exp(final ValueExpression base, final SingleValueExpression count) { return new Expand(base, count); }
     public static BinaryValueExpression mapLeft(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression left, final ValueExpression rightExpand) { return func.apply(left, exp(rightExpand, count(left))); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -185,9 +185,9 @@ public final class Shorthand {
     public static SingleValueExpression con(final byte[] value, final Encoding encoding) { return con(ConstantFactory.createFromBytes(value, encoding)); }
     public static ValueExpression len(final ValueExpression operand) { return new Len(operand); }
     public static NameRef ref(final String name) { return ref(name, null); }
-    public static NameRef ref(final String name, final ValueExpression limit) { return new NameRef(name, limit); }
+    public static NameRef ref(final String name, final SingleValueExpression limit) { return new NameRef(name, limit); }
     public static DefinitionRef ref(final Token definition) { return ref(definition, null); }
-    public static DefinitionRef ref(final Token definition, final ValueExpression limit) { return new DefinitionRef(definition, limit); }
+    public static DefinitionRef ref(final Token definition, final SingleValueExpression limit) { return new DefinitionRef(definition, limit); }
     public static SingleValueExpression first(final ValueExpression operand) { return new First(operand); }
     public static SingleValueExpression last(final ValueExpression operand) { return new Last(operand); }
     public static SingleValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, con(1))); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -164,16 +164,27 @@ public final class Shorthand {
     public static Token when(final Token token, final Expression predicate) { return when(token, predicate, null); }
 
     public static BinaryValueExpression add(final ValueExpression left, final ValueExpression right) { return new Add(left, right); }
+    public static SingleValueExpression add(final SingleValueExpression left, final SingleValueExpression right) { return last(new Add(left, right)); }
     public static BinaryValueExpression div(final ValueExpression left, final ValueExpression right) { return new Div(left, right); }
+    public static SingleValueExpression div(final SingleValueExpression left, final SingleValueExpression right) { return last(new Div(left, right)); }
     public static BinaryValueExpression mul(final ValueExpression left, final ValueExpression right) { return new Mul(left, right); }
+    public static SingleValueExpression mul(final SingleValueExpression left, final SingleValueExpression right) { return last(new Mul(left, right)); }
     public static BinaryValueExpression sub(final ValueExpression left, final ValueExpression right) { return new Sub(left, right); }
+    public static SingleValueExpression sub(final SingleValueExpression left, final SingleValueExpression right) { return last(new Sub(left, right)); }
     public static BinaryValueExpression mod(final ValueExpression left, final ValueExpression right) { return new Mod(left, right); }
+    public static SingleValueExpression mod(final SingleValueExpression left, final SingleValueExpression right) { return last(new Mod(left, right)); }
     public static UnaryValueExpression neg(final ValueExpression operand) { return new Neg(operand); }
+    public static SingleValueExpression neg(final SingleValueExpression operand) { return last(new Neg(operand)); }
     public static BinaryValueExpression and(final ValueExpression left, final ValueExpression right) { return new io.parsingdata.metal.expression.value.bitwise.And(left, right); }
+    public static SingleValueExpression and(final SingleValueExpression left, final SingleValueExpression right) { return last(new io.parsingdata.metal.expression.value.bitwise.And(left, right)); }
     public static BinaryValueExpression or(final ValueExpression left, final ValueExpression right) { return new io.parsingdata.metal.expression.value.bitwise.Or(left, right); }
+    public static SingleValueExpression or(final SingleValueExpression left, final SingleValueExpression right) { return last(new io.parsingdata.metal.expression.value.bitwise.Or(left, right)); }
     public static UnaryValueExpression not(final ValueExpression operand) { return new io.parsingdata.metal.expression.value.bitwise.Not(operand); }
+    public static SingleValueExpression not(final SingleValueExpression operand) { return last(new io.parsingdata.metal.expression.value.bitwise.Not(operand)); }
     public static BinaryValueExpression shl(final ValueExpression left, final ValueExpression right) { return new ShiftLeft(left, right); }
+    public static SingleValueExpression shl(final SingleValueExpression left, final SingleValueExpression right) { return last(new ShiftLeft(left, right)); }
     public static BinaryValueExpression shr(final ValueExpression left, final ValueExpression right) { return new ShiftRight(left, right); }
+    public static SingleValueExpression shr(final SingleValueExpression left, final SingleValueExpression right) { return last(new ShiftRight(left, right)); }
     public static SingleValueExpression con(final long value) { return con(value, DEFAULT_ENCODING); }
     public static SingleValueExpression con(final long value, final Encoding encoding) { return con(ConstantFactory.createFromNumeric(value, encoding)); }
     public static SingleValueExpression con(final String value) { return con(value, DEFAULT_ENCODING); }
@@ -184,6 +195,7 @@ public final class Shorthand {
     public static SingleValueExpression con(final byte[] value) { return con(value, DEFAULT_ENCODING); }
     public static SingleValueExpression con(final byte[] value, final Encoding encoding) { return con(ConstantFactory.createFromBytes(value, encoding)); }
     public static ValueExpression len(final ValueExpression operand) { return new Len(operand); }
+    public static SingleValueExpression len(final SingleValueExpression operand) { return last(new Len(operand)); }
     public static NameRef ref(final String name) { return ref(name, null); }
     public static NameRef ref(final String name, final SingleValueExpression limit) { return new NameRef(name, limit); }
     public static DefinitionRef ref(final Token definition) { return ref(definition, null); }
@@ -193,12 +205,16 @@ public final class Shorthand {
     public static SingleValueExpression last(final NameRef operand) { return new Last(new NameRef(operand.reference, con(1))); }
     public static SingleValueExpression last(final DefinitionRef operand) { return new Last(new DefinitionRef(operand.reference, con(1))); }
     public static ValueExpression nth(final ValueExpression values, final ValueExpression indices) { return new Nth(values, indices); }
+    public static SingleValueExpression nth(final ValueExpression values, final SingleValueExpression index) { return last(new Nth(values, index)); }
     public static ValueExpression offset(final ValueExpression operand) { return new Offset(operand); }
+    public static SingleValueExpression offset(final SingleValueExpression operand) { return last(new Offset(operand)); }
     public static SingleValueExpression iteration(final int level) { return iteration(con(level)); }
     public static SingleValueExpression iteration(final SingleValueExpression level) { return new CurrentIteration(level); }
     public static ValueExpression cat(final ValueExpression left, final ValueExpression right) { return new Cat(left, right); }
+    public static SingleValueExpression cat(final SingleValueExpression left, final SingleValueExpression right) { return last(new Cat(left, right)); }
     public static SingleValueExpression cat(final ValueExpression operand) { return new FoldCat(operand); }
     public static ValueExpression elvis(final ValueExpression left, final ValueExpression right) { return new Elvis(left, right); }
+    public static SingleValueExpression elvis(final SingleValueExpression left, final SingleValueExpression right) { return last(new Elvis(left, right)); }
     public static SingleValueExpression count(final ValueExpression operand) { return new Count(operand); }
     public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer) { return new FoldLeft(values, reducer, null); }
     public static SingleValueExpression foldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) { return new FoldLeft(values, reducer, initial); }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldLeft.java
@@ -33,7 +33,7 @@ import io.parsingdata.metal.data.ImmutableList;
  */
 public class FoldLeft extends Fold {
 
-    public FoldLeft(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) {
+    public FoldLeft(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer, final SingleValueExpression initial) {
         super(values, reducer, initial);
     }
 
@@ -43,7 +43,7 @@ public class FoldLeft extends Fold {
     }
 
     @Override
-    protected ValueExpression reduce(final BinaryOperator<ValueExpression> reducer, final Value head, final Value tail) {
+    protected SingleValueExpression reduce(final BinaryOperator<SingleValueExpression> reducer, final Value head, final Value tail) {
         return reducer.apply(con(head), con(tail));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/FoldRight.java
@@ -32,7 +32,7 @@ import io.parsingdata.metal.data.ImmutableList;
  */
 public class FoldRight extends Fold {
 
-    public FoldRight(final ValueExpression values, final BinaryOperator<ValueExpression> reducer, final SingleValueExpression initial) {
+    public FoldRight(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer, final SingleValueExpression initial) {
         super(values, reducer, initial);
     }
 
@@ -42,7 +42,7 @@ public class FoldRight extends Fold {
     }
 
     @Override
-    protected ValueExpression reduce(final BinaryOperator<ValueExpression> reducer, final Value head, final Value tail) {
+    protected SingleValueExpression reduce(final BinaryOperator<SingleValueExpression> reducer, final Value head, final Value tail) {
         return reducer.apply(con(tail), con(head));
     }
 

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Ref.java
@@ -24,7 +24,6 @@ import static io.parsingdata.metal.data.Selection.getAllValues;
 import static io.parsingdata.metal.expression.value.NotAValue.NOT_A_VALUE;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import io.parsingdata.metal.Trampoline;

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -55,7 +55,7 @@ public class ByteLengthTest {
     private static final Token STRING = seq(
         def("length", 1),
         def("text1", last(ref("length"))),
-        def("text2", last(len(ref("text1")))));
+        def("text2", len(last(ref("text1")))));
     //  let("hasText", con(true), ltNum(len(ref("text1")), con(0))));
 
     private static final Token NAME =

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -48,22 +48,22 @@ public class ErrorsTest {
     public void noValueForSize() {
         thrown = ExpectedException.none();
         // Basic division by zero.
-        final Token nanSize = def("a", last(div(con(1), con(0))));
+        final Token nanSize = def("a", div(con(1), con(0)));
         assertFalse(nanSize.parse(env(stream(1))).isPresent());
         // Try to negate division by zero.
-        final Token negNanSize = def("a", last(neg(div(con(1), con(0)))));
+        final Token negNanSize = def("a", neg(div(con(1), con(0))));
         assertFalse(negNanSize.parse(env(stream(1))).isPresent());
         // Add one to division by zero.
-        final Token addNanSize = def("a", last(add(div(con(1), con(0)), con(1))));
+        final Token addNanSize = def("a", add(div(con(1), con(0)), con(1)));
         assertFalse(addNanSize.parse(env(stream(1))).isPresent());
         // Add division by zero to one.
-        final Token addNanSize2 = def("a", last(add(con(1), div(con(1), con(0)))));
+        final Token addNanSize2 = def("a", add(con(1), div(con(1), con(0))));
         assertFalse(addNanSize2.parse(env(stream(1))).isPresent());
         // Subtract one from division by zero.
-        final Token subNanSize = def("a", last(sub(div(con(1), con(0)), con(1))));
+        final Token subNanSize = def("a", sub(div(con(1), con(0)), con(1)));
         assertFalse(subNanSize.parse(env(stream(1))).isPresent());
         // Multiply division by zero with one.
-        final Token mulNanSize = def("a", last(mul(div(con(1), con(0)), con(1))));
+        final Token mulNanSize = def("a", mul(div(con(1), con(0)), con(1)));
         assertFalse(mulNanSize.parse(env(stream(1))).isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/IterateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/IterateTest.java
@@ -46,7 +46,7 @@ public class IterateTest extends ParameterizedParse {
             def("f", con(1), eq(con(42))));
 
     private static final Token repBrokenNToken =
-        seq(repn(any("x"), last(div(con(1), con(0)))),
+        seq(repn(any("x"), div(con(1), con(0))),
             def("f", con(1), eq(con(42))));
 
     @Parameters(name = "{0} ({4})")

--- a/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2020 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal;
+
+import static org.junit.Assert.assertTrue;
+
+import static io.parsingdata.metal.Shorthand.add;
+import static io.parsingdata.metal.Shorthand.and;
+import static io.parsingdata.metal.Shorthand.cat;
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.div;
+import static io.parsingdata.metal.Shorthand.elvis;
+import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.len;
+import static io.parsingdata.metal.Shorthand.mod;
+import static io.parsingdata.metal.Shorthand.mul;
+import static io.parsingdata.metal.Shorthand.neg;
+import static io.parsingdata.metal.Shorthand.not;
+import static io.parsingdata.metal.Shorthand.nth;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.Shorthand.or;
+import static io.parsingdata.metal.Shorthand.shl;
+import static io.parsingdata.metal.Shorthand.shr;
+import static io.parsingdata.metal.Shorthand.sub;
+import static io.parsingdata.metal.encoding.Encoding.DEFAULT_ENCODING;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import io.parsingdata.metal.data.ByteStream;
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
+
+@RunWith(Parameterized.class)
+public class ShorthandOverloadsTest {
+
+    public static final ParseState PARSE_STATE = ParseState.createFromByteStream(new ByteStream() {
+        @Override public byte[] read(BigInteger offset, int length) { return new byte[0]; }
+        @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
+    });
+
+    @Parameterized.Parameter public String description;
+    @Parameterized.Parameter(1) public SingleValueExpression toExecute;
+    @Parameterized.Parameter(2) public SingleValueExpression expectedResult;
+
+    @Parameterized.Parameters(name="SingleValueExpression {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "add", add(con(1), con(1)), con(2) },
+            { "div", div(con(12), con(4)), con(3) },
+            { "mul", mul(con(3), con(4)), con(12) },
+            { "sub", sub(con(4), con(3)), con(1) },
+            { "mod", mod(con(6), con(3)), con(0) },
+            { "neg", neg(con(0)), con(0) },
+            { "and", and(con(1), con(1)), con(1) },
+            { "or", or(con(1), con(0)), con(1) },
+            { "not", not(con(0)), con(255) },
+            { "shl", shl(con(1), con(1)), con(2) },
+            { "shr", shr(con(2), con(1)), con(1) },
+            { "len", len(con(0)), con(1) },
+            { "nth", nth(con(1), con(0)), con(1) },
+            { "offset", offset(con(0)), con(0) },
+            { "cat", cat(con(0), con(1)), con(0, 1) },
+            { "elvis", elvis(con(1), con(2)), con(1) },
+        });
+    }
+
+    @Test
+    public void test() {
+        assertTrue(eq(toExecute, expectedResult).eval(PARSE_STATE, DEFAULT_ENCODING));
+    }
+
+}

--- a/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
 
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.ParseState;
@@ -58,9 +59,9 @@ public class ShorthandOverloadsTest {
         @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
     });
 
-    @Parameterized.Parameter public String description;
-    @Parameterized.Parameter(1) public SingleValueExpression toExecute;
-    @Parameterized.Parameter(2) public SingleValueExpression expectedResult;
+    @Parameter(0) public String description;
+    @Parameter(1) public SingleValueExpression toExecute;
+    @Parameter(2) public SingleValueExpression expectedResult;
 
     @Parameterized.Parameters(name="SingleValueExpression {0}")
     public static Collection<Object[]> data() {

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -73,9 +73,9 @@ public class SliceTest {
         final ReadTrackingByteStream stream = new ReadTrackingByteStream(new InMemoryByteStream(toByteArray(1, 2, 3, 0, 0, 0, 4, 1)));
         final Optional<ParseState> result =
             seq(def("a", con(3)),
-                post(def("b", last(len(last(ref("a"))))), eq(con(0, 0, 0))),
+                post(def("b", len(last(ref("a")))), eq(con(0, 0, 0))),
                 def("c", con(1)),
-                post(def("d", last(len(last(ref("c"))))), eq(con(1)))).parse(env(createFromByteStream(stream), enc()));
+                post(def("d", len(last(ref("c")))), eq(con(1)))).parse(env(createFromByteStream(stream), enc()));
         assertTrue(result.isPresent());
         assertTrue(stream.containsAll(3, 4, 5, 7));
         assertTrue(stream.containsNone(0, 1, 2, 6));

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -59,7 +59,7 @@ public class ExpandTest {
     public void expandNotAValueTimes() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Count must evaluate to a non-empty countable value.");
-        exp(con(1), last(div(con(1), con(0)))).eval(EMPTY_PARSE_STATE, enc());
+        exp(con(1), div(con(1), con(0))).eval(EMPTY_PARSE_STATE, enc());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -56,7 +56,7 @@ import io.parsingdata.metal.data.ParseState;
  */
 public class FoldEdgeCaseTest {
 
-    private static final BinaryOperator<ValueExpression> MULTIPLE_VALUE_REDUCER = (left, right) -> ref("value");
+    private static final BinaryOperator<SingleValueExpression> EMPTY_VALUE_REDUCER = (left, right) -> (parseState, encoding) -> Optional.empty();
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
@@ -103,7 +103,7 @@ public class FoldEdgeCaseTest {
 
     private void faultyReducer(final ValueExpression expression) {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Reducer must evaluate to a single value.");
+        thrown.expectMessage("Reducer must evaluate to a value.");
 
         seq(
             def("value", 1), // the reducer returns a Ref to these two values
@@ -116,12 +116,12 @@ public class FoldEdgeCaseTest {
 
     @Test
     public void faultyReducerFoldLeft() {
-        faultyReducer(foldLeft(ref("toFold"), MULTIPLE_VALUE_REDUCER));
+        faultyReducer(foldLeft(ref("toFold"), EMPTY_VALUE_REDUCER));
     }
 
     @Test
     public void faultyReducerFoldRight() {
-        faultyReducer(foldRight(ref("toFold"), MULTIPLE_VALUE_REDUCER));
+        faultyReducer(foldRight(ref("toFold"), EMPTY_VALUE_REDUCER));
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -59,7 +59,7 @@ public class RefEdgeCaseTest {
 
     @Test
     public void nanLimit() {
-        final ImmutableList<Value> result = ref("a", last(div(con(1), con(0)))).eval(parseState, enc());
+        final ImmutableList<Value> result = ref("a", div(con(1), con(0))).eval(parseState, enc());
         assertEquals(1, result.size);
         assertEquals(NOT_A_VALUE, result.head);
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
 import static io.parsingdata.metal.Shorthand.exp;
+import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.expression.value.NotAValue.NOT_A_VALUE;
@@ -50,22 +51,15 @@ public class RefEdgeCaseTest {
     }
 
     @Test
-    public void multiLimit() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Limit must evaluate to a single non-empty value.");
-        ref("a", exp(con(1), con(3))).eval(parseState, enc());
-    }
-
-    @Test
     public void emptyLimit() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Limit must evaluate to a single non-empty value.");
-        ref("a", ref("b")).eval(parseState, enc());
+        thrown.expectMessage("Limit must evaluate to a non-empty value.");
+        ref("a", last(ref("b"))).eval(parseState, enc());
     }
 
     @Test
     public void nanLimit() {
-        final ImmutableList<Value> result = ref("a", div(con(1), con(0))).eval(parseState, enc());
+        final ImmutableList<Value> result = ref("a", last(div(con(1), con(0)))).eval(parseState, enc());
         assertEquals(1, result.size);
         assertEquals(NOT_A_VALUE, result.head);
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationTest.java
@@ -63,7 +63,7 @@ public class CurrentIterationTest extends ParameterizedParse {
             { "[0] CURRENT_ITERATION", VALUE_EQ_ITERATION, stream(0), enc(), false },
             { "[0, 1] seq(!CURRENT_ITERATION, ...)", seq(VALUE_NOT_EQ_ITERATION, VALUE_NOT_EQ_ITERATION), stream(0, 1), enc(), true },
             { "[0] !CURRENT_ITERATION", VALUE_NOT_EQ_ITERATION, stream(0), enc(), true },
-            { "[0 | 0, 1 | 0, 0, 2 | 0, 0, 0, 3] rep(CURRENT_ITERATION)", rep(def("value", last(add(CURRENT_ITERATION, con(1))), eqNum(CURRENT_ITERATION))), stream(0, 0, 1, 0, 0, 2, 0, 0, 0, 3), enc(), true },
+            { "[0 | 0, 1 | 0, 0, 2 | 0, 0, 0, 3] rep(CURRENT_ITERATION)", rep(def("value", add(CURRENT_ITERATION, con(1)), eqNum(CURRENT_ITERATION))), stream(0, 0, 1, 0, 0, 2, 0, 0, 0, 3), enc(), true },
             { "[1, 1, 0, 1 | 0 | 1 | 3] repn=4(def(size)), repn=4(if(sizeRef(CURRENT_ITERATION) != 0, def(CURRENT_ITERATION)))", seq(repn(def("size", 1), con(4)), repn(when(def("value", con(1), eq(CURRENT_ITERATION)), not(eq(nth(ref("size"), CURRENT_ITERATION), con(0)))), con(4))), stream(1, 1, 0, 1, 0, 1, 3), enc(), true },
         });
     }

--- a/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ParameterizedParse.java
@@ -39,7 +39,7 @@ import io.parsingdata.metal.token.Token;
 @RunWith(Parameterized.class)
 public class ParameterizedParse {
 
-    @Parameter public String description;
+    @Parameter(0) public String description;
     @Parameter(1) public Token token;
     @Parameter(2) public ParseState parseState;
     @Parameter(3) public Encoding encoding;

--- a/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
+++ b/core/src/test/java/io/parsingdata/metal/util/TokenDefinitions.java
@@ -30,8 +30,8 @@ import io.parsingdata.metal.token.Token;
 
 public class TokenDefinitions {
 
-    public static final ValueExpression EMPTY_VE = div(con(1), con(0)); // division by zero to wrap empty value
-    public static final SingleValueExpression EMPTY_SVE = last(EMPTY_VE); // same for SingleValueExpression
+    public static final SingleValueExpression EMPTY_SVE = div(con(1), con(0)); // division by zero to wrap empty value
+    public static final SingleValueExpression EMPTY_VE = EMPTY_SVE; // same but typed as ValueExpression
 
     private TokenDefinitions() {}
 

--- a/formats/src/main/java/io/parsingdata/metal/format/JPEG.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/JPEG.java
@@ -61,7 +61,7 @@ public final class JPEG {
                 def(MARKER, con(1), eq(con(0xff))),
                 def(IDENTIFIER, con(1), or(ltNum(con(0xd8)), gtNum(con(0xda)))),
                 def(LENGTH, con(2)),
-                def(PAYLOAD, last(sub(last(ref(LENGTH)), con(2)))));
+                def(PAYLOAD, sub(last(ref(LENGTH)), con(2))));
 
     private static final Token SCAN_SEGMENT =
             seq("scan segment",

--- a/formats/src/main/java/io/parsingdata/metal/format/VarInt.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/VarInt.java
@@ -42,7 +42,7 @@ public final class VarInt {
         return until(name, con(1), post(EMPTY, eq(and(last(bytes(last(ref(name)))), con(128)), con(0))));
     }
 
-    public static ValueExpression decodeVarInt(final ValueExpression expression) {
+    public static SingleValueExpression decodeVarInt(final ValueExpression expression) {
         return foldLeft(rev(bytes(expression)), VarInt::varIntReducer);
     }
 

--- a/formats/src/main/java/io/parsingdata/metal/format/VarInt.java
+++ b/formats/src/main/java/io/parsingdata/metal/format/VarInt.java
@@ -30,6 +30,7 @@ import static io.parsingdata.metal.Shorthand.rev;
 import static io.parsingdata.metal.Shorthand.shl;
 import static io.parsingdata.metal.Shorthand.until;
 
+import io.parsingdata.metal.expression.value.SingleValueExpression;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.token.Token;
 
@@ -38,18 +39,15 @@ public final class VarInt {
     private VarInt() {}
 
     public static Token varInt(final String name) {
-        return
-        until(name, con(1), post(EMPTY, eq(and(last(bytes(last(ref(name)))), con(128)), con(0))));
+        return until(name, con(1), post(EMPTY, eq(and(last(bytes(last(ref(name)))), con(128)), con(0))));
     }
 
     public static ValueExpression decodeVarInt(final ValueExpression expression) {
-        return
-        foldLeft(rev(bytes(expression)), VarInt::varIntReducer);
+        return foldLeft(rev(bytes(expression)), VarInt::varIntReducer);
     }
 
-    private static ValueExpression varIntReducer(final ValueExpression left, final ValueExpression right) {
-        return
-        or(shl(left, con(7)), and(right, con(127)));
+    private static SingleValueExpression varIntReducer(final SingleValueExpression left, final SingleValueExpression right) {
+        return or(shl(left, con(7)), and(right, con(127)));
     }
 
 }

--- a/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
@@ -50,7 +50,7 @@ public class VarIntTest extends ParameterizedParse {
         repn(
             seq(
                 varInt("varInt"),
-                post(def("decoded", last(len(decodeVarInt(last(ref("varInt")))))), eq(decodeVarInt(last(ref("varInt")))))
+                post(def("decoded", len(decodeVarInt(last(ref("varInt"))))), eq(decodeVarInt(last(ref("varInt")))))
             ), con(4));
 
     @Parameterized.Parameters(name = "{0} ({4})")


### PR DESCRIPTION
Resolves #285.

The `Shorthand` helper methods that we can safely create are the following:

1. Mathematical operators: `add`, `div`, `mul`, `sub`, `mod` and `neg`.
2. Bit-wise operators: `and`, `or`, `not`, `shl` and `shr`.
3. Reference operators: `len`, `nth`*, `offset`, `cat`** and `elvis`.

Note*: For `nth` this only concerns the second argument and the return value. The first argument needs to be a list to index into.
Note**: For `cat` this refers to the version that has two arguments. The single argument version of `cat` explicitly operates on lists.

There are some additional `ValueExpression`s that could be converted but I believe it's better if we don't create far-fetched cases. For example, the `mapLeft` and `mapRight` could get a `SingleValueExpression` as input argument (and then as a result also as return value), but if you know beforehand that you only need to apply something to a single value, why even use map?

Some additional things following from this:
 - [x] In the earlier issue introducing `SingleValueExpression` the `limit` argument of `Ref` should have been converted too but was not.
 - [x] For the `Fold` `ValueExpression`s, the `reducer` argument should probably be converted from `BinaryOperator<ValueExpression>` to `BinaryOperator<SingleValueExpression>`. This was noticed earlier but not changed due to usability concerns (we wanted to be able to use method references to the `Shorthand` helper methods here, which will stay possible with this change once we add the additional helper methods).
 - [x] Remove the added `last(...)` wrappings from test code that were added when `SingleValueExpression` was added (in #283, issue #70) that are now no longer needed.