### PR TITLE
-#360: Rename Until class to DefUntil

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/Shorthand.java
+++ b/core/src/main/java/io/parsingdata/metal/Shorthand.java
@@ -87,7 +87,7 @@ import io.parsingdata.metal.token.Seq;
 import io.parsingdata.metal.token.Tie;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
-import io.parsingdata.metal.token.Until;
+import io.parsingdata.metal.token.DefUntil;
 import io.parsingdata.metal.token.While;
 
 public final class Shorthand {
@@ -125,34 +125,34 @@ public final class Shorthand {
     public static Token def(final String name, final long size, final Expression predicate) { return def(name, size, predicate, null); }
 
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined. */
-    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new Until(name, initialSize, stepSize, maxSize, terminator, encoding); }
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined. */
+    public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return new DefUntil(name, initialSize, stepSize, maxSize, terminator, encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined with {@code encoding = null}. */
     public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return def(name, initialSize, stepSize, maxSize, terminator, null); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code maxSize = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined with {@code maxSize = null}. */
     public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return def(name, initialSize, stepSize, null, terminator, encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code maxSize = null} and {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined with {@code maxSize = null} and {@code encoding = null}. */
     public static Token def(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return def(name, initialSize, stepSize, null, terminator, null); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code stepSize = null} and {@code maxSize = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined with {@code stepSize = null} and {@code maxSize = null}. */
     public static Token def(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return def(name, initialSize, null, terminator, encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined with {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
     public static Token def(final String name, final ValueExpression initialSize, final Token terminator) { return def(name, initialSize, null, terminator, null); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code initialSize = null}, {@code stepSize = null} and {@code maxSize = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined with {@code initialSize = null}, {@code stepSize = null} and {@code maxSize = null}. */
     public static Token def(final String name, final Token terminator, final Encoding encoding) { return def(name, null, terminator, encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the size of the def is dynamically determined with {@code initialSize = null}, {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the size of the def is dynamically determined with {@code initialSize = null}, {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
     public static Token def(final String name, final Token terminator) { return def(name, terminator, null); }
 
-    /** "DEFinition": Instantiates a {@link Until} with the expression nested in a {@link Post} and {@code initialSize = con(1)}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} with the expression nested in a {@link Post} and {@code initialSize = con(1)}. */
     public static Token def(final String name, final Expression predicate, final Encoding encoding) { return def(name, con(1), post(EMPTY, predicate), encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} where the terminator is the expression nested in a {@link Post}, {@code initialSize = con(1)} and {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} where the terminator is the expression nested in a {@link Post}, {@code initialSize = con(1)} and {@code encoding = null}. */
     public static Token def(final String name, final Expression predicate) { return def(name, predicate, null); }
 
 
@@ -214,28 +214,28 @@ public final class Shorthand {
     /** @see Tie */ public static Token tie(final Token token, final ValueExpression dataExpression) { return tie(token, dataExpression, null); }
 
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq}. */
     public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) { return seq(def(name, initialSize, stepSize, maxSize, terminator, encoding), terminator); }
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq} with {@code encoding = null}. */
     public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator) { return until(name, initialSize, stepSize, maxSize, terminator, null); }
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code maxSize = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq} with {@code maxSize = null}. */
     public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, stepSize, null, terminator, encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code maxSize = null} and {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq} with {@code maxSize = null} and {@code encoding = null}. */
     public static Token until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final Token terminator) { return until(name, initialSize, stepSize, null, terminator, null); }
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code stepSize = null} and {@code maxSize = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq} with {@code stepSize = null} and {@code maxSize = null}. */
     public static Token until(final String name, final ValueExpression initialSize, final Token terminator, final Encoding encoding) { return until(name, initialSize, null, terminator, encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq} with {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
     public static Token until(final String name, final ValueExpression initialSize, final Token terminator) { return until(name, initialSize, null, terminator, null); }
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code initialSize = null}, {@code stepSize = null} and {@code maxSize = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq} with {@code initialSize = null}, {@code stepSize = null} and {@code maxSize = null}. */
     public static Token until(final String name, final Token terminator, final Encoding encoding) { return until(name, null, terminator, encoding); }
 
-    /** "DEFinition": Instantiates a {@link Until} and its terminator nested in a {@link Seq} with {@code initialSize = null}, {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
+    /** "DEFinition": Instantiates a {@link DefUntil} and its terminator nested in a {@link Seq} with {@code initialSize = null}, {@code stepSize = null}, {@code maxSize = null} and {@code encoding = null}. */
     public static Token until(final String name, final Token terminator) { return until(name, terminator, null); }
 
 

--- a/core/src/main/java/io/parsingdata/metal/token/DefUntil.java
+++ b/core/src/main/java/io/parsingdata/metal/token/DefUntil.java
@@ -70,7 +70,7 @@ import io.parsingdata.metal.expression.value.ValueExpression;
  *
  * @see ValueExpression
  */
-public class Until extends Token {
+public class DefUntil extends Token {
 
     public static final ValueExpression DEFAULT_INITIAL = con(0);
     public static final ValueExpression DEFAULT_STEP = con(1);
@@ -81,7 +81,7 @@ public class Until extends Token {
     public final ValueExpression maxSize;
     public final Token terminator;
 
-    public Until(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) {
+    public DefUntil(final String name, final ValueExpression initialSize, final ValueExpression stepSize, final ValueExpression maxSize, final Token terminator, final Encoding encoding) {
         super(checkNotEmpty(name, "name"), encoding);
         this.initialSize = initialSize == null ? DEFAULT_INITIAL : initialSize;
         this.stepSize = stepSize == null ? DEFAULT_STEP : stepSize;
@@ -140,10 +140,10 @@ public class Until extends Token {
     @Override
     public boolean equals(final Object obj) {
         return super.equals(obj)
-            && Objects.equals(initialSize, ((Until)obj).initialSize)
-            && Objects.equals(stepSize, ((Until)obj).stepSize)
-            && Objects.equals(maxSize, ((Until)obj).maxSize)
-            && Objects.equals(terminator, ((Until)obj).terminator);
+            && Objects.equals(initialSize, ((DefUntil)obj).initialSize)
+            && Objects.equals(stepSize, ((DefUntil)obj).stepSize)
+            && Objects.equals(maxSize, ((DefUntil)obj).maxSize)
+            && Objects.equals(terminator, ((DefUntil)obj).terminator);
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -68,7 +68,7 @@ import io.parsingdata.metal.token.Seq;
 import io.parsingdata.metal.token.Sub;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
-import io.parsingdata.metal.token.Until;
+import io.parsingdata.metal.token.DefUntil;
 import io.parsingdata.metal.token.While;
 
 @RunWith(Parameterized.class)
@@ -153,8 +153,8 @@ public class ArgumentsTest {
             { TokenRef.class, new Object[] { null, VALID_NAME, null } },
             { TokenRef.class, new Object[] { null, null, null } },
             { TokenRef.class, new Object[] { VALID_NAME, EMPTY_NAME, null } },
-            { Until.class, new Object[] { null, VALID_VE, VALID_VE, VALID_VE, VALID_T, null }},
-            { Until.class, new Object[] { VALID_NAME, VALID_VE, VALID_VE, VALID_VE, null, null }}
+            { DefUntil.class, new Object[] { null, VALID_VE, VALID_VE, VALID_VE, VALID_T, null }},
+            { DefUntil.class, new Object[] { VALID_NAME, VALID_VE, VALID_VE, VALID_VE, null, null }}
         });
     }
 

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -121,7 +121,7 @@ import io.parsingdata.metal.token.Sub;
 import io.parsingdata.metal.token.Tie;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
-import io.parsingdata.metal.token.Until;
+import io.parsingdata.metal.token.DefUntil;
 import io.parsingdata.metal.token.While;
 import io.parsingdata.metal.util.EncodingFactory;
 import io.parsingdata.metal.util.InMemoryByteStream;
@@ -200,7 +200,7 @@ public class AutoEqualityTest {
         return generateObjectArrays(
             // Tokens
             Cho.class, Def.class, Pre.class, Rep.class, RepN.class, Seq.class, Sub.class, Tie.class,
-            TokenRef.class, While.class, Post.class, Until.class,
+            TokenRef.class, While.class, Post.class, DefUntil.class,
             // ValueExpressions
             Len.class, Offset.class, Neg.class, Not.class, Count.class, First.class, Last.class, Reverse.class,
             And.class, Or.class, ShiftLeft.class, ShiftRight.class, Add.class, Div.class, Mod.class, Mul.class,

--- a/core/src/test/java/io/parsingdata/metal/token/DefUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefUntilTest.java
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class UntilTest {
+class DefUntilTest {
 
     private static final String INPUT_1 = "Hello, World!";
     private static final String INPUT_2 = "Another line...";


### PR DESCRIPTION
Since it parses a single value now, we should consider renaming the class accordingly.

Resolves #360 