### PR TITLE
Added size() to Source and size() token to obtain the size of the data

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -77,6 +77,7 @@ import io.parsingdata.metal.expression.value.reference.Ref;
 import io.parsingdata.metal.expression.value.reference.Ref.DefinitionRef;
 import io.parsingdata.metal.expression.value.reference.Ref.NameRef;
 import io.parsingdata.metal.expression.value.reference.Self;
+import io.parsingdata.metal.expression.value.reference.Size;
 import io.parsingdata.metal.token.Cho;
 import io.parsingdata.metal.token.Def;
 import io.parsingdata.metal.token.Post;
@@ -281,6 +282,8 @@ public final class Shorthand {
     /** @see FoldRight */public static SingleValueExpression fold(final ValueExpression values, final BinaryOperator<SingleValueExpression> reducer, final SingleValueExpression initial) { return foldRight(values, reducer, initial); }
     /** @see Reverse */ public static ValueExpression rev(final ValueExpression values) { return new Reverse(values); }
     /** @see Expand */ public static ValueExpression exp(final ValueExpression base, final SingleValueExpression count) { return new Expand(base, count); }
+    /** @see Size */ public static ValueExpression size() { return new Size(); }
+
 
     /** "MAPLEFT": denotes a map operation using the provided {@code func}, applied once for each result of evaluating {@code left} and reusing the single result of evaluating {@code rightExpand}. */
     public static BinaryValueExpression mapLeft(final BiFunction<ValueExpression, ValueExpression, BinaryValueExpression> func, final ValueExpression left, final SingleValueExpression rightExpand) { return func.apply(left, exp(rightExpand, count(left))); }

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStream.java
@@ -25,4 +25,5 @@ public interface ByteStream {
 
     boolean isAvailable(BigInteger offset, BigInteger length);
 
+    BigInteger size();
 }

--- a/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ByteStreamSource.java
@@ -53,6 +53,11 @@ public class ByteStreamSource extends Source {
     }
 
     @Override
+    public BigInteger size() {
+        return input.size();
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + input + ")";
     }

--- a/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConcatenatedValueSource.java
@@ -94,6 +94,11 @@ public class ConcatenatedValueSource extends Source {
     }
 
     @Override
+    public BigInteger size() {
+        return length;
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + values + "(" + length + "))";
     }

--- a/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/ConstantSource.java
@@ -51,6 +51,11 @@ public class ConstantSource extends Source {
     }
 
     @Override
+    public BigInteger size() {
+        return BigInteger.valueOf(data.length);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(0x" + bytesToHexString(data) + ")";
     }

--- a/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
+++ b/core/src/main/java/io/parsingdata/metal/data/DataExpressionSource.java
@@ -65,6 +65,11 @@ public class DataExpressionSource extends Source {
         return checkNotNegative(offset, "offset").add(checkNotNegative(length, "length")).compareTo(BigInteger.valueOf(getValue().length)) <= 0;
     }
 
+    @Override
+    public BigInteger size() {
+        return BigInteger.valueOf(getValue().length);
+    }
+
     private synchronized byte[] getValue() {
         if (cache == null) {
             final ImmutableList<Value> results = dataExpression.eval(parseState, encoding);

--- a/core/src/main/java/io/parsingdata/metal/data/Source.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Source.java
@@ -24,4 +24,5 @@ public abstract class Source {
 
     protected abstract boolean isAvailable(BigInteger offset, BigInteger length);
 
+    public abstract BigInteger size();
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Size.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Size.java
@@ -21,14 +21,10 @@ import static io.parsingdata.metal.expression.value.ConstantFactory.createFromNu
 
 import java.util.Optional;
 
-import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ParseState;
-import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.Source;
 import io.parsingdata.metal.encoding.Encoding;
-import io.parsingdata.metal.expression.value.ConstantFactory;
 import io.parsingdata.metal.expression.value.SingleValueExpression;
-import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.expression.value.ValueExpression;
 
@@ -40,20 +36,5 @@ public class Size implements SingleValueExpression {
     @Override
     public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
         return Optional.of(createFromNumeric(parseState.source.size(), DEFAULT_ENCODING));
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName();
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return Util.notNullAndSameClass(this, obj);
-    }
-
-    @Override
-    public int hashCode() {
-        return getClass().hashCode();
     }
 }

--- a/core/src/main/java/io/parsingdata/metal/expression/value/reference/Size.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/reference/Size.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2021 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value.reference;
+
+import static io.parsingdata.metal.encoding.Encoding.DEFAULT_ENCODING;
+import static io.parsingdata.metal.expression.value.ConstantFactory.createFromNumeric;
+
+import java.util.Optional;
+
+import io.parsingdata.metal.Util;
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.data.ParseValue;
+import io.parsingdata.metal.data.Source;
+import io.parsingdata.metal.encoding.Encoding;
+import io.parsingdata.metal.expression.value.ConstantFactory;
+import io.parsingdata.metal.expression.value.SingleValueExpression;
+import io.parsingdata.metal.expression.value.UnaryValueExpression;
+import io.parsingdata.metal.expression.value.Value;
+import io.parsingdata.metal.expression.value.ValueExpression;
+
+/**
+ * A {@link ValueExpression} that represents the total byte size of the {@link Source}.
+ */
+public class Size implements SingleValueExpression {
+
+    @Override
+    public Optional<Value> evalSingle(final ParseState parseState, final Encoding encoding) {
+        return Optional.of(createFromNumeric(parseState.source.size(), DEFAULT_ENCODING));
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return Util.notNullAndSameClass(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -139,6 +139,7 @@ public class AutoEqualityTest {
     public static final ByteStream DUMMY_STREAM = new ByteStream() {
         @Override public byte[] read(BigInteger offset, int length) { return new byte[0]; }
         @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
+        @Override public BigInteger size() { return BigInteger.ZERO; }
     };
 
     private static final ParseValue PARSE_VALUE = new ParseValue("a", any("a"), createFromBytes(new byte[]{1, 2}), enc());

--- a/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
@@ -57,6 +57,7 @@ public class ShorthandOverloadsTest {
     public static final ParseState PARSE_STATE = ParseState.createFromByteStream(new ByteStream() {
         @Override public byte[] read(BigInteger offset, int length) { return new byte[0]; }
         @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
+        @Override public BigInteger size() { return BigInteger.ZERO; }
     });
 
     @Parameter(0) public String description;

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -29,6 +29,7 @@ import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
+import static io.parsingdata.metal.Shorthand.eqNum;
 import static io.parsingdata.metal.Shorthand.eqStr;
 import static io.parsingdata.metal.Shorthand.gtEqNum;
 import static io.parsingdata.metal.Shorthand.gtNum;
@@ -44,6 +45,7 @@ import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.repn;
 import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.Shorthand.size;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.tie;
 import static io.parsingdata.metal.Shorthand.when;
@@ -244,4 +246,16 @@ public class ShorthandsTest {
         assertEquals(1, Selection.getAllValues(result.get().order, parseValue -> parseValue.matches("name2") && parseValue.value().length == 1 && parseValue.value()[0] == 2).size);
     }
 
+    @Test
+    public void sourceSize() {
+        int size = (int)(Math.random() * 10);
+        int[] bytes = new int[size];
+        bytes[bytes.length - 1] = 0x01;
+
+        Optional<ParseState> result = sub(def("footer", con(1), eqNum(con(0x01))), sub(size(), con(1))).parse(env(stream(bytes)));
+        assertTrue(result.isPresent());
+
+        ParseValue footer = Selection.getAllValues(result.get().order, parseValue -> parseValue.matches("footer")).head;
+        assertEquals(size, footer.slice().offset.intValue() + 1);
+    }
 }

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -248,7 +248,7 @@ public class ShorthandsTest {
 
     @Test
     public void sourceSize() {
-        int size = (int)(Math.random() * 10);
+        int size = (int)(Math.random() * 10) + 2;
         int[] bytes = new int[size];
         bytes[bytes.length - 1] = 0x01;
 

--- a/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
@@ -32,6 +32,7 @@ public class ByteStreamSourceTest {
     public static final ByteStreamSource DUMMY_BYTE_STREAM_SOURCE = new ByteStreamSource(new ByteStream() {
         @Override public byte[] read(BigInteger offset, int length) throws IOException { throw new IOException("Always fails."); }
         @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return true; }
+        @Override public BigInteger size() { return BigInteger.ZERO; }
     });
 
     @Rule

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -86,6 +86,7 @@ public class ConcatenatedValueSourceTest {
 
     @Test
     public void checkData() {
+        assertEquals(25, cvs.size().intValue());
         byte[] data = cvs.getData(BigInteger.valueOf(offset), BigInteger.valueOf(length));
         assertEquals(length, data.length);
         for (int i = 0; i < length; i++) {

--- a/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
@@ -58,6 +58,7 @@ public class ConstantSliceTest {
         final byte[] output = slice.getData();
         assertEquals(input.length, output.length);
         assertTrue(Arrays.equals(input, output));
+        assertEquals(4, slice.source.size().intValue());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -17,7 +17,7 @@
 package io.parsingdata.metal.data;
 
 import static java.math.BigInteger.ZERO;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -81,6 +81,12 @@ public class DataExpressionSourceTest {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("ValueExpression dataExpression yields NOT_A_VALUE at index 0.");
         new DataExpressionSource(div(con(1), con(0)), 0, EMPTY_PARSE_STATE, enc()).isAvailable(ZERO, ZERO);
+    }
+
+    @Test
+    public void size() {
+        final Optional<ParseState> result = setupResult();
+        assertEquals(4, result.get().source.size().intValue());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -86,7 +86,8 @@ public class DataExpressionSourceTest {
     @Test
     public void size() {
         final Optional<ParseState> result = setupResult();
-        assertEquals(4, result.get().source.size().intValue());
+        final DataExpressionSource source = new DataExpressionSource(ref("a"), 0, result.get(), enc());
+        assertEquals(4, source.size().intValue());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
@@ -41,6 +41,7 @@ public class SelectionTest {
         return new Source() {
             @Override protected byte[] getData(BigInteger offset, BigInteger length) { return new byte[0]; }
             @Override protected boolean isAvailable(BigInteger offset, BigInteger length) { return true; }
+            @Override public BigInteger size() { return BigInteger.ZERO; }
         };
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -37,6 +37,7 @@ public class ByTypeTest {
     public static final Source EMPTY_SOURCE = new Source() {
         @Override protected byte[] getData(BigInteger offset, BigInteger length) { throw new IllegalStateException(); }
         @Override protected boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
+        @Override public BigInteger size() { return BigInteger.ZERO; }
     };
 
     @Rule

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/SizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/SizeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2021 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.parsingdata.metal.expression.value.reference;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.List;
+
+import static io.parsingdata.metal.Shorthand.con;
+import static io.parsingdata.metal.Shorthand.offset;
+import static io.parsingdata.metal.Shorthand.size;
+import static io.parsingdata.metal.util.EncodingFactory.enc;
+import static io.parsingdata.metal.util.ParseStateFactory.stream;
+import static java.lang.Long.MAX_VALUE;
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.TEN;
+import static java.math.BigInteger.TWO;
+import static java.math.BigInteger.ZERO;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import io.parsingdata.metal.Shorthand;
+import io.parsingdata.metal.data.ByteStream;
+import io.parsingdata.metal.data.ByteStreamSource;
+import io.parsingdata.metal.data.ImmutableList;
+import io.parsingdata.metal.data.ParseGraph;
+import io.parsingdata.metal.data.ParseState;
+import io.parsingdata.metal.expression.value.Value;
+
+@RunWith(Parameterized.class)
+public class SizeTest {
+
+    @Parameters
+    public static Collection<BigInteger> data() {
+        return List.of(ZERO, ONE, TEN, BigInteger.valueOf(MAX_VALUE).multiply(TWO));
+    }
+
+    private BigInteger size;
+
+    public SizeTest(final BigInteger size) {
+        this.size = size;
+    }
+
+    @Test
+    public void validateSize() {
+        ByteStream byteStream = new ByteStream() {
+            @Override public byte[] read(BigInteger offset, int length) { return new byte[0]; }
+            @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
+            @Override public BigInteger size() { return size; }
+        };
+
+        final ImmutableList<Value> offsetCon = size().eval(ParseState.createFromByteStream(byteStream), enc());
+        assertEquals(1, offsetCon.size);
+        assertEquals(size, offsetCon.head.asNumeric());
+    }
+}

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/SizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/SizeTest.java
@@ -68,7 +68,7 @@ public class SizeTest {
             @Override public BigInteger size() { return size; }
         };
 
-        final ImmutableList<Value> offsetCon = size().eval(ParseState.createFromByteStream(byteStream), enc());
+        ImmutableList<Value> offsetCon = size().eval(ParseState.createFromByteStream(byteStream), enc());
         assertEquals(1, offsetCon.size);
         assertEquals(size, offsetCon.head.asNumeric());
     }

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -79,6 +79,9 @@ public class DefTest {
             @Override public boolean isAvailable(final BigInteger offset, final BigInteger length) {
                 return true;
             }
+            @Override public BigInteger size() {
+                return BigInteger.valueOf(Long.MAX_VALUE);
+            }
         };
         final ParseState state = ParseState.createFromByteStream(infiniteZeroStream, BigInteger.ONE);
         final Environment environment = new Environment(state, enc());

--- a/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/InMemoryByteStream.java
@@ -46,6 +46,11 @@ public class InMemoryByteStream implements ByteStream {
     }
 
     @Override
+    public BigInteger size() {
+        return BigInteger.valueOf(data.length);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + data.length + ")";
     }

--- a/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ReadTrackingByteStream.java
@@ -66,6 +66,11 @@ public class ReadTrackingByteStream implements ByteStream {
     }
 
     @Override
+    public BigInteger size() {
+        return byteStream.size();
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "(" + byteStream + ")";
     }


### PR DESCRIPTION
ValueExpression to easily read a footer

```
sub(
    def("footer", con(1), eqNum(con(0x01))),
    sub(size(), con(1)))
```

We could consider renaming it to `eof()` or `end()` to keep the method length 3 characters. We could also consider returning the last byte position instead of the size (so `size - 1`), but on the other hand, keeping `size()` might come in handy when we want to paginate data blocks (size == 64 might be better than lastByte == 63)