### PR TITLE
#360: Add variant to Until to allow parsing excluding terminator

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -215,7 +215,7 @@ public final class Shorthand {
 
 
     /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq}. */
-    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return seq(name, def(name, initialSize, stepSize, maxSize, terminator, encoding), terminator); }
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return seq(def(name, initialSize, stepSize, maxSize, terminator, encoding), terminator); }
 
     /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code encoding = null}. */
     public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return until(name, initialSize, stepSize, maxSize, terminator, null); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -180,7 +180,7 @@ public final class Shorthand {
     /** @see Tie */ public static Token tie(final String name, final Token token, final ValueExpression dataExpression) { return tie(name, token, dataExpression, null); }
     /** @see Tie */ public static Token tie(final Token token, final ValueExpression dataExpression, final Encoding encoding) { return tie(NO_NAME, token, dataExpression, encoding); }
     /** @see Tie */ public static Token tie(final Token token, final ValueExpression dataExpression) { return tie(token, dataExpression, null); }
-    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, encoding); }
+    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, true, encoding); }
     /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return until(name, initialSize, stepSize, maxSize, terminator, null); }
     /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, stepSize, null, terminator, encoding); }
     /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return until(name, initialSize, stepSize, null, terminator, null); }
@@ -188,6 +188,15 @@ public final class Shorthand {
     /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final Token terminator) { return until(name, initialSize, null, terminator, null); }
     /** @see Until */ public static Token until(final String name, final Token terminator, final Encoding encoding) { return until(name, null, terminator, encoding); }
     /** @see Until */ public static Token until(final String name, final Token terminator) { return until(name, terminator, null); }
+
+    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, false, encoding); }
+    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return defU(name, initialSize, stepSize, maxSize, terminator, null); }
+    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return defU(name, initialSize, stepSize, null, terminator, encoding); }
+    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return defU(name, initialSize, stepSize, null, terminator, null); }
+    public static Token defU(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return defU(name, initialSize, null, terminator, encoding); }
+    public static Token defU(final String name, final ValueExpression initialSize, final Token terminator) { return defU(name, initialSize, null, terminator, null); }
+    public static Token defU(final String name, final Token terminator, final Encoding encoding) { return defU(name, null, terminator, encoding); }
+    public static Token defU(final String name, final Token terminator) { return defU(name, terminator, null); }
 
     /** "WHEN": denotes a logical implication, parses the {@code token} only if the {@code predicate} evaluates to {code true} and subsequently only fails if {@code token} does not successfully parse. A composition of {@link Cho} and {@link Pre}. */
     public static Token when(final String name, final Token token, final Expression predicate, final Encoding encoding) { return cho(name, encoding, pre(def(EMPTY_NAME, 0), not(predicate)), token); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -126,7 +126,7 @@ public final class Shorthand {
 
 
     /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined. */
-    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, false, encoding); }
+    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, encoding); }
 
     /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code encoding = null}. */
     public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return def(name, initialSize, stepSize, maxSize, terminator, null); }

