### PR TITLE
#383 join equality

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/expression/value/Join.java
+++ b/core/src/main/java/io/parsingdata/metal/expression/value/Join.java
@@ -20,7 +20,9 @@ package io.parsingdata.metal.expression.value;
 import static io.parsingdata.metal.Util.checkContainsNoNulls;
 
 import java.util.Arrays;
+import java.util.Objects;
 
+import io.parsingdata.metal.Util;
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;
@@ -45,5 +47,21 @@ public class Join implements ValueExpression {
         return Arrays.stream(expressions)
             .map(e -> e.eval(parseState, encoding))
             .reduce(new ImmutableList<>(), ImmutableList::add, ImmutableList::add);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + Arrays.toString(expressions) + ")";
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return Util.notNullAndSameClass(this, obj)
+            && Arrays.equals(expressions, ((Join)obj).expressions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass(), Arrays.hashCode(expressions));
     }
 }

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -21,6 +21,8 @@ import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -52,7 +54,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -61,7 +62,6 @@ import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -255,9 +255,9 @@ public class AutoEqualityTest {
 
     @Parameterized.Parameters(name="{0}")
     public static Collection<Object[]> data() throws IllegalAccessException, InvocationTargetException, InstantiationException {
-        final Set<Class<?>> classes = findClasses().filter(not(CLASSES_TO_IGNORE::contains)).collect(Collectors.toSet());
+        final Set<Class<?>> classes = findClasses().filter(not(CLASSES_TO_IGNORE::contains)).collect(toSet());
         classes.removeAll(CLASSES_TO_TEST);
-        assertEquals("Please add missing class to the CLASSES_TO_TEST or CLASSES_TO_IGNORE constant.", Collections.emptySet(), classes);
+        assertEquals("Please add missing class to the CLASSES_TO_TEST or CLASSES_TO_IGNORE constant.", Set.of(), classes);
         return generateObjectArrays(CLASSES_TO_TEST);
     }
 
@@ -293,7 +293,7 @@ public class AutoEqualityTest {
                 .filter(line -> line.endsWith(".class"))
                 .map(className -> packageName + "." + className.substring(0, className.lastIndexOf('.')))
                 .map(AutoEqualityTest::getClass)
-                .collect(Collectors.toList()).stream();
+                .collect(toList()).stream();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -165,13 +165,16 @@ public class AutoEqualityTest {
         io.parsingdata.metal.expression.value.arithmetic.Sub.class, Cat.class, Nth.class, Elvis.class,
         FoldLeft.class, FoldRight.class, Const.class, Expand.class, Bytes.class, CurrentOffset.class,
         FoldCat.class, CurrentIteration.class, Scope.class,
+        Join.class, Self.class, Ref.NameRef.class, Ref.DefinitionRef.class,
         // Expressions
         Eq.class, EqNum.class, EqStr.class, GtEqNum.class, GtNum.class, LtEqNum.class, LtNum.class,
         io.parsingdata.metal.expression.logical.And.class, io.parsingdata.metal.expression.logical.Or.class,
         io.parsingdata.metal.expression.logical.Not.class,
         // Data structures
         CoreValue.class, ParseValue.class, ParseReference.class, ParseState.class,
+        NotAValue.class, ParseGraph.class, ImmutableList.class,
         // Inputs
+        Slice.class,
         ConstantSource.class, DataExpressionSource.class, ByteStreamSource.class, ConcatenatedValueSource.class
     );
 
@@ -204,6 +207,7 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> TOKEN_ARRAYS = Arrays.asList(() -> new Token[] { any("a"), any("b")}, () -> new Token[] { any("b"), any("c") }, () -> new Token[] { any("a"), any("b"), any("c") });
     private static final List<Supplier<Object>> SINGLE_VALUE_EXPRESSIONS = Arrays.asList(() -> con(1), () -> con(2));
     private static final List<Supplier<Object>> VALUE_EXPRESSIONS = Arrays.asList(() -> con(1), () -> exp(con(1), con(2)));
+    private static final List<Supplier<Object>> VALUE_EXPRESSION_ARRAY = Arrays.asList(() -> new ValueExpression[] { con(1), exp(con(1), con(2))}, () -> new ValueExpression[] { exp(con(1), con(2)), con(1)}, () -> new ValueExpression[] { exp(con(1), con(2)), exp(con(1), con(3))});
     private static final List<Supplier<Object>> EXPRESSIONS = Arrays.asList(() -> TRUE, () -> not(TRUE));
     private static final List<Supplier<Object>> VALUES = Arrays.asList(() -> ConstantFactory.createFromString("a", enc()), () -> ConstantFactory.createFromString("b", enc()), () -> ConstantFactory.createFromNumeric(1L, signed()), () -> NOT_A_VALUE);
     private static final List<Supplier<Object>> REDUCERS = Arrays.asList(() -> (BinaryOperator<ValueExpression>) Shorthand::cat, () -> (BinaryOperator<ValueExpression>) Shorthand::div);
@@ -229,6 +233,7 @@ public class AutoEqualityTest {
         result.put(Token[].class, TOKEN_ARRAYS);
         result.put(SingleValueExpression.class, SINGLE_VALUE_EXPRESSIONS);
         result.put(ValueExpression.class, VALUE_EXPRESSIONS);
+        result.put(ValueExpression[].class, VALUE_EXPRESSION_ARRAY);
         result.put(Expression.class, EXPRESSIONS);
         result.put(Value.class, VALUES);
         result.put(BinaryOperator.class, REDUCERS);
@@ -251,7 +256,7 @@ public class AutoEqualityTest {
     public static Collection<Object[]> data() throws IllegalAccessException, InvocationTargetException, InstantiationException {
         final Set<Class> classes = findClasses().filter(not(CLASSES_TO_IGNORE::contains)).collect(Collectors.toSet());
         classes.removeAll(CLASSES_TO_TEST);
-        assertEquals("Please add missing class to the CLASSES_TO_TEST constant or filter it here if it has its own equality test.", Collections.emptySet(), classes);
+        assertEquals("Please add missing class to the CLASSES_TO_TEST or CLASSES_TO_IGNORE constant.", Collections.emptySet(), classes);
         return generateObjectArrays(CLASSES_TO_TEST);
     }
 

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -42,6 +42,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -282,7 +283,7 @@ public class AutoEqualityTest {
                 .filter(u -> u.getPath().contains("/classes/")) // ignore test classes
                 .flatMap(url -> getClasses(packageName, url));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -294,7 +295,7 @@ public class AutoEqualityTest {
                 .map(AutoEqualityTest::getClass)
                 .collect(Collectors.toList()).stream();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -302,7 +303,7 @@ public class AutoEqualityTest {
         try {
             return Class.forName(className);
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Unable to find class for name " + className, e);
+            throw new IllegalStateException("Unable to find class for name " + className, e);
         }
     }
 

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -275,7 +275,7 @@ public class AutoEqualityTest {
             .filter(c -> !Modifier.isAbstract(c.getModifiers()));
     }
 
-    public static Stream<Class<?>> findAllClassesUsingClassLoader(String packageName) {
+    public static Stream<Class<?>> findAllClassesUsingClassLoader(final String packageName) {
         try {
             final Iterator<URL> iterator = ClassLoader.getSystemClassLoader()
                 .getResources(packageName.replaceAll("[.]", "/")).asIterator();
@@ -299,7 +299,7 @@ public class AutoEqualityTest {
         }
     }
 
-    private static Class<?> getClass(String className) {
+    private static Class<?> getClass(final String className) {
         try {
             return Class.forName(className);
         } catch (ClassNotFoundException e) {
@@ -307,7 +307,7 @@ public class AutoEqualityTest {
         }
     }
 
-    private static Collection<Object[]> generateObjectArrays(Set<Class<?>> classes) throws IllegalAccessException, InstantiationException, InvocationTargetException {
+    private static Collection<Object[]> generateObjectArrays(final Set<Class<?>> classes) throws IllegalAccessException, InstantiationException, InvocationTargetException {
         Collection<Object[]> results = new ArrayList<>();
         for (Class<?> c : classes) {
             results.add(generateObjectArrays(c));
@@ -315,7 +315,7 @@ public class AutoEqualityTest {
         return results;
     }
 
-    private static Object[] generateObjectArrays(Class<?> c) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+    private static Object[] generateObjectArrays(final Class<?> c) throws IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<?> cons = c.getDeclaredConstructors()[0];
         cons.setAccessible(true);
         List<List<Supplier<Object>>> args = new ArrayList<>();
@@ -334,7 +334,7 @@ public class AutoEqualityTest {
         };
     }
 
-    private static List<List<Supplier<Object>>> generateCombinations(int index, List<List<Supplier<Object>>> args) {
+    private static List<List<Supplier<Object>>> generateCombinations(final int index, final List<List<Supplier<Object>>> args) {
         List<List<Supplier<Object>>> result = new ArrayList<>();
         if (index == args.size()) {
             result.add(new ArrayList<>());

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -156,7 +156,7 @@ public class AutoEqualityTest {
     @Parameter(1) public Object same;
     @Parameter(2) public Object[] other;
 
-    private static final Set<Class> CLASSES_TO_TEST = Set.of(
+    private static final Set<Class<?>> CLASSES_TO_TEST = Set.of(
         // Tokens
         Cho.class, Def.class, Pre.class, Rep.class, RepN.class, Seq.class, Sub.class, Tie.class,
         TokenRef.class, While.class, Post.class, DefUntil.class,
@@ -224,10 +224,10 @@ public class AutoEqualityTest {
     private static final List<Supplier<Object>> PARSE_STATES = Arrays.asList(() -> createFromByteStream(DUMMY_STREAM), () -> createFromByteStream(DUMMY_STREAM, ONE), () -> new ParseState(GRAPH_WITH_REFERENCE, DUMMY_BYTE_STREAM_SOURCE, TEN, new ImmutableList<>(), new ImmutableList<>()));
     private static final List<Supplier<Object>> IMMUTABLE_LISTS = Arrays.asList(ImmutableList::new, () -> ImmutableList.create("TEST"), () -> ImmutableList.create(1), () -> ImmutableList.create(1).add(2));
     private static final List<Supplier<Object>> BOOLEANS = Arrays.asList(() -> true, () -> false);
-    private static final Map<Class, List<Supplier<Object>>> mapping = buildMap();
+    private static final Map<Class<?>, List<Supplier<Object>>> mapping = buildMap();
 
-    private static Map<Class, List<Supplier<Object>>> buildMap() {
-        final Map<Class, List<Supplier<Object>>> result = new HashMap<>();
+    private static Map<Class<?>, List<Supplier<Object>>> buildMap() {
+        final Map<Class<?>, List<Supplier<Object>>> result = new HashMap<>();
         result.put(String.class, STRINGS);
         result.put(Encoding.class, ENCODINGS);
         result.put(Token.class, TOKENS);
@@ -255,13 +255,13 @@ public class AutoEqualityTest {
 
     @Parameterized.Parameters(name="{0}")
     public static Collection<Object[]> data() throws IllegalAccessException, InvocationTargetException, InstantiationException {
-        final Set<Class> classes = findClasses().filter(not(CLASSES_TO_IGNORE::contains)).collect(Collectors.toSet());
+        final Set<Class<?>> classes = findClasses().filter(not(CLASSES_TO_IGNORE::contains)).collect(Collectors.toSet());
         classes.removeAll(CLASSES_TO_TEST);
         assertEquals("Please add missing class to the CLASSES_TO_TEST or CLASSES_TO_IGNORE constant.", Collections.emptySet(), classes);
         return generateObjectArrays(CLASSES_TO_TEST);
     }
 
-    private static Stream<Class> findClasses() {
+    private static Stream<Class<?>> findClasses() {
         return Stream.of("io.parsingdata.metal.data",
                 "io.parsingdata.metal.expression.comparison",
                 "io.parsingdata.metal.expression.logical",
@@ -275,7 +275,7 @@ public class AutoEqualityTest {
             .filter(c -> !Modifier.isAbstract(c.getModifiers()));
     }
 
-    public static Stream<Class> findAllClassesUsingClassLoader(String packageName) {
+    public static Stream<Class<?>> findAllClassesUsingClassLoader(String packageName) {
         try {
             final Iterator<URL> iterator = ClassLoader.getSystemClassLoader()
                 .getResources(packageName.replaceAll("[.]", "/")).asIterator();
@@ -287,7 +287,7 @@ public class AutoEqualityTest {
         }
     }
 
-    private static Stream<Class> getClasses(final String packageName, final URL url) {
+    private static Stream<? extends Class<?>> getClasses(final String packageName, final URL url) {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
             return reader.lines()
                 .filter(line -> line.endsWith(".class"))
@@ -299,7 +299,7 @@ public class AutoEqualityTest {
         }
     }
 
-    private static Class getClass(String className) {
+    private static Class<?> getClass(String className) {
         try {
             return Class.forName(className);
         } catch (ClassNotFoundException e) {
@@ -307,19 +307,19 @@ public class AutoEqualityTest {
         }
     }
 
-    private static Collection<Object[]> generateObjectArrays(Set<Class> classes) throws IllegalAccessException, InstantiationException, InvocationTargetException {
+    private static Collection<Object[]> generateObjectArrays(Set<Class<?>> classes) throws IllegalAccessException, InstantiationException, InvocationTargetException {
         Collection<Object[]> results = new ArrayList<>();
-        for (Class c : classes) {
+        for (Class<?> c : classes) {
             results.add(generateObjectArrays(c));
         }
         return results;
     }
 
-    private static Object[] generateObjectArrays(Class c) throws IllegalAccessException, InvocationTargetException, InstantiationException {
-        Constructor cons = c.getDeclaredConstructors()[0];
+    private static Object[] generateObjectArrays(Class<?> c) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        Constructor<?> cons = c.getDeclaredConstructors()[0];
         cons.setAccessible(true);
         List<List<Supplier<Object>>> args = new ArrayList<>();
-        for (Class cl : cons.getParameterTypes()) {
+        for (Class<?> cl : cons.getParameterTypes()) {
             args.add(mapping.get(cl));
         }
         List<List<Supplier<Object>>> argLists = generateCombinations(0, args);


### PR DESCRIPTION
There was a bug introduced when the Join class was merged, because the join class did not contain equality methods. 
Since it is easy to forget them, I thought it may be a good idea to help ourselves and let the AutoEqualityTest tell us if we forgot to include a class.

This Pull Request contains:
1. Add missing equality methods for [Join](core/src/main/java/io/parsingdata/metal/expression/value/Join.java) class.
2. Automatically check that we test all classes for equality in [AutoEqualityTest](core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java).
I extended the AutoEqualityClass that collects all the classes from certain packages to force us to add a new class to the CLASSES_TO_TEST or CLASSES_TO_IGNORE constant.

It turned out, `Join.class` was not the only class missing in the AutoEqualityTest. I added:
Join.class, Self.class, Ref.NameRef.class, Ref.DefinitionRef.class, NotAValue.class, ParseGraph.class, ImmutableList.class and Slice.class. See also [this commit](https://github.com/parsingdata/metal/commit/8cb3ff83ef06a6dca924a790e46437f3bf942124).

Let me know what you think.