### PR TITLE
#367 Use scope of environment for ParseValue in Until instead of the direct name.

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/token/Until.java
+++ b/core/src/main/java/io/parsingdata/metal/token/Until.java
@@ -113,7 +113,7 @@ public class Until extends Token {
     }
 
     private Trampoline<Optional<ParseState>> parseSlice(final Environment environment, final BigInteger currentSize, final BigInteger stepSize, final BigInteger maxSize, final Slice slice) {
-        return (currentSize.compareTo(ZERO) == 0 ? Optional.of(environment.parseState) : environment.parseState.add(new ParseValue(name, this, slice, environment.encoding)).seek(environment.parseState.offset.add(currentSize)))
+        return (currentSize.compareTo(ZERO) == 0 ? Optional.of(environment.parseState) : environment.parseState.add(new ParseValue(environment.scope, this, slice, environment.encoding)).seek(environment.parseState.offset.add(currentSize)))
             .map(preparedParseState -> terminator.parse(environment.withParseState(preparedParseState)))
             .orElseGet(Util::failure)
             .map(parsedParseState -> complete(() -> success(parsedParseState)))

--- a/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/UntilTest.java
@@ -17,6 +17,7 @@
 package io.parsingdata.metal.token;
 
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
+import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
@@ -125,6 +126,18 @@ public class UntilTest {
 
     private Token createToken(final ValueExpression initialSize, final Token terminator) {
         return repn(until("line", initialSize, terminator), con(3));
+    }
+
+    @Test
+    public void nameScope() {
+        final Token terminator = def("terminator", con(1), eq(con(0x00)));
+        final Token token = seq("struct", until("value", terminator), terminator);
+        final Optional<ParseState> parse = token.parse(env(stream('d', 'a', 't', 'a', 0, 0)));
+        assertTrue(parse.isPresent());
+        assertEquals(1, getAllValues(parse.get().order, "struct.terminator").size);
+        assertEquals(1, getAllValues(parse.get().order, "struct.value").size);
+        assertEquals(1, getAllValues(parse.get().order, "struct.value.terminator").size);
+        assertEquals("data", getAllValues(parse.get().order, "struct.value").head.asString());
     }
 
 }


### PR DESCRIPTION
Due to this bug you are unable to select a specific value from the `ParseGraph` in an other structure.

Included a test, which failed without the fix.

Resolves #367 