--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -124,6 +124,38 @@ public final class Shorthand {
     /** "DEFinition": Instantiates a {@link Def} with {@code size = con(size)} and {@code encoding = null}, nested in a {@link Post}. */
     public static Token def(final String name, final long size, final Expression predicate) { return def(name, size, predicate, null); }
 
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined. */
+    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, false, encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code encoding = null}. */
+    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return def(name, initialSize, stepSize, maxSize, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code maxSize = null}. */
+    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return def(name, initialSize, stepSize, null, terminator, encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code maxSize = null} and {@code encoding = null}. */
+    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return def(name, initialSize, stepSize, null, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code stepSize = null} and {@code maxSize = null}. */
+    public static Token def(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return def(name, initialSize, null, terminator, encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    public static Token def(final String name, final ValueExpression initialSize, final Token terminator) { return def(name, initialSize, null, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code initialSize = null}, {@code stepSize = null} and {@code maxSize = null}. */
+    public static Token def(final String name, final Token terminator, final Encoding encoding) { return def(name, null, terminator, encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code initialSize = null}, {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    public static Token def(final String name, final Token terminator) { return def(name, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} with the expression nested in a {@link Post} and {@code initialSize = con(1)}. */
+    public static Token def(final String name, final Expression predicate, final Encoding encoding) { return def(name, con(1), post(EMPTY, predicate), encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} where the terminator is the expression nested in a {@link Post}, {@code initialSize = con(1)} and {@code encoding = null}. */
+    public static Token def(final String name, final Expression predicate) { return def(name, predicate, null); }
+
+
     /** "NO Data": denotes data that is not required during parsing and afterwards. Instantiates a {@link Def} with {@code name = EMPTY_NAME} and {@code encoding = null}. */
     public static Token nod(final SingleValueExpression size) { return def(EMPTY_NAME, size); }
 
@@ -180,23 +212,32 @@ public final class Shorthand {
     /** @see Tie */ public static Token tie(final String name, final Token token, final ValueExpression dataExpression) { return tie(name, token, dataExpression, null); }
     /** @see Tie */ public static Token tie(final Token token, final ValueExpression dataExpression, final Encoding encoding) { return tie(NO_NAME, token, dataExpression, encoding); }
     /** @see Tie */ public static Token tie(final Token token, final ValueExpression dataExpression) { return tie(token, dataExpression, null); }
-    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, true, encoding); }
-    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return until(name, initialSize, stepSize, maxSize, terminator, null); }
-    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, stepSize, null, terminator, encoding); }
-    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return until(name, initialSize, stepSize, null, terminator, null); }
-    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, null, terminator, encoding); }
-    /** @see Until */ public static Token until(final String name, final ValueExpression initialSize, final Token terminator) { return until(name, initialSize, null, terminator, null); }
-    /** @see Until */ public static Token until(final String name, final Token terminator, final Encoding encoding) { return until(name, null, terminator, encoding); }
-    /** @see Until */ public static Token until(final String name, final Token terminator) { return until(name, terminator, null); }
 
-    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, false, encoding); }
-    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return defU(name, initialSize, stepSize, maxSize, terminator, null); }
-    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return defU(name, initialSize, stepSize, null, terminator, encoding); }
-    public static Token defU(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return defU(name, initialSize, stepSize, null, terminator, null); }
-    public static Token defU(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return defU(name, initialSize, null, terminator, encoding); }
-    public static Token defU(final String name, final ValueExpression initialSize, final Token terminator) { return defU(name, initialSize, null, terminator, null); }
-    public static Token defU(final String name, final Token terminator, final Encoding encoding) { return defU(name, null, terminator, encoding); }
-    public static Token defU(final String name, final Token terminator) { return defU(name, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq}. */
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return seq(name, def(name, initialSize, stepSize, maxSize, terminator, encoding), terminator); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code encoding = null}. */
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return until(name, initialSize, stepSize, maxSize, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code maxSize = null}. */
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, stepSize, null, terminator, encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code maxSize = null} and {@code encoding = null}. */
+    public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return until(name, initialSize, stepSize, null, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code stepSize = null} and {@code maxSize = null}. */
+    public static Token until(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, null, terminator, encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    public static Token until(final String name, final ValueExpression initialSize, final Token terminator) { return until(name, initialSize, null, terminator, null); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code initialSize = null}, {@code stepSize = null} and {@code maxSize = null}. */
+    public static Token until(final String name, final Token terminator, final Encoding encoding) { return until(name, null, terminator, encoding); }
+
+    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code initialSize = null}, {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    public static Token until(final String name, final Token terminator) { return until(name, terminator, null); }
+
 
     /** "WHEN": denotes a logical implication, parses the {@code token} only if the {@code predicate} evaluates to {code true} and subsequently only fails if {@code token} does not successfully parse. A composition of {@link Cho} and {@link Pre}. */
     public static Token when(final String name, final Token token, final Expression predicate, final Encoding encoding) { return cho(name, encoding, pre(def(EMPTY_NAME, 0), not(predicate)), token); }

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -59,6 +59,10 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  * <code>terminator</code> is made. Parsing fails if no combination of any size
  * is found where the <code>terminator</code> parses successfully.
  * <p>
+ * Whether the resulting <code>ParseState</code> includes the parsed
+ * terminator, depends on the value of the <code>includeTerminator</code>
+ * argument.
+ * <p>
  * If the <code>ValueExpressions</code> evaluate to lists, they are treated
  * as sets of values to attempt. If <code>stepSize</code> is negative,
  * <code>maxSize</code> must be smaller than <code>initialSize</code>.

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -146,7 +146,8 @@ public class Until extends Token {
             && Objects.equals(initialSize, ((Until)obj).initialSize)
             && Objects.equals(stepSize, ((Until)obj).stepSize)
             && Objects.equals(maxSize, ((Until)obj).maxSize)
-            && Objects.equals(terminator, ((Until)obj).terminator);
+            && Objects.equals(terminator, ((Until)obj).terminator)
+            && Objects.equals(includeTerminator, ((Until)obj).includeTerminator);
     }
 
     @Override

--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -80,15 +80,13 @@ public class Until extends Token {
     public final ValueExpression stepSize;
     public final ValueExpression maxSize;
     public final Token terminator;
-    public final boolean includeTerminator;
 
-    public Until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final boolean includeTerminator, final Encoding encoding) {
+    public Until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) {
         super(checkNotEmpty(name, "name"), encoding);
         this.initialSize = initialSize == null ? DEFAULT_INITIAL : initialSize;
         this.stepSize = stepSize == null ? DEFAULT_STEP : stepSize;
         this.maxSize = maxSize == null ? DEFAULT_MAX : maxSize;
         this.terminator = checkNotNull(terminator, "terminator");
-        this.includeTerminator = includeTerminator;
     }
 
     @Override
@@ -120,15 +118,10 @@ public class Until extends Token {
 
     private Trampoline<Optional<ParseState>> parseSlice(final Environment environment, final BigInteger currentSize, final BigInteger stepSize, final BigInteger maxSize, final Slice slice) {
         return (currentSize.compareTo(ZERO) == 0 ? Optional.of(environment.parseState) : environment.parseState.add(new ParseValue(environment.scope, this, slice, environment.encoding)).seek(environment.parseState.offset.add(currentSize)))
-            .map(preparedParseState -> parseTerminator(environment, preparedParseState))
+            .map(preparedParseState -> terminator.parse(environment.withParseState(preparedParseState)).map(ignore -> preparedParseState))
             .orElseGet(Util::failure)
             .map(parseState -> complete(() -> success(parseState)))
             .orElseGet(() -> intermediate(() -> iterate(environment, currentSize.add(stepSize), stepSize, maxSize)));
-    }
-
-    private Optional<ParseState> parseTerminator(final Environment environment, final ParseState parseStateExcludingTerminator) {
-        return terminator.parse(environment.withParseState(parseStateExcludingTerminator))
-            .map(parseStateIncludingTerminator -> includeTerminator ? parseStateIncludingTerminator : parseStateExcludingTerminator);
     }
 
     private boolean checkNotValidList(final ImmutableList<Value> list) {
@@ -150,8 +143,7 @@ public class Until extends Token {
             && Objects.equals(initialSize, ((Until)obj).initialSize)
             && Objects.equals(stepSize, ((Until)obj).stepSize)
             && Objects.equals(maxSize, ((Until)obj).maxSize)
-            && Objects.equals(terminator, ((Until)obj).terminator)
-            && Objects.equals(includeTerminator, ((Until)obj).includeTerminator);
+            && Objects.equals(terminator, ((Until)obj).terminator);
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -153,8 +153,8 @@ public class ArgumentsTest {
             { TokenRef.class, new Object[] { null, VALID_NAME, null } },
             { TokenRef.class, new Object[] { null, null, null } },
             { TokenRef.class, new Object[] { VALID_NAME, EMPTY_NAME, null } },
-            { Until.class, new Object[] { null, VALID_VE, VALID_VE, VALID_VE, VALID_T, true, null }},
-            { Until.class, new Object[] { VALID_NAME, VALID_VE, VALID_VE, VALID_VE, null, false, null }}
+            { Until.class, new Object[] { null, VALID_VE, VALID_VE, VALID_VE, VALID_T, null }},
+            { Until.class, new Object[] { VALID_NAME, VALID_VE, VALID_VE, VALID_VE, null, null }}
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -153,8 +153,8 @@ public class ArgumentsTest {
             { TokenRef.class, new Object[] { null, VALID_NAME, null } },
             { TokenRef.class, new Object[] { null, null, null } },
             { TokenRef.class, new Object[] { VALID_NAME, EMPTY_NAME, null } },
-            { Until.class, new Object[] { null, VALID_VE, VALID_VE, VALID_VE, VALID_T, null }},
-            { Until.class, new Object[] { VALID_NAME, VALID_VE, VALID_VE, VALID_VE, null, null }}
+            { Until.class, new Object[] { null, VALID_VE, VALID_VE, VALID_VE, VALID_T, true, null }},
+            { Until.class, new Object[] { VALID_NAME, VALID_VE, VALID_VE, VALID_VE, null, false, null }}
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -166,6 +166,7 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> BIG_INTEGERS = Arrays.asList(() -> ONE, () -> BigInteger.valueOf(3));
     private static final List<Supplier<Object>> PARSE_STATES = Arrays.asList(() -> createFromByteStream(DUMMY_STREAM), () -> createFromByteStream(DUMMY_STREAM, ONE), () -> new ParseState(GRAPH_WITH_REFERENCE, DUMMY_BYTE_STREAM_SOURCE, TEN, new ImmutableList<>(), new ImmutableList<>()));
     private static final List<Supplier<Object>> IMMUTABLE_LISTS = Arrays.asList(ImmutableList::new, () -> ImmutableList.create("TEST"), () -> ImmutableList.create(1), () -> ImmutableList.create(1).add(2));
+    private static final List<Supplier<Object>> BOOLEANS = Arrays.asList(() -> true, () -> false);
     private static final Map<Class, List<Supplier<Object>>> mapping = buildMap();
 
     private static Map<Class, List<Supplier<Object>>> buildMap() {
@@ -190,6 +191,7 @@ public class AutoEqualityTest {
         result.put(BigInteger.class, BIG_INTEGERS);
         result.put(ParseState.class, PARSE_STATES);
         result.put(ImmutableList.class, IMMUTABLE_LISTS);
+        result.put(boolean.class, BOOLEANS);
         return result;
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -164,14 +164,25 @@ class UntilTest {
     }
 
     @Test
-    public void nameScope() {
+    public void nameScopeWithUntil() {
         final Token terminator = def("terminator", con(1), eq(con(0x00)));
         final Token token = seq("struct", until("value", terminator), terminator);
         final Optional<ParseState> parse = token.parse(env(stream('d', 'a', 't', 'a', 0, 0)));
         assertTrue(parse.isPresent());
         assertEquals(1, getAllValues(parse.get().order, "struct.terminator").size);
-        assertEquals(1, getAllValues(parse.get().order, "struct.value").size);
+        assertEquals(1, getAllValues(parse.get().order, "struct.value.value").size);
         assertEquals(1, getAllValues(parse.get().order, "struct.value.terminator").size);
+        assertEquals("data", getAllValues(parse.get().order, "struct.value.value").head.asString());
+    }
+
+    @Test
+    public void nameScopeWithDef() {
+        final Token terminator = def("terminator", con(1), eq(con(0x00)));
+        final Token token = seq("struct", def("value", terminator), terminator);
+        final Optional<ParseState> parse = token.parse(env(stream('d', 'a', 't', 'a', 0, 0)));
+        assertTrue(parse.isPresent());
+        assertEquals(1, getAllValues(parse.get().order, "struct.terminator").size);
+        assertEquals(1, getAllValues(parse.get().order, "struct.value").size);
         assertEquals("data", getAllValues(parse.get().order, "struct.value").head.asString());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runners.Parameterized.Parameters;
 
-public class UntilTest {
+class UntilTest {
 
     private static final String INPUT_1 = "Hello, World!";
     private static final String INPUT_2 = "Another line...";
@@ -65,7 +65,7 @@ public class UntilTest {
     public static final Token NEXT_START_WITH_TERMINATOR = sub(NEWLINE, CURRENT_OFFSET);
 
     @Parameters(name="{0}")
-    public static Collection<Object[]> data() {
+    static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
             { "until: terminator not part of line, available in parseGraph",  until("line", NEWLINE),                                  3, 3, INPUT_1, INPUT_2, INPUT_3},
             { "until: terminator part of line, not available in parseGraph",  until("line", con(1), END_WITH_NEWLINE_POST),      3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
@@ -83,7 +83,7 @@ public class UntilTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void repTest(final String name, final Token token, final int lineCount, final int newlineCount, final String line1, final String line2, final String line3) {
+    void repTest(final String name, final Token token, final int lineCount, final int newlineCount, final String line1, final String line2, final String line3) {
         final Optional<ParseState> parseState = rep(token).parse(env(stream(INPUT, US_ASCII)));
         assertTrue(parseState.isPresent());
 
@@ -98,7 +98,7 @@ public class UntilTest {
     }
 
     @Parameters(name="{0}")
-    public static Collection<Object[]> defUShorthands() {
+    static Collection<Object[]> defUShorthands() {
         return Arrays.asList(new Object[][] {
             { "defU",                         defU("line", NEWLINE)               },
             { "defU initial size",            defU("line", con(13), NEWLINE)},
@@ -112,7 +112,7 @@ public class UntilTest {
 
     @ParameterizedTest
     @MethodSource("defUShorthands")
-    public void shorthandTest(final String name, final Token token) {
+    void shorthandTest(final String name, final Token token) {
         final Optional<ParseState> parseState = rep(seq(token, NEWLINE)).parse(env(stream(INPUT, US_ASCII)));
         assertTrue(parseState.isPresent());
 
@@ -127,12 +127,12 @@ public class UntilTest {
     }
 
     @Test
-    public void allDefaultValueExpressions() {
+    void allDefaultValueExpressions() {
         assertTrue(until("value", def("terminator", 1, eq(con(0)))).parse(env(stream(1, 2, 3, 0))).isPresent());
     }
 
     @Test
-    public void errorNegativeSize() {
+    void errorNegativeSize() {
         assertFalse(until("value", con(-1, signed()), def("terminator", 1, eq(con(0)))).parse(env(stream(1, 2, 3, 0))).isPresent());
     }
 }

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -65,25 +65,27 @@ class UntilTest {
     public static final Token END_WITH_NEWLINE_SUB = sub(NEWLINE, sub(CURRENT_OFFSET, con(1)));
     public static final Token NEXT_START_WITH_TERMINATOR = sub(NEWLINE, CURRENT_OFFSET);
 
-    static Collection<Object[]> data() {
+    static Collection<Object[]> repTest() {
         return Arrays.asList(new Object[][] {
-            { "until: terminator not part of line, available in parseGraph",  until("line", NEWLINE),                                  3, 3, INPUT_1, INPUT_2, INPUT_3},
+            { "until: terminator not part of line, available in parseGraph",  until("line", NEWLINE),                            3, 3, INPUT_1, INPUT_2, INPUT_3},
             { "until: terminator part of line, not available in parseGraph",  until("line", con(1), END_WITH_NEWLINE_POST),      3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
             { "until: terminator part of line, available in parseGraph",      until("line", con(1), END_WITH_NEWLINE_SUB),       3, 3, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
             { "until: terminator part of next line, available in parseGraph", until("line", con(1), NEXT_START_WITH_TERMINATOR), 3, 3, INPUT_1, '\n' + INPUT_2, '\n' + INPUT_3},
 
-            { "def: terminator not part of line, available in parseGraph",  seq(def("line", NEWLINE), NEWLINE),                        3, 3, INPUT_1, INPUT_2, INPUT_3},
             { "def: terminator part of line, not available in parseGraph",      def("line", con(1), END_WITH_NEWLINE_POST),      3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
             { "def: terminator part of line, not available in parseGraph",      def("line", con(1), END_WITH_NEWLINE_SUB),       3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
-            { "def: terminator part of line, not available in parseGraph",      def("line", ENDS_WITH_NEWLINE),                        3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
+            { "def: terminator part of line, not available in parseGraph",      def("line", ENDS_WITH_NEWLINE),                  3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
             { "def: terminator part of next line, not available in parseGraph", def("line", con(1), NEWLINE),                    3, 0, INPUT_1, '\n' + INPUT_2, '\n' + INPUT_3},
             { "def: terminator part of next line, not available in parseGraph", def("line", con(1), NEXT_START_WITH_TERMINATOR), 3, 0, INPUT_1, '\n' + INPUT_2, '\n' + INPUT_3},
-            // "def: terminator part of line, available in parseGraph" is not possible with def, only with until.
+
+            { "def: terminator not part of line, available in parseGraph",  seq(def("line", NEWLINE), NEWLINE),                                               3, 3, INPUT_1, INPUT_2, INPUT_3},
+            { "def: terminator part of line, available in parseGraph",      seq(def("line", con(1), END_WITH_NEWLINE_SUB), END_WITH_NEWLINE_SUB),             3, 3, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
+            { "def: terminator part of next line, available in parseGraph", seq(def("line", con(1), NEXT_START_WITH_TERMINATOR), NEXT_START_WITH_TERMINATOR), 3, 3, INPUT_1, '\n' + INPUT_2, '\n' + INPUT_3}
         });
     }
 
     @ParameterizedTest(name="{0}")
-    @MethodSource("data")
+    @MethodSource
     void repTest(final String name, final Token token, final int lineCount, final int newlineCount, final String line1, final String line2, final String line3) {
         final Optional<ParseState> parseState = rep(token).parse(env(stream(INPUT, US_ASCII)));
         assertTrue(parseState.isPresent());

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -17,38 +17,40 @@
 package io.parsingdata.metal.token;
 
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
-import static io.parsingdata.metal.Shorthand.defU;
-import static io.parsingdata.metal.Shorthand.rep;
-import static io.parsingdata.metal.Shorthand.sub;
-import static java.nio.charset.StandardCharsets.US_ASCII;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import static io.parsingdata.metal.Shorthand.EMPTY;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
+import static io.parsingdata.metal.Shorthand.defU;
 import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.Shorthand.last;
 import static io.parsingdata.metal.Shorthand.mod;
 import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.ref;
-import static io.parsingdata.metal.Shorthand.repn;
+import static io.parsingdata.metal.Shorthand.rep;
+import static io.parsingdata.metal.Shorthand.seq;
+import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
-
-import org.junit.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
-import io.parsingdata.metal.expression.value.ValueExpression;
+import io.parsingdata.metal.encoding.Encoding;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.runners.Parameterized.Parameters;
 
 public class UntilTest {
 
@@ -56,81 +58,72 @@ public class UntilTest {
     private static final String INPUT_2 = "Another line...";
     private static final String INPUT_3 = "Another way to scroll...";
     private static final String INPUT = INPUT_1 + "\n" + INPUT_2 + "\n" + INPUT_3 + "\n";
+
     public static final Token NEWLINE = def("newline", con(1), eq(con('\n')));
+    public static final Token END_WITH_NEWLINE_POST = post(EMPTY, eq(mod(last(ref("line")), con(256)), con('\n')));
+    public static final Token END_WITH_NEWLINE_SUB = sub(NEWLINE, sub(CURRENT_OFFSET, con(1)));
+    public static final Token NEXT_START_WITH_TERMINATOR = sub(NEWLINE, CURRENT_OFFSET);
 
-    @Test
-    public void threeNewLines() {
-        final Optional<ParseState> parseState = rep(until("line", NEWLINE)).parse(env(stream(INPUT, US_ASCII)));
+    @Parameters(name="{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "until: terminator not part of line, available in parseGraph",  until("line", NEWLINE),                                  3, 3, INPUT_1, INPUT_2, INPUT_3},
+            { "until: terminator part of line, not available in parseGraph",  until("line", con(1), END_WITH_NEWLINE_POST),      3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
+            { "until: terminator part of line, available in parseGraph",      until("line", con(1), END_WITH_NEWLINE_SUB),       3, 3, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
+            { "until: terminator part of next line, available in parseGraph", until("line", con(1), NEXT_START_WITH_TERMINATOR), 3, 3, INPUT_1, '\n' + INPUT_2, '\n' + INPUT_3},
+
+            { "defU: terminator not part of line, available in parseGraph",  seq(defU("line", NEWLINE), NEWLINE),                        3, 3, INPUT_1, INPUT_2, INPUT_3},
+            { "defU: terminator part of line, not available in parseGraph",      defU("line", con(1), END_WITH_NEWLINE_POST),      3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
+            { "defU: terminator part of line, not available in parseGraph",      defU("line", con(1), END_WITH_NEWLINE_SUB),       3, 0, INPUT_1 + '\n', INPUT_2 + '\n', INPUT_3 + '\n'},
+            { "defU: terminator part of next line, not available in parseGraph", defU("line", con(1), NEWLINE),                    3, 0, INPUT_1, '\n' + INPUT_2, '\n' + INPUT_3},
+            { "defU: terminator part of next line, not available in parseGraph", defU("line", con(1), NEXT_START_WITH_TERMINATOR), 3, 0, INPUT_1, '\n' + INPUT_2, '\n' + INPUT_3},
+            // "defU: terminator part of line, available in parseGraph" is not possible with defU, only with until.
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void repTest(final String name, final Token token, final int lineCount, final int newlineCount, final String line1, final String line2, final String line3) {
+        final Optional<ParseState> parseState = rep(token).parse(env(stream(INPUT, US_ASCII)));
+        assertTrue(parseState.isPresent());
+
+        ImmutableList<ParseValue> values = getAllValues(parseState.get().order, "line");
+        assertEquals(lineCount, values.size);
+        assertEquals(line1, values.tail.tail.head.asString());
+        assertEquals(line2, values.tail.head.asString());
+        assertEquals(line3, values.head.asString());
+
+        ImmutableList<ParseValue> newLines = getAllValues(parseState.get().order, "newline");
+        assertEquals(newlineCount, newLines.size);
+    }
+
+    @Parameters(name="{0}")
+    public static Collection<Object[]> defUShorthands() {
+        return Arrays.asList(new Object[][] {
+            { "defU",                         defU("line", NEWLINE)               },
+            { "defU initial size",            defU("line", con(13), NEWLINE)},
+            { "defU initial size + encoding", defU("line", con(13), NEWLINE, Encoding.DEFAULT_ENCODING)},
+            { "defU step size",               defU("line", con(13), con(1), NEWLINE)},
+            { "defU step size + encoding",    defU("line", con(13), con(1), NEWLINE, Encoding.DEFAULT_ENCODING)},
+            { "defU max size",                defU("line", con(13), con(1), con(24), NEWLINE)},
+            { "defU max size + encoding",     defU("line", con(13), con(1), con(24), NEWLINE, Encoding.DEFAULT_ENCODING)},
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("defUShorthands")
+    public void shorthandTest(final String name, final Token token) {
+        final Optional<ParseState> parseState = rep(seq(token, NEWLINE)).parse(env(stream(INPUT, US_ASCII)));
         assertTrue(parseState.isPresent());
 
         ImmutableList<ParseValue> values = getAllValues(parseState.get().order, "line");
         assertEquals(3, values.size);
-        assertEquals(INPUT_3, values.head.asString());
-        assertEquals(INPUT_2, values.tail.head.asString());
         assertEquals(INPUT_1, values.tail.tail.head.asString());
+        assertEquals(INPUT_2, values.tail.head.asString());
+        assertEquals(INPUT_3, values.head.asString());
 
         ImmutableList<ParseValue> newLines = getAllValues(parseState.get().order, "newline");
         assertEquals(3, newLines.size);
-    }
-
-    @Test
-    public void untilInclusiveWithEmptyInParseGraph() {
-        final Token terminator = post(EMPTY, eq(mod(last(ref("line")), con(256)), con('\n')));
-        final Optional<ParseState> parseState = rep(until("line", con(1), terminator)).parse(env(stream(INPUT, US_ASCII)));
-        assertTrue(parseState.isPresent());
-
-        ImmutableList<ParseValue> values = getAllValues(parseState.get().order, "line");
-        assertEquals(3, values.size);
-        assertEquals(INPUT_3 + '\n', values.head.asString());
-        assertEquals(INPUT_2 + '\n', values.tail.head.asString());
-        assertEquals(INPUT_1 + '\n', values.tail.tail.head.asString());
-    }
-
-    @Test
-    public void untilInclusiveWithTerminatorInParseGraph() {
-        final Token terminator = sub(NEWLINE, sub(CURRENT_OFFSET, con(1)));
-        final Optional<ParseState> parseState = rep(until("line", con(1), terminator)).parse(env(stream(INPUT, US_ASCII)));
-        assertTrue(parseState.isPresent());
-
-        ImmutableList<ParseValue> lines = getAllValues(parseState.get().order, "line");
-        assertEquals(3, lines.size);
-        assertEquals(INPUT_3 + '\n', lines.head.asString());
-        assertEquals(INPUT_2 + '\n', lines.tail.head.asString());
-        assertEquals(INPUT_1 + '\n', lines.tail.tail.head.asString());
-
-        ImmutableList<ParseValue> newLines = getAllValues(parseState.get().order, "newline");
-        assertEquals(3, newLines.size);
-    }
-
-    @Test
-    public void untilExclusiveWithTerminatorInParseGraph() {
-        final Token terminator = sub(NEWLINE, CURRENT_OFFSET);
-        final Optional<ParseState> parseState = rep(until("line", con(1), terminator)).parse(env(stream(INPUT, US_ASCII)));
-        assertTrue(parseState.isPresent());
-
-        ImmutableList<ParseValue> lines = getAllValues(parseState.get().order, "line");
-        assertEquals(3, lines.size);
-        assertEquals("\n" + INPUT_3 , lines.head.asString());
-        assertEquals("\n" + INPUT_2, lines.tail.head.asString());
-        assertEquals(INPUT_1, lines.tail.tail.head.asString());
-
-        ImmutableList<ParseValue> newLines = getAllValues(parseState.get().order, "newline");
-        assertEquals(3, newLines.size);
-    }
-
-    @Test
-    public void defUnterminated() {
-        final Optional<ParseState> parseState = rep(defU("line", con(1), NEWLINE)).parse(env(stream(INPUT, US_ASCII)));
-        assertTrue(parseState.isPresent());
-
-        ImmutableList<ParseValue> lines = getAllValues(parseState.get().order, "line");
-        assertEquals(3, lines.size);
-        assertEquals("\n" + INPUT_3 , lines.head.asString());
-        assertEquals("\n" + INPUT_2, lines.tail.head.asString());
-        assertEquals(INPUT_1, lines.tail.tail.head.asString());
-
-        ImmutableList<ParseValue> newLines = getAllValues(parseState.get().order, "newline");
-        assertEquals(0, newLines.size);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
   <properties>
     <encoding>UTF-8</encoding>
 
+    <junit-jupiter.version>5.9.2</junit-jupiter.version>
     <junit.version>4.13.2</junit.version>
 
     <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
@@ -71,6 +72,7 @@
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-project-info-reports.version>3.4.2</maven-project-info-reports.version>
+    <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
   </properties>
 
   <profiles>
@@ -97,6 +99,23 @@
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
     </dependency>
   </dependencies>
 
@@ -188,6 +207,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>${maven-site-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
There are three scenarios where you would like to use Until:

1. when there is a separate terminator between structure A and B (A|T|B)
2. when you know how structure A ends (AT|B)
3. when you know how structure B starts (A|TB)

The current implementation of Until parses two structures: a def and the terminator.
The current implementation can handle 1. correctly, but for 2 and 3 requires some hacky solutions with some drawbacks. See examples solutions below.

1. until("A", T)
2. until("A", post(EMPTY, endsWith(T)))
3. until("A", sub(T, CURRENT_OFFSET))

Especially for scenario 3, the "T" part is parsed twice and is also available twice in the parseGraph.
This can be resolved by allowing two implementations of Until where you can specify if the terminator should be part of the parseGraph.

This PR includes the new shorthands "defU" (name still in progress) that parses the def, but not the terminator. It uses the same Until class, but with an additional boolean indicating if the terminator should be included or not.

Resolves #360.