### PR TITLE
#394 Convert all test to JUnit5.

### DIFF
--- a/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArgumentsTest.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import static io.parsingdata.metal.Shorthand.con;
 
@@ -29,10 +29,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
@@ -61,6 +59,7 @@ import io.parsingdata.metal.expression.value.reference.Nth;
 import io.parsingdata.metal.expression.value.reference.Offset;
 import io.parsingdata.metal.token.Cho;
 import io.parsingdata.metal.token.Def;
+import io.parsingdata.metal.token.DefUntil;
 import io.parsingdata.metal.token.Pre;
 import io.parsingdata.metal.token.Rep;
 import io.parsingdata.metal.token.RepN;
@@ -68,10 +67,8 @@ import io.parsingdata.metal.token.Seq;
 import io.parsingdata.metal.token.Sub;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.token.TokenRef;
-import io.parsingdata.metal.token.DefUntil;
 import io.parsingdata.metal.token.While;
 
-@RunWith(Parameterized.class)
 public class ArgumentsTest {
 
     final private static String VALID_NAME = "name";
@@ -85,10 +82,6 @@ public class ArgumentsTest {
         }
     };
 
-    private final Class<?> _class;
-    private final Object[] _arguments;
-
-    @Parameters(name = "{index}-{0}")
     public static Collection<Object[]> arguments() {
         return List.of(new Object[][] {
             // Derived directly from ValueExpression
@@ -158,17 +151,13 @@ public class ArgumentsTest {
         });
     }
 
-    public ArgumentsTest(final Class<?> argumentsClass, final Object[] arguments) {
-        _class = argumentsClass;
-        _arguments = arguments;
-    }
-
-    @Test
-    public void runConstructor() throws Throwable {
-        final Constructor<?>[] constructors = _class.getConstructors();
+    @ParameterizedTest(name = "{index}-{0}")
+    @MethodSource("arguments")
+    public void runConstructor(final Class<?> clazz, final Object[] arguments) throws Throwable {
+        final Constructor<?>[] constructors = clazz.getConstructors();
         assertEquals(1, constructors.length);
         try {
-            constructors[0].newInstance(_arguments);
+            constructors[0].newInstance(arguments);
             fail("Should have thrown an IllegalArgumentException.");
         }
         catch (final InvocationTargetException e) {

--- a/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ArithmeticValueExpressionSemanticsTest.java
@@ -36,8 +36,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.expression.value.BinaryValueExpression;
 import io.parsingdata.metal.expression.value.UnaryValueExpression;
 import io.parsingdata.metal.expression.value.ValueExpression;
@@ -68,8 +66,8 @@ public class ArithmeticValueExpressionSemanticsTest extends ParameterizedParse {
         return singleToken("a", "b", 1, unaryValueExpression);
     }
 
-    @Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[signed] 1 + 2 == 3", add, stream(1, 2, 3), signed(), true },
             { "[signed] -10 + 3 == -7", add, stream(-10, 3, -7), signed(), true },

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -252,7 +252,7 @@ public class AutoEqualityTest {
     public static Stream<Arguments> data() throws IllegalAccessException, InvocationTargetException, InstantiationException {
         final Set<Class<?>> classes = findClasses().filter(not(CLASSES_TO_IGNORE::contains)).collect(toSet());
         classes.removeAll(CLASSES_TO_TEST);
-        Assertions.assertEquals(Set.of(), classes, "Please add missing class to the CLASSES_TO_TEST or CLASSES_TO_IGNORE constant.");
+        assertEquals(Set.of(), classes, "Please add missing class to the CLASSES_TO_TEST or CLASSES_TO_IGNORE constant.");
         return generateObjectArrays(CLASSES_TO_TEST).stream();
     }
 

--- a/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/AutoEqualityTest.java
@@ -64,7 +64,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackNameBindTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
@@ -33,7 +33,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 

--- a/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BackTrackOffsetTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.rep;
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 

--- a/core/src/test/java/io/parsingdata/metal/BitwiseValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/BitwiseValueExpressionSemanticsTest.java
@@ -32,15 +32,13 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
 public class BitwiseValueExpressionSemanticsTest extends ParameterizedParse {
 
-    @Parameters(name = "{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[170, 85] a, not(a)", simpleNot(1), stream(170, 85), enc(), true },
             { "[0, 255] a not(a)", simpleNot(1), stream(0, 255), enc(), true },

--- a/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ByteLengthTest.java
@@ -18,9 +18,9 @@ package io.parsingdata.metal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -37,7 +37,7 @@ import static io.parsingdata.metal.util.EnvironmentFactory.env;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.ParseGraph;

--- a/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ComparisonExpressionSemanticsTest.java
@@ -39,8 +39,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.comparison.ComparisonExpression;
@@ -49,8 +47,8 @@ import io.parsingdata.metal.util.ParameterizedParse;
 
 public class ComparisonExpressionSemanticsTest extends ParameterizedParse {
 
-    @Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "1 == 1(eqNum)", numericCompare(1, eqNum(ref("a"))), stream(1, 1), enc(), true },
             { "2 == 1(eqNum)", numericCompare(1, eqNum(ref("a"))), stream(1, 2), enc(), false },

--- a/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConditionalTokenTest.java
@@ -37,8 +37,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
@@ -52,8 +50,8 @@ public class ConditionalTokenTest extends ParameterizedParse {
         whl(any("value"), ltNum(CURRENT_OFFSET, add(ref("size"), add(offset(last(ref("size"))), con(1))))),
         def("footer", con(1), eq(con(0xff))));
 
-    @Parameters(name = "{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[1, 2, 3] a b c", preToken, stream(1, 2, 3), enc(), true },
             { "[2, 3] a c", preToken, stream(2, 3), enc(), true },

--- a/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ConstantValueTest.java
@@ -28,16 +28,14 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
 public class ConstantValueTest extends ParameterizedParse {
 
-    @Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "1 byte, Eq(0), Signed", single(1, eq(con(0))), stream(0), signed(), true },
             { "1 byte, Eq(0), Unsigned", single(1, eq(con(0))), stream(0), enc(), true },

--- a/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/CurrentOffsetTest.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
 import static io.parsingdata.metal.Shorthand.SELF;
@@ -33,7 +33,7 @@ import static io.parsingdata.metal.util.EnvironmentFactory.env;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefSizeTest.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.EMPTY;
 import static io.parsingdata.metal.Shorthand.con;
@@ -37,7 +37,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_SVE;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/DefinitionTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
 import static io.parsingdata.metal.Shorthand.cho;
@@ -40,7 +40,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EndiannessTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.SELF;
 import static io.parsingdata.metal.Shorthand.and;
@@ -28,7 +28,7 @@ import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 

--- a/core/src/test/java/io/parsingdata/metal/EqualityTest.java
+++ b/core/src/test/java/io/parsingdata/metal/EqualityTest.java
@@ -19,10 +19,10 @@ package io.parsingdata.metal;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.con;
@@ -51,7 +51,7 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ConstantSource;
 import io.parsingdata.metal.data.ImmutableList;
@@ -124,8 +124,7 @@ public class EqualityTest {
         assertEquals(same, same);
         assertEquals(object, same);
         assertEquals(same, object);
-        assertNotEquals(object, new Object() {
-        });
+        assertNotEquals(object, new Object() {});
         assertEquals(object.hashCode(), same.hashCode());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ErrorsTest.java
@@ -16,7 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.add;
@@ -32,20 +33,15 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.math.BigInteger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 
 public class ErrorsTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void noValueForSize() {
-        thrown = ExpectedException.none();
         // Basic division by zero.
         final Token nanSize = def("a", div(con(1), con(0)));
         assertFalse(nanSize.parse(env(stream(1))).isPresent());
@@ -68,9 +64,8 @@ public class ErrorsTest {
 
     @Test
     public void parseStateWithNegativeOffset() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument offset may not be negative.");
-        createFromByteStream(DUMMY_STREAM, BigInteger.valueOf(-1));
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> createFromByteStream(DUMMY_STREAM, BigInteger.valueOf(-1)));
+        assertEquals("Argument offset may not be negative.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/ImmutableListTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ImmutableListTest.java
@@ -146,7 +146,6 @@ public class ImmutableListTest {
         assertEquals(0, new ImmutableList<ParseValue>().size);
     }
 
-
     private ParseValue val(final char c) {
         return new ParseValue(Character.toString(c), def(Character.toString(c), 0L), createFromBytes(new byte[] { (byte) c }), enc());
     }

--- a/core/src/test/java/io/parsingdata/metal/ImmutableListTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ImmutableListTest.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.data.Selection.reverse;
@@ -27,7 +27,7 @@ import static io.parsingdata.metal.data.selection.ByName.get;
 import static io.parsingdata.metal.data.selection.ByName.getAll;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
@@ -145,6 +145,12 @@ public class ImmutableListTest {
     public void sizeEmpty() {
         assertEquals(0, new ImmutableList<ParseValue>().size);
     }
+
+//    @Test
+//    public void arrayListTest() {
+//        assertEquals(List.of(v5, v4, v3, v2, v1), new ArrayList<>(l5));
+//    }
+
 
     private ParseValue val(final char c) {
         return new ParseValue(Character.toString(c), def(Character.toString(c), 0L), createFromBytes(new byte[] { (byte) c }), enc());

--- a/core/src/test/java/io/parsingdata/metal/ImmutableListTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ImmutableListTest.java
@@ -146,11 +146,6 @@ public class ImmutableListTest {
         assertEquals(0, new ImmutableList<ParseValue>().size);
     }
 
-//    @Test
-//    public void arrayListTest() {
-//        assertEquals(List.of(v5, v4, v3, v2, v1), new ArrayList<>(l5));
-//    }
-
 
     private ParseValue val(final char c) {
         return new ParseValue(Character.toString(c), def(Character.toString(c), 0L), createFromBytes(new byte[] { (byte) c }), enc());

--- a/core/src/test/java/io/parsingdata/metal/IterateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/IterateTest.java
@@ -33,8 +33,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
@@ -49,8 +47,8 @@ public class IterateTest extends ParameterizedParse {
         seq(repn(any("x"), div(con(1), con(0))),
             def("f", con(1), eq(con(42))));
 
-    @Parameters(name = "{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[3, 2, 3, 4, 42] n, repN(x>1, n), f", repNToken, stream(3, 2, 3, 4, 42), enc(), true },
             { "[3, 2, 3, 4, 41] n, repN(x>1, n), f", repNToken, stream(3, 2, 3, 4, 41), enc(), false },

--- a/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/LogicalExpressionSemanticsTest.java
@@ -33,8 +33,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.expression.logical.LogicalExpression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
@@ -51,8 +49,8 @@ public class LogicalExpressionSemanticsTest extends ParameterizedParse {
             def("c", con(1), le));
     }
 
-    @Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "2 == 2 && 2 > 1", andEqGt, stream(2, 1, 2), enc(), true },
             { "3 == 2 && 3 > 1", andEqGt, stream(2, 1, 3), enc(), false },

--- a/core/src/test/java/io/parsingdata/metal/PITestCasesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/PITestCasesTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -36,7 +36,7 @@ import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.encoding.Encoding;

--- a/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReadUntilTest.java
@@ -16,8 +16,9 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.Shorthand.seq;
@@ -26,7 +27,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.eq;
 import static io.parsingdata.metal.util.TokenDefinitions.notEq;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 

--- a/core/src/test/java/io/parsingdata/metal/ReducersTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReducersTest.java
@@ -36,8 +36,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.token.Token;
@@ -72,8 +70,8 @@ public class ReducersTest extends ParameterizedParse {
         return token(size, pred, enc(), enc());
     }
 
-    @Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[1, 2, 3, 6] a, a, a, addAll(a)", reduceAddA, stream(1, 2, 3, 6), enc(), true },
             { "[1, 2, 3, 3] a, a, a, addAllOffset(a)", reduceAddOffsetA, stream(1, 2, 3, 3), enc(), true },

--- a/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ReferenceValueExpressionSemanticsTest.java
@@ -36,8 +36,6 @@ import static io.parsingdata.metal.util.TokenDefinitions.eqRef;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.expression.value.reference.Ref;
@@ -74,8 +72,8 @@ public class ReferenceValueExpressionSemanticsTest extends ParameterizedParse {
                 def("sum", con(1), eq(fold(ref, Shorthand::add))));
     }
 
-    @Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[2, 2] b == a", sequenceMatch2, stream(2, 2), enc(), true },
             { "[2, 1] b == a", sequenceMatch2, stream(2, 1), enc(), false },

--- a/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandOverloadsTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.and;
@@ -42,16 +42,13 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.expression.value.SingleValueExpression;
 
-@RunWith(Parameterized.class)
 public class ShorthandOverloadsTest {
 
     public static final ParseState PARSE_STATE = ParseState.createFromByteStream(new ByteStream() {
@@ -59,11 +56,6 @@ public class ShorthandOverloadsTest {
         @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
     });
 
-    @Parameter(0) public String description;
-    @Parameter(1) public SingleValueExpression toExecute;
-    @Parameter(2) public SingleValueExpression expectedResult;
-
-    @Parameterized.Parameters(name="SingleValueExpression {0}")
     public static Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "add", add(con(1), con(1)), con(2) },
@@ -85,8 +77,9 @@ public class ShorthandOverloadsTest {
         });
     }
 
-    @Test
-    public void test() {
+    @ParameterizedTest(name="SingleValueExpression {0}")
+    @MethodSource("data")
+    public void test(final String description, final SingleValueExpression toExecute, final SingleValueExpression expectedResult) {
         assertTrue(eq(toExecute, expectedResult).eval(PARSE_STATE, DEFAULT_ENCODING));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ShorthandsTest.java
@@ -18,9 +18,10 @@ package io.parsingdata.metal;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.TRUE;
@@ -53,13 +54,10 @@ import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static junit.framework.TestCase.assertFalse;
 
 import java.util.Optional;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
@@ -178,9 +176,6 @@ public class ShorthandsTest {
             values = values.tail;
         }
     }
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     public static final Token DEF_A = any("a");
     public static final Token DEF_B = any("b");

--- a/core/src/test/java/io/parsingdata/metal/SimpleTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SimpleTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -25,7 +25,7 @@ import static io.parsingdata.metal.Shorthand.eq;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 

--- a/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTableTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -33,7 +33,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/SubStructTest.java
+++ b/core/src/test/java/io/parsingdata/metal/SubStructTest.java
@@ -16,8 +16,9 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -35,12 +36,11 @@ import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.EMPTY_VE;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
-import static junit.framework.TestCase.assertFalse;
 
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseGraph;
 import io.parsingdata.metal.data.ParseItem;

--- a/core/src/test/java/io/parsingdata/metal/ToStringTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ToStringTest.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.CURRENT_ITERATION;
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
@@ -79,8 +79,8 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
@@ -104,7 +104,7 @@ public class ToStringTest {
     private static final String prefix = "prefix";
     private int count;
 
-    @Before
+    @BeforeEach
     public void before() {
         count = 0;
     }

--- a/core/src/test/java/io/parsingdata/metal/TrampolineTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TrampolineTest.java
@@ -19,37 +19,31 @@ package io.parsingdata.metal;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.Trampoline.complete;
 import static io.parsingdata.metal.Trampoline.intermediate;
 
 import java.math.BigInteger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.Trampoline.CompletedTrampoline;
 import io.parsingdata.metal.Trampoline.IntermediateTrampoline;
 
 public class TrampolineTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void resultOnIntermediateTrampoline() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("An IntermediateTrampoline does not have a result.");
-        ((IntermediateTrampoline<Integer>) () -> null).result();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, () -> ((IntermediateTrampoline<Integer>) () -> null).result());
+        assertEquals("An IntermediateTrampoline does not have a result.", e.getMessage());
     }
 
     @Test
     public void nextOnFinalTrampoline() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("A CompletedTrampoline does not have a next computation.");
-        ((CompletedTrampoline<Integer>) () -> 42).next();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, () -> ((CompletedTrampoline<Integer>) () -> 42).next());
+        assertEquals("A CompletedTrampoline does not have a next computation.", e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/TreeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/TreeTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
@@ -32,7 +32,7 @@ import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseGraph;

--- a/core/src/test/java/io/parsingdata/metal/UtilHexTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilHexTest.java
@@ -23,21 +23,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class UtilHexTest {
 
-    @Parameter
-    public byte[] input;
-
-    @Parameter(1)
-    public String output;
-
-    @Parameterized.Parameters(name = "{1}")
     public static Collection<Object[]> data() {
         return List.of(new Object[][] {
             { new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef}, "0123456789ABCDEF" },
@@ -48,8 +38,9 @@ public class UtilHexTest {
         });
     }
 
-    @Test
-    public void byteToHex() {
+    @ParameterizedTest(name = "0x{1}")
+    @MethodSource("data")
+    public void byteToHex(final byte[] input, final String output) {
         assertThat(Util.bytesToHexString(input), is(equalTo(output)));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilInflateTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Util.inflate;
@@ -24,7 +24,7 @@ import static io.parsingdata.metal.expression.value.NotAValue.NOT_A_VALUE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.expression.value.Value;

--- a/core/src/test/java/io/parsingdata/metal/UtilityClassTest.java
+++ b/core/src/test/java/io/parsingdata/metal/UtilityClassTest.java
@@ -16,11 +16,11 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.util.ClassDefinition.checkUtilityClass;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.Selection;
 import io.parsingdata.metal.data.selection.ByName;

--- a/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/ValueExpressionSemanticsTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cat;
 import static io.parsingdata.metal.Shorthand.con;
@@ -29,7 +29,7 @@ import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 

--- a/core/src/test/java/io/parsingdata/metal/data/ByNameTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ByNameTest.java
@@ -16,11 +16,11 @@
 
 package io.parsingdata.metal.data;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import static io.parsingdata.metal.data.selection.ByName.getValue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ByNameTest {
 

--- a/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ByteStreamSourceTest.java
@@ -19,13 +19,13 @@ package io.parsingdata.metal.data;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class ByteStreamSourceTest {
 
@@ -34,13 +34,9 @@ public class ByteStreamSourceTest {
         @Override public boolean isAvailable(BigInteger offset, BigInteger length) { return true; }
     });
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void brokenByteStream() {
-        thrown.expect(UncheckedIOException.class);
-        Slice.createFromSource(DUMMY_BYTE_STREAM_SOURCE, ZERO, TEN).get().getData();
+        assertThrows(UncheckedIOException.class, () -> Slice.createFromSource(DUMMY_BYTE_STREAM_SOURCE, ZERO, TEN).get().getData());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceErrorTest.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal.data;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConcatenatedValueSourceErrorTest {
 

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.data;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.data.Slice.createFromSource;
 import static io.parsingdata.metal.expression.value.ConstantFactory.createFromBytes;
@@ -26,34 +26,30 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.parsingdata.metal.expression.value.CoreValue;
 import io.parsingdata.metal.expression.value.Value;
 
-@RunWith(Parameterized.class)
 public class ConcatenatedValueSourceTest {
 
-    @Parameter public String description;
-    @Parameter(1) public int offset;
-    @Parameter(2) public int length;
+    private static ConcatenatedValueSource cvs;
 
-    public static final ConcatenatedValueSource cvs = ConcatenatedValueSource.create(createValues()).get();
-
-    private static ImmutableList<Value> createValues() {
+    @BeforeAll
+    public static void setup() {
         final byte[] twoSliceSource = new byte[] { -1, -1, 5, 6, 7, 8, 9, -1, -1, 10, 11, 12, 13, 14, -1, -1 };
-        return ImmutableList
-            .create(createFromBytes(new byte[] { 0, 1, 2, 3, 4 }, enc()))
+        final ImmutableList<Value> list = ImmutableList
+            .create(createFromBytes(new byte[]{0, 1, 2, 3, 4}, enc()))
             .add(new CoreValue(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(2), BigInteger.valueOf(5)).get(), enc()))
             .add(new CoreValue(createFromSource(new ConstantSource(twoSliceSource), BigInteger.valueOf(9), BigInteger.valueOf(5)).get(), enc()))
-            .add(createFromBytes(new byte[] { 15, 16, 17, 18, 19 }, enc()))
-            .add(createFromBytes(new byte[] { 20, 21, 22, 23, 24 }, enc()));
+            .add(createFromBytes(new byte[]{15, 16, 17, 18, 19}, enc()))
+            .add(createFromBytes(new byte[]{20, 21, 22, 23, 24}, enc()));
+
+        cvs = ConcatenatedValueSource.create(list).orElseThrow();
     }
 
-    @Parameterized.Parameters(name="{0}")
     public static Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "full", 0, 25 },                // [XXXXX][XXXXX][XXXXX][XXXXX][XXXXX]
@@ -84,8 +80,9 @@ public class ConcatenatedValueSourceTest {
         });
     }
 
-    @Test
-    public void checkData() {
+    @ParameterizedTest(name="{0}")
+    @MethodSource("data")
+    public void checkData(final String description, final int offset, final int length) {
         byte[] data = cvs.getData(BigInteger.valueOf(offset), BigInteger.valueOf(length));
         assertEquals(length, data.length);
         for (int i = 0; i < length; i++) {

--- a/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConstantSliceTest.java
@@ -19,36 +19,30 @@ package io.parsingdata.metal.data;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 
 import java.math.BigInteger;
 import java.util.Arrays;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class ConstantSliceTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void nullInput() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument data may not be null.");
-        createFromBytes(null);
+        final Exception e = assertThrows(IllegalArgumentException.class, () -> createFromBytes(null));
+        assertEquals("Argument data may not be null.", e.getMessage());
     }
 
     @Test
     public void readBeyondSourceSize() {
         final byte[] input = { 1, 2, 3, 4 };
         final Slice slice = createFromBytes(input);
-        thrown.expect(IllegalStateException.class);
-        slice.source.getData(BigInteger.valueOf(4), ONE);
+        assertThrows(IllegalStateException.class, () -> slice.source.getData(BigInteger.valueOf(4), ONE));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/DataExpressionSourceTest.java
@@ -18,8 +18,9 @@ package io.parsingdata.metal.data;
 
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -36,16 +37,12 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 
 public class DataExpressionSourceTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     public ParseValue setupValue() {
         final Optional<ParseState> result = setupResult();
@@ -69,18 +66,17 @@ public class DataExpressionSourceTest {
 
     @Test
     public void indexOutOfBounds() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("ValueExpression dataExpression yields 1 result(s) (expected at least 2).");
         final Optional<ParseState> result = setupResult();
         final DataExpressionSource source = new DataExpressionSource(ref("a"), 1, result.get(), enc());
-        source.getData(ZERO, BigInteger.valueOf(4));
+
+        final Exception e = Assertions.assertThrows(IllegalStateException.class, () -> source.getData(ZERO, BigInteger.valueOf(4)));
+        assertEquals("ValueExpression dataExpression yields 1 result(s) (expected at least 2).", e.getMessage());
     }
 
     @Test
     public void notAValue() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("ValueExpression dataExpression yields NOT_A_VALUE at index 0.");
-        new DataExpressionSource(div(con(1), con(0)), 0, EMPTY_PARSE_STATE, enc()).isAvailable(ZERO, ZERO);
+        final Exception e = Assertions.assertThrows(IllegalStateException.class, () -> new DataExpressionSource(div(con(1), con(0)), 0, EMPTY_PARSE_STATE, enc()).isAvailable(ZERO, ZERO));
+        assertEquals("ValueExpression dataExpression yields NOT_A_VALUE at index 0.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseGraphTest.java
@@ -19,10 +19,11 @@ package io.parsingdata.metal.data;
 import static java.math.BigInteger.ZERO;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.data.ParseGraph.EMPTY;
@@ -35,16 +36,11 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Optional;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 
 public class ParseGraphTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     private final Token t = any("t");
 
@@ -210,30 +206,26 @@ public class ParseGraphTest {
     @Test
     public void testNone() {
         assertEquals("None", NONE.toString());
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("This placeholder may not be invoked.");
-        NONE.parse(env(stream()));
+        final Exception e = assertThrows(IllegalStateException.class, () -> NONE.parse(env(stream())));
+        assertEquals("This placeholder may not be invoked.", e.getMessage());
     }
 
     @Test
     public void testCloseNotBranched() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Cannot close branch that is not open.");
-        EMPTY.closeBranch();
+        final Exception e = assertThrows(IllegalStateException.class, EMPTY::closeBranch);
+        assertEquals("Cannot close branch that is not open.", e.getMessage());
     }
 
     @Test
     public void testAsValue() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert to ParseValue.");
-        EMPTY.asValue();
+        final Exception e = assertThrows(UnsupportedOperationException.class, EMPTY::asValue);
+        assertEquals("Cannot convert to ParseValue.", e.getMessage());
     }
 
     @Test
     public void testAsRef() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert to ParseReference.");
-        EMPTY.asReference();
+        final Exception e = assertThrows(UnsupportedOperationException.class, EMPTY::asReference);
+        assertEquals("Cannot convert to ParseReference.", e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseReferenceTest.java
@@ -20,31 +20,28 @@ import static java.math.BigInteger.ZERO;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.data.selection.ByTypeTest.EMPTY_SOURCE;
-import static junit.framework.TestCase.assertFalse;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 
 public class ParseReferenceTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     private Token definition;
     private ParseReference reference;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         definition = sub(def("value", 1), con(0));
         reference = new ParseReference(ZERO, EMPTY_SOURCE, definition);
@@ -71,18 +68,16 @@ public class ParseReferenceTest {
     public void referenceIsNotAValue() {
         assertFalse(reference.isValue());
 
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert to ParseValue");
-        reference.asValue();
+        final Exception e = assertThrows(UnsupportedOperationException.class, () -> reference.asValue());
+        assertEquals("Cannot convert to ParseValue.", e.getMessage());
     }
 
     @Test
     public void referenceIsNotAGraph() {
         assertFalse(reference.isGraph());
 
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert to ParseGraph");
-        reference.asGraph();
+        final Exception e = assertThrows(UnsupportedOperationException.class, () -> reference.asGraph());
+        assertEquals("Cannot convert to ParseGraph.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ParseStateTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseStateTest.java
@@ -16,28 +16,25 @@
 
 package io.parsingdata.metal.data;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 
 public class ParseStateTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void closeParseStateWithWrongToken() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("Cannot close branch for iterable token closeName. Current iteration state is for token openName.");
         final Token open = rep("openName", any("a"));
         final Token close = rep("closeName", any("a"));
-        stream().addBranch(open).closeBranch(close);
+        final Exception e = Assertions.assertThrows(IllegalStateException.class, () -> stream().addBranch(open).closeBranch(close));
+        assertEquals("Cannot close branch for iterable token closeName. Current iteration state is for token openName.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -19,31 +19,27 @@ package io.parsingdata.metal.data;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.data.Slice.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
-import static junit.framework.TestCase.assertFalse;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 
 public class ParseValueTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     private Token definition;
     private ParseValue value;
     private ParseValue largerValue;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         definition = def("value", 1);
         value = new ParseValue("value", definition, createFromBytes(new byte[] { 1 }), enc());
@@ -62,8 +58,8 @@ public class ParseValueTest {
     public void matching() {
         assertTrue(value.matches("value"));
 
-        assertFalse(value.matches("lue"));
-        assertFalse(value.matches(".value"));
+        Assertions.assertFalse(value.matches("lue"));
+        Assertions.assertFalse(value.matches(".value"));
     }
 
     @Test
@@ -84,28 +80,22 @@ public class ParseValueTest {
 
     @Test
     public void valueIsNotARef() {
-        assertFalse(value.isReference());
-
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert to ParseReference");
-        value.asReference();
+        Assertions.assertFalse(value.isReference());
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, value::asReference);
+        assertEquals("Cannot convert to ParseReference.", e.getMessage());
     }
 
     @Test
     public void valueIsNotAGraph() {
-        assertFalse(value.isGraph());
-
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("Cannot convert to ParseGraph");
-        value.asGraph();
+        Assertions.assertFalse(value.isGraph());
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, value::asGraph);
+        assertEquals("Cannot convert to ParseGraph.", e.getMessage());
     }
 
     @Test
     public void emptyName() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument name may not be empty.");
-
-        new ParseValue("", definition, createFromBytes(new byte[] { 1 }), enc());
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ParseValue("", definition, createFromBytes(new byte[] { 1 }), enc()));
+        assertEquals("Argument name may not be empty.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ParseValueTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.def;
@@ -61,8 +62,8 @@ public class ParseValueTest {
         assertTrue(value.matches(def("value", 1)));
 
         assertFalse(value.matches(def("value", 2)));
-        Assertions.assertFalse(value.matches("lue"));
-        Assertions.assertFalse(value.matches(".value"));
+        assertFalse(value.matches("lue"));
+        assertFalse(value.matches(".value"));
     }
 
     @Test
@@ -83,14 +84,14 @@ public class ParseValueTest {
 
     @Test
     public void valueIsNotARef() {
-        Assertions.assertFalse(value.isReference());
+        assertFalse(value.isReference());
         final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, value::asReference);
         assertEquals("Cannot convert to ParseReference.", e.getMessage());
     }
 
     @Test
     public void valueIsNotAGraph() {
-        Assertions.assertFalse(value.isGraph());
+        assertFalse(value.isGraph());
         final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, value::asGraph);
         assertEquals("Cannot convert to ParseGraph.", e.getMessage());
     }

--- a/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SelectionTest.java
@@ -19,7 +19,8 @@ package io.parsingdata.metal.data;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.rep;
 import static io.parsingdata.metal.data.Selection.findItemAtOffset;
@@ -32,8 +33,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SelectionTest {
 
@@ -62,7 +62,7 @@ public class SelectionTest {
     @Test
     public void limit() {
         Optional<ParseState> parseState = rep(any("a")).parse(env(stream(1, 2, 3, 4, 5)));
-        Assert.assertTrue(parseState.isPresent());
+        assertTrue(parseState.isPresent());
         for (int i = 0; i < 7; i++) {
             assertEquals(Math.min(5, i), getAllValues(parseState.get().order, (value) -> value.matches("a"), i).size);
         }

--- a/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SliceTest.java
@@ -20,9 +20,9 @@ import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.TEN;
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -44,16 +44,13 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.util.InMemoryByteStream;
 import io.parsingdata.metal.util.ReadTrackingByteStream;
 
 public class SliceTest {
-
-    @Rule public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void lazyRead() {
@@ -83,9 +80,10 @@ public class SliceTest {
 
     @Test
     public void retrieveDataFromSliceWithNegativeLimit() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument limit may not be negative.");
-        Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.valueOf(-1));
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            Slice.createFromSource(new ConstantSource(new byte[] { 0, 1, 2, 3 }), ZERO, BigInteger.valueOf(4)).get().getData(BigInteger.valueOf(-1))
+        );
+        assertEquals("Argument limit may not be negative.", e.getMessage());
     }
 
 

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -68,15 +68,15 @@ public class SourceAndSliceTest {
     @ParameterizedTest
     @MethodSource("data")
     public void validSlice(final Source source) {
-        checkSlice(ZERO, 2, source);
-        checkSlice(ZERO, 4, source);
-        checkSlice(ONE, 3, source);
-        checkSlice(BigInteger.valueOf(2), 1, source);
-        checkSlice(BigInteger.valueOf(2), 2, source);
-        checkSlice(BigInteger.valueOf(4), 0, source);
+        assertSlice(ZERO, 2, source);
+        assertSlice(ZERO, 4, source);
+        assertSlice(ONE, 3, source);
+        assertSlice(BigInteger.valueOf(2), 1, source);
+        assertSlice(BigInteger.valueOf(2), 2, source);
+        assertSlice(BigInteger.valueOf(4), 0, source);
     }
 
-    private void checkSlice(final BigInteger offset, final int length, final Source source) {
+    private void assertSlice(final BigInteger offset, final int length, final Source source) {
         assertTrue(compareDataSlices(createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset.intValueExact()));
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/SourceAndSliceTest.java
@@ -19,8 +19,9 @@ package io.parsingdata.metal.data;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.data.Slice.createFromSource;
@@ -31,28 +32,17 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.parsingdata.metal.expression.value.CoreValue;
 import io.parsingdata.metal.expression.value.Value;
 import io.parsingdata.metal.util.InMemoryByteStream;
 
-@RunWith(Parameterized.class)
 public class SourceAndSliceTest {
-
-    @Rule public final ExpectedException thrown = ExpectedException.none();
-
-    @Parameter public Source source;
 
     private static final byte[] DATA = { 0, 1, 2, 3 };
 
-    @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return List.of(new Object[][] {
             { new ConstantSource(DATA) },
@@ -62,8 +52,9 @@ public class SourceAndSliceTest {
         });
     }
 
-    @Test
-    public void validSource() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void validSource(final Source source) {
         assertTrue(source.isAvailable(ZERO, BigInteger.valueOf(4)));
         assertTrue(source.isAvailable(ONE, BigInteger.valueOf(3)));
         assertTrue(source.isAvailable(BigInteger.valueOf(2), ONE));
@@ -74,17 +65,18 @@ public class SourceAndSliceTest {
         assertFalse(source.isAvailable(BigInteger.valueOf(5), ZERO));
     }
 
-    @Test
-    public void validSlice() {
-        checkSlice(ZERO, 2);
-        checkSlice(ZERO, 4);
-        checkSlice(ONE, 3);
-        checkSlice(BigInteger.valueOf(2), 1);
-        checkSlice(BigInteger.valueOf(2), 2);
-        checkSlice(BigInteger.valueOf(4), 0);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void validSlice(final Source source) {
+        checkSlice(ZERO, 2, source);
+        checkSlice(ZERO, 4, source);
+        checkSlice(ONE, 3, source);
+        checkSlice(BigInteger.valueOf(2), 1, source);
+        checkSlice(BigInteger.valueOf(2), 2, source);
+        checkSlice(BigInteger.valueOf(4), 0, source);
     }
 
-    private void checkSlice(final BigInteger offset, final int length) {
+    private void checkSlice(final BigInteger offset, final int length, final Source source) {
         assertTrue(compareDataSlices(createFromSource(source, offset, BigInteger.valueOf(length)).get().getData(), offset.intValueExact()));
     }
 
@@ -97,36 +89,39 @@ public class SourceAndSliceTest {
         return true;
     }
 
-    @Test
-    public void readBeyondEndOfSource() {
-        thrown.expect(IllegalStateException.class);
-        source.getData(ONE, BigInteger.valueOf(4));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void readBeyondEndOfSource(final Source source) {
+        assertThrows(IllegalStateException.class, () -> source.getData(ONE, BigInteger.valueOf(4)));
     }
 
-    @Test
-    public void readBeyondEndOfSlice() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void readBeyondEndOfSlice(final Source source) {
         assertFalse(createFromSource(source, ONE, BigInteger.valueOf(4)).isPresent());
     }
 
-    @Test
-    public void startReadBeyondEndOfSource() {
-        thrown.expect(IllegalStateException.class);
-        source.getData(BigInteger.valueOf(5), ZERO);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void startReadBeyondEndOfSource(final Source source) {
+        assertThrows(IllegalStateException.class, () -> source.getData(BigInteger.valueOf(5), ZERO));
     }
 
-    @Test
-    public void startReadBeyondEndOfSlice() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void startReadBeyondEndOfSlice(final Source source) {
         assertFalse(createFromSource(source, BigInteger.valueOf(5), ZERO).isPresent());
     }
 
-    @Test
-    public void startReadAtNegativeOffsetSource() {
-        thrown.expect(IllegalArgumentException.class);
-        source.getData(BigInteger.valueOf(-1L), ONE);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void startReadAtNegativeOffsetSource(final Source source) {
+        assertThrows(IllegalArgumentException.class, () -> source.getData(BigInteger.valueOf(-1L), ONE));
     }
 
-    @Test
-    public void startReadAtNegativeOffsetSlice() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void startReadAtNegativeOffsetSlice(final Source source) {
         assertFalse(createFromSource(source, BigInteger.valueOf(-1L), ONE).isPresent());
     }
 

--- a/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/callback/CallbackTest.java
@@ -18,9 +18,9 @@ package io.parsingdata.metal.data.callback;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
@@ -42,7 +42,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.SubStructTest;
 import io.parsingdata.metal.data.ImmutableList;

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTokenTest.java
@@ -20,9 +20,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
 import static io.parsingdata.metal.Shorthand.con;
@@ -48,9 +49,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;
@@ -92,15 +91,10 @@ public class ByTokenTest {
             repn(
                  token("selfRec"), last(ref("childCount"))));
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void nullCheck() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument definition may not be null");
-
-        get(parseResultGraph(stream(0, 1, 2), SIMPLE_SEQ), null);
+        final Exception e = assertThrows(IllegalArgumentException.class, () -> get(parseResultGraph(stream(0, 1, 2), SIMPLE_SEQ), null));
+        assertEquals("Argument definition may not be null.", e.getMessage());
     }
 
     @Test
@@ -129,10 +123,8 @@ public class ByTokenTest {
 
     @Test
     public void getAllNullCheck() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument definition may not be null");
-
-        getAll(parseResultGraph(stream(0, 1, 2), SIMPLE_SEQ), null);
+        final Exception e = assertThrows(IllegalArgumentException.class, () -> getAll(parseResultGraph(stream(0, 1, 2), SIMPLE_SEQ), null));
+        assertEquals("Argument definition may not be null.", e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/selection/ByTypeTest.java
@@ -18,6 +18,8 @@ package io.parsingdata.metal.data.selection;
 
 import static java.math.BigInteger.ZERO;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.data.ParseGraph.NONE;
 import static io.parsingdata.metal.data.ParseState.createFromByteStream;
@@ -25,9 +27,8 @@ import static io.parsingdata.metal.data.selection.ByType.getReferences;
 
 import java.math.BigInteger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseReference;
 import io.parsingdata.metal.data.Source;
@@ -39,14 +40,12 @@ public class ByTypeTest {
         @Override protected boolean isAvailable(BigInteger offset, BigInteger length) { return false; }
     };
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void unresolvableRef() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("A ParseReference must point to an existing graph.");
-        getReferences(createFromByteStream(DUMMY_STREAM).createCycle(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).order);
+        final Exception e = Assertions.assertThrows(IllegalStateException.class, () ->
+            getReferences(createFromByteStream(DUMMY_STREAM).createCycle(new ParseReference(ZERO, EMPTY_SOURCE, NONE)).order)
+        );
+        assertEquals("A ParseReference must point to an existing graph.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/BytesTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.bytes;
 import static io.parsingdata.metal.Shorthand.con;
@@ -32,7 +32,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryBigIntegerTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryBigIntegerTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
@@ -25,21 +25,11 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ConstantFactoryBigIntegerTest {
 
-    private final BigInteger value;
-
-    public ConstantFactoryBigIntegerTest(String value) {
-        this.value = new BigInteger(value);
-    }
-
-    @Parameters(name = "{0}")
     public static Collection<Object[]> arguments() {
         return List.of(new Object[][] {
             { "0" },
@@ -49,8 +39,9 @@ public class ConstantFactoryBigIntegerTest {
         });
     }
 
-    @Test
-    public void checkBigInteger() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("arguments")
+    public void checkBigInteger(final BigInteger value) {
         assertEquals(0, value.compareTo(ConstantFactory.createFromNumeric(value, signed()).asNumeric()));
         assertEquals(0, new BigInteger(1, value.toByteArray()).compareTo(ConstantFactory.createFromNumeric(value, enc()).asNumeric()));
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryLongTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ConstantFactoryLongTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
@@ -25,23 +25,13 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ConstantFactoryLongTest {
 
     public static final BigInteger TWOS_DIFF = BigInteger.valueOf(2).add(BigInteger.valueOf(Long.MAX_VALUE)).add(BigInteger.valueOf(Long.MAX_VALUE));
 
-    private final long value;
-
-    public ConstantFactoryLongTest(long value) {
-        this.value = value;
-    }
-
-    @Parameters(name = "{0}")
     public static Collection<Object[]> arguments() {
         return List.of(new Object[][] {
             { 0L },
@@ -56,8 +46,9 @@ public class ConstantFactoryLongTest {
         });
     }
 
-    @Test
-    public void checkLong() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("arguments")
+    public void checkLong(final long value) {
         assertEquals(value, ConstantFactory.createFromNumeric(value, signed()).asNumeric().longValueExact());
         if (value >= 0) {
             assertEquals(value, ConstantFactory.createFromNumeric(value, enc()).asNumeric().longValueExact());

--- a/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/CountTest.java
@@ -29,8 +29,6 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
@@ -41,8 +39,8 @@ public class CountTest extends ParameterizedParse {
         def("count", 1, eq(count(ref("a"))))
     );
 
-    @Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][]{
             {"[] = count(0)", COUNT, stream(0), enc(), true},
             {"[3] = count(1)", COUNT, stream(3, 1), enc(), true},

--- a/core/src/test/java/io/parsingdata/metal/expression/value/CurrentOffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/CurrentOffsetTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
 import static io.parsingdata.metal.Shorthand.con;
@@ -34,7 +34,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.token.Token;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ElvisExpressionTest.java
@@ -18,10 +18,10 @@ package io.parsingdata.metal.expression.value;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
@@ -39,7 +39,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ExpandTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.AutoEqualityTest.DUMMY_STREAM;
 import static io.parsingdata.metal.Shorthand.con;
@@ -31,9 +31,8 @@ import static io.parsingdata.metal.expression.value.BytesTest.EMPTY_PARSE_STATE;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseValue;
@@ -44,8 +43,6 @@ public class ExpandTest {
     public static final int VALUE_1 = 42;
     public static final int VALUE_2 = 84;
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     public static final ParseValue PARSEVALUE_1 = createParseValue("a", VALUE_1);
     public static final ParseValue PARSEVALUE_2 = createParseValue("a", VALUE_2);
 
@@ -57,16 +54,14 @@ public class ExpandTest {
 
     @Test
     public void expandNotAValueTimes() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Count must evaluate to a non-empty countable value.");
-        exp(con(1), div(con(1), con(0))).eval(EMPTY_PARSE_STATE, enc());
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> exp(con(1), div(con(1), con(0))).eval(EMPTY_PARSE_STATE, enc()));
+        assertEquals("Count must evaluate to a non-empty countable value.", e.getMessage());
     }
 
     @Test
     public void expandEmptyTimes() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Count must evaluate to a non-empty countable value.");
-        exp(con(1), last(ref("a"))).eval(EMPTY_PARSE_STATE, enc());
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> exp(con(1), last(ref("a"))).eval(EMPTY_PARSE_STATE, enc()));
+        assertEquals("Count must evaluate to a non-empty countable value.", e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldCatTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cat;
 import static io.parsingdata.metal.Shorthand.con;
@@ -32,7 +32,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ImmutableList;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/FoldEdgeCaseTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
@@ -43,9 +43,8 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.Shorthand;
 import io.parsingdata.metal.data.ImmutableList;
@@ -57,9 +56,6 @@ import io.parsingdata.metal.data.ParseState;
 public class FoldEdgeCaseTest {
 
     private static final BinaryOperator<SingleValueExpression> EMPTY_VALUE_REDUCER = (left, right) -> (parseState, encoding) -> Optional.empty();
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void valuesContainsEmpty() {
@@ -102,16 +98,17 @@ public class FoldEdgeCaseTest {
     }
 
     private void faultyReducer(final ValueExpression expression) {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Reducer must evaluate to a value.");
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () ->
+            seq(
+                def("value", 1), // the reducer returns a Ref to these two values
+                def("value", 1),
+                def("toFold", 1),
+                def("toFold", 1),
+                def("folded", 1, eq(expression))
+            ).parse(env(stream(1, 2, 1, 2, 3)))
+        );
+        assertEquals("Reducer must evaluate to a value.", e.getMessage());
 
-        seq(
-            def("value", 1), // the reducer returns a Ref to these two values
-            def("value", 1),
-            def("toFold", 1),
-            def("toFold", 1),
-            def("folded", 1, eq(expression))
-        ).parse(env(stream(1, 2, 1, 2, 3)));
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NotAValueTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NotAValueTest.java
@@ -16,64 +16,55 @@
 
 package io.parsingdata.metal.expression.value;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import static io.parsingdata.metal.expression.value.NotAValue.NOT_A_VALUE;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NotAValueTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void getSlice() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("NOT_A_VALUE does not support any Value operation.");
-        NOT_A_VALUE.slice();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, NOT_A_VALUE::slice);
+        assertEquals("NOT_A_VALUE does not support any Value operation.", e.getMessage());
     }
 
     @Test
     public void getEncoding() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("NOT_A_VALUE does not support any Value operation.");
-        NOT_A_VALUE.encoding();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, NOT_A_VALUE::encoding);
+        assertEquals("NOT_A_VALUE does not support any Value operation.", e.getMessage());
     }
 
     @Test
     public void getValue() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("NOT_A_VALUE does not support any Value operation.");
-        NOT_A_VALUE.value();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, NOT_A_VALUE::value);
+        assertEquals("NOT_A_VALUE does not support any Value operation.", e.getMessage());
     }
 
     @Test
     public void getLength() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("NOT_A_VALUE does not support any Value operation.");
-        NOT_A_VALUE.length();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, NOT_A_VALUE::length);
+        assertEquals("NOT_A_VALUE does not support any Value operation.", e.getMessage());
     }
 
     @Test
     public void asNumeric() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("NOT_A_VALUE does not support any Value operation.");
-        NOT_A_VALUE.asNumeric();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, NOT_A_VALUE::asNumeric);
+        assertEquals("NOT_A_VALUE does not support any Value operation.", e.getMessage());
     }
 
     @Test
     public void asString() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("NOT_A_VALUE does not support any Value operation.");
-        NOT_A_VALUE.asString();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, NOT_A_VALUE::asString);
+        assertEquals("NOT_A_VALUE does not support any Value operation.", e.getMessage());
     }
 
     @Test
     public void asBitSet() {
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("NOT_A_VALUE does not support any Value operation.");
-        NOT_A_VALUE.asBitSet();
+        final Exception e = Assertions.assertThrows(UnsupportedOperationException.class, NOT_A_VALUE::asBitSet);
+        assertEquals("NOT_A_VALUE does not support any Value operation.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/NthExpressionTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
@@ -35,7 +35,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/RefEdgeCaseTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ScopeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ScopeTest.java
@@ -18,8 +18,8 @@ package io.parsingdata.metal.expression.value;
 
 import static java.math.BigInteger.ZERO;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.EMPTY;
 import static io.parsingdata.metal.Shorthand.con;
@@ -41,30 +41,24 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Optional;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.token.Token;
 
 public class ScopeTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void notAValueScopeSize() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument scopeSize must evaluate to a positive, countable value.");
-        new Scope(con(0), EMPTY_SVE).eval(EMPTY_PARSE_STATE, enc());
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> new Scope(con(0), EMPTY_SVE).eval(EMPTY_PARSE_STATE, enc()));
+        assertEquals("Argument scopeSize must evaluate to a positive, countable value.", e.getMessage());
     }
 
     @Test
     public void negativeScopeSize() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument scopeSize must evaluate to a positive, countable value.");
-        new Scope(con(0), con(-1, signed())).eval(EMPTY_PARSE_STATE, enc());
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> new Scope(con(0), con(-1, signed())).eval(EMPTY_PARSE_STATE, enc()));
+        assertEquals("Argument scopeSize must evaluate to a positive, countable value.", e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionEvalEmptyTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionEvalEmptyTest.java
@@ -16,7 +16,7 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
@@ -26,7 +26,7 @@ import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 

--- a/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionListSemanticsTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/ValueExpressionListSemanticsTest.java
@@ -35,16 +35,14 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized;
-
 import io.parsingdata.metal.expression.Expression;
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
 public class ValueExpressionListSemanticsTest extends ParameterizedParse {
 
-    @Parameterized.Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "a, a, b, b, last(a+b)", pred2(eq(last(add(ref("a"), ref("b"))))), stream(1, 2, 3, 4, 6), enc(), true },
             { "a, a, b, b, first(a+b)", pred2(eq(first(add(ref("a"), ref("b"))))), stream(1, 2, 3, 4, 4), enc(), true },

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationEdgeCaseTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationEdgeCaseTest.java
@@ -15,8 +15,8 @@
  */
 package io.parsingdata.metal.expression.value.reference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.div;
@@ -33,22 +33,17 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.expression.value.Value;
 
 public class CurrentIterationEdgeCaseTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     private ParseState parseState;
 
-    @Before
+    @BeforeEach
     public void before() {
         parseState = rep(any("a")).parse(env(stream(1, 2, 3))).get();
     }

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/CurrentIterationTest.java
@@ -37,8 +37,6 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized;
-
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
@@ -50,8 +48,8 @@ public class CurrentIterationTest extends ParameterizedParse {
     public static final Token VALUE_EQ_ITERATION_GRANDPARENT = def("value", con(1), eq(iteration(2)));
     public static final Token VALUE_EQ_255 = def("value", con(1), eq(con(255)));
 
-    @Parameterized.Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[0, 1, 2, 3, 255] rep(CURRENT_ITERATION), def(255)", seq(rep(VALUE_EQ_ITERATION), VALUE_EQ_255), stream(0, 1, 2, 3, 255), enc(), true },
             { "[0, 1, 2, 3] repn=4(CURRENT_ITERATION)", repn(VALUE_EQ_ITERATION, con(4)), stream(0, 1, 2, 3), enc(), true },

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/LocalReferenceFollowingScopeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/LocalReferenceFollowingScopeTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.count;
@@ -36,7 +36,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.Shorthand;
 import io.parsingdata.metal.data.ParseState;

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/LocalReferenceNestedScopeTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/LocalReferenceNestedScopeTest.java
@@ -18,8 +18,8 @@ package io.parsingdata.metal.expression.value.reference;
 
 import static java.math.BigInteger.ONE;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.cho;
 import static io.parsingdata.metal.Shorthand.con;
@@ -39,7 +39,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.expression.Expression;
@@ -71,7 +71,7 @@ public class LocalReferenceNestedScopeTest {
     private void nestedScopes(final Expression rightExpression) {
         Optional<ParseState> parseState = topLevelNestedScopes(rightExpression).parse(env(stream(42, 1, 2, 3, 42, 3, 2, 1), enc()));
         assertTrue(parseState.isPresent());
-        assertFalse("The test has not parsed the whole stream. It ended at offset " + parseState.get().offset + ".", parseState.get().slice(ONE).isPresent());
+        assertFalse(parseState.get().slice(ONE).isPresent(), "The test has not parsed the whole stream. It ended at offset " + parseState.get().offset + ".");
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
+++ b/core/src/test/java/io/parsingdata/metal/expression/value/reference/OffsetTest.java
@@ -16,14 +16,14 @@
 
 package io.parsingdata.metal.expression.value.reference;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.offset;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.expression.value.Value;

--- a/core/src/test/java/io/parsingdata/metal/token/DefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefTest.java
@@ -19,8 +19,9 @@ package io.parsingdata.metal.token;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -32,9 +33,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.math.BigInteger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ByteStream;
 import io.parsingdata.metal.data.Environment;
@@ -43,9 +42,6 @@ import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.data.Selection;
 
 public class DefTest {
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void scopeWithoutEncoding() {
@@ -59,9 +55,8 @@ public class DefTest {
 
     @Test
     public void errorEmptyName() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument name may not be empty.");
-        def("", 1);
+        final Exception e = assertThrows(IllegalArgumentException.class, () -> def("", 1));
+        assertEquals("Argument name may not be empty.", e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/io/parsingdata/metal/token/DefUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/DefUntilTest.java
@@ -16,8 +16,13 @@
 
 package io.parsingdata.metal.token;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import static io.parsingdata.metal.Shorthand.CURRENT_OFFSET;
-import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.EMPTY;
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -27,30 +32,28 @@ import static io.parsingdata.metal.Shorthand.mod;
 import static io.parsingdata.metal.Shorthand.post;
 import static io.parsingdata.metal.Shorthand.ref;
 import static io.parsingdata.metal.Shorthand.rep;
+import static io.parsingdata.metal.Shorthand.seq;
 import static io.parsingdata.metal.Shorthand.sub;
 import static io.parsingdata.metal.Shorthand.until;
 import static io.parsingdata.metal.data.selection.ByName.getAllValues;
 import static io.parsingdata.metal.util.EncodingFactory.signed;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
-import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.data.ParseValue;
 import io.parsingdata.metal.encoding.Encoding;
 import io.parsingdata.metal.expression.Expression;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class DefUntilTest {
 

--- a/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/ParameterizedUntilTest.java
@@ -37,8 +37,6 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized.Parameters;
-
 import io.parsingdata.metal.expression.value.ValueExpression;
 import io.parsingdata.metal.util.ParameterizedParse;
 
@@ -46,8 +44,8 @@ public class ParameterizedUntilTest extends ParameterizedParse {
 
     private static final Token ABC = def("abc", 3, eq(con("abc")));
 
-    @Parameters(name = "{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[a,b,c,a,b,c] i=0,s=1,m=6 ab",      untilToken(0, 1, 6, con('c'), con("ab"), ABC), stream("abcabc", US_ASCII), enc(), true },
             { "[a,b,c,a,b,c] i=3,s=1,m=6 abcab",   untilToken(3, 1, 6, con('c'), con("abcab")),   stream("abcabc", US_ASCII), enc(), true },

--- a/core/src/test/java/io/parsingdata/metal/token/PostTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PostTest.java
@@ -18,7 +18,7 @@ package io.parsingdata.metal.token;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -32,7 +32,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 

--- a/core/src/test/java/io/parsingdata/metal/token/PreTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/PreTest.java
@@ -18,7 +18,7 @@ package io.parsingdata.metal.token;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -31,7 +31,7 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 

--- a/core/src/test/java/io/parsingdata/metal/token/TieTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TieTest.java
@@ -16,9 +16,9 @@
 
 package io.parsingdata.metal.token;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.add;
 import static io.parsingdata.metal.Shorthand.cat;
@@ -50,7 +50,7 @@ import static io.parsingdata.metal.util.TokenDefinitions.any;
 import java.util.Optional;
 import java.util.zip.Deflater;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.Shorthand;
 import io.parsingdata.metal.data.ImmutableList;

--- a/core/src/test/java/io/parsingdata/metal/token/TokenRefTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenRefTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.token;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -30,7 +30,7 @@ import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import static io.parsingdata.metal.util.TokenDefinitions.any;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TokenRefTest {
 

--- a/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/TokenTest.java
@@ -16,23 +16,22 @@
 
 package io.parsingdata.metal.token;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
 import java.util.Optional;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.Environment;
 import io.parsingdata.metal.data.ParseState;
 
 public class TokenTest {
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
     private final Token token = new Token("", null) {
         @Override
         protected Optional<ParseState> parseImpl(final Environment environment) {
@@ -42,16 +41,14 @@ public class TokenTest {
 
     @Test
     public void parseNullParseState() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument parseState may not be null.");
-        token.parse(env(null, enc()));
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> token.parse(env(null, enc())));
+        assertEquals("Argument parseState may not be null.", e.getMessage());
     }
 
     @Test
     public void parseNullScope() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Argument scope may not be null.");
-        token.parse(env(null, stream(), enc()));
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> token.parse(env(null, stream(), enc())));
+        assertEquals("Argument scope may not be null.", e.getMessage());
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
+++ b/core/src/test/java/io/parsingdata/metal/token/WhileTest.java
@@ -18,7 +18,8 @@ package io.parsingdata.metal.token;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Shorthand.def;
@@ -31,11 +32,10 @@ import static io.parsingdata.metal.Shorthand.whl;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
-import static junit.framework.TestCase.assertFalse;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ParseState;
 

--- a/core/src/test/java/io/parsingdata/metal/util/ClassDefinition.java
+++ b/core/src/test/java/io/parsingdata/metal/util/ClassDefinition.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -28,14 +28,14 @@ public class ClassDefinition {
     public static void checkUtilityClass(Class<?> utilityClass) throws ReflectiveOperationException {
         final String simpleName = utilityClass.getSimpleName();
         // class is final
-        assertTrue(simpleName + " should be final", Modifier.isFinal(utilityClass.getModifiers()));
+        assertTrue(Modifier.isFinal(utilityClass.getModifiers()), simpleName + " should be final");
 
         // has one constructor
         final Constructor<?>[] constructors = utilityClass.getDeclaredConstructors();
-        assertEquals(simpleName + " should have exactly 1 constructor", 1, constructors.length);
+        assertEquals(1, constructors.length, simpleName + " should have exactly 1 constructor");
 
         // which is private
-        assertTrue(simpleName + " should have a private constructor", Modifier.isPrivate(constructors[0].getModifiers()));
+        assertTrue(Modifier.isPrivate(constructors[0].getModifiers()), simpleName + " should have a private constructor");
 
         // call it for coverage
         constructors[0].setAccessible(true);
@@ -43,7 +43,7 @@ public class ClassDefinition {
 
         // check that all declared methods are static
         for (final Method method : utilityClass.getDeclaredMethods()) {
-            assertTrue("method '" + method.getName()  + "' in " + simpleName + " should be static", Modifier.isStatic(method.getModifiers()));
+            assertTrue(Modifier.isStatic(method.getModifiers()), "method '" + method.getName()  + "' in " + simpleName + " should be static");
         }
     }
 

--- a/formats/src/test/java/io/parsingdata/metal/DescriptionClassTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/DescriptionClassTest.java
@@ -18,7 +18,7 @@ package io.parsingdata.metal;
 
 import static io.parsingdata.metal.util.ClassDefinition.checkUtilityClass;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.format.Callback;
 import io.parsingdata.metal.format.JPEG;

--- a/formats/src/test/java/io/parsingdata/metal/expression/value/GUIDTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/expression/value/GUIDTest.java
@@ -16,7 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
@@ -26,16 +27,12 @@ import static io.parsingdata.metal.util.EncodingFactory.le;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 
 public class GUIDTest {
-
-    @Rule
-    public final ExpectedException _exception = ExpectedException.none();
 
     @Test
     public void checkUtility() throws ReflectiveOperationException {
@@ -45,11 +42,10 @@ public class GUIDTest {
     @Test
     public void parseGUID() {
         final Token guid = def("guid", 16, eq(guid("00c27766-f623-4200-9d64-115e9bfd4a08")));
-        assertTrue("be", guid.parse(env(stream(0x00, 0xc2, 0x77, 0x66, 0xf6, 0x23, 0x42, 0x00, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08))).isPresent());
-        assertTrue("le", guid.parse(env(stream(0x66, 0x77, 0xc2, 0x00, 0x23, 0xf6, 0x00, 0x42, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08), le())).isPresent());
+        assertTrue(guid.parse(env(stream(0x00, 0xc2, 0x77, 0x66, 0xf6, 0x23, 0x42, 0x00, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08))).isPresent(), "be");
+        assertTrue(guid.parse(env(stream(0x66, 0x77, 0xc2, 0x00, 0x23, 0xf6, 0x00, 0x42, 0x9d, 0x64, 0x11, 0x5e, 0x9b, 0xfd, 0x4a, 0x08), le())).isPresent(), "le");
 
-        _exception.expect(IllegalArgumentException.class);
-        _exception.expectMessage("Invalid GUID string: test");
-        guid("test");
+        final Exception e = Assertions.assertThrows(IllegalArgumentException.class, () -> guid("test"));
+        assertEquals("Invalid GUID string: test", e.getMessage());
     }
 }

--- a/formats/src/test/java/io/parsingdata/metal/expression/value/UUIDTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/expression/value/UUIDTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.expression.value;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static io.parsingdata.metal.Shorthand.def;
 import static io.parsingdata.metal.Shorthand.eq;
@@ -26,7 +26,7 @@ import static io.parsingdata.metal.util.ClassDefinition.checkUtilityClass;
 import static io.parsingdata.metal.util.EnvironmentFactory.env;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.token.Token;
 

--- a/formats/src/test/java/io/parsingdata/metal/format/CallbackTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/CallbackTest.java
@@ -16,8 +16,8 @@
 
 package io.parsingdata.metal.format;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static io.parsingdata.metal.Shorthand.con;
 import static io.parsingdata.metal.Util.inflate;
@@ -25,7 +25,7 @@ import static io.parsingdata.metal.format.Callback.crc32;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.parsingdata.metal.data.ImmutableList;
 import io.parsingdata.metal.expression.value.Value;

--- a/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
@@ -24,15 +24,13 @@ import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized;
-
 import io.parsingdata.metal.data.ParseState;
 import io.parsingdata.metal.util.ParameterizedParse;
 
 public class FormatTest extends ParameterizedParse {
 
-    @Parameterized.Parameters(name="{0} ({4})")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "PNG", PNG.FORMAT, parseState("/test.png"), enc(), true },
             { "ZIP", ZIP.FORMAT, parseState("/singlefile-zip30-ubuntu.zip"), enc(), true },
@@ -41,8 +39,12 @@ public class FormatTest extends ParameterizedParse {
         });
     }
 
-    private static ParseState parseState(final String path) throws URISyntaxException, IOException {
-        return stream(FormatTest.class.getResource(path).toURI());
+    private static ParseState parseState(final String path) {
+        try {
+            return stream(FormatTest.class.getResource(path).toURI());
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
     }
 
 }

--- a/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/FormatTest.java
@@ -19,8 +19,6 @@ package io.parsingdata.metal.format;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 import static io.parsingdata.metal.util.ParseStateFactory.stream;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 

--- a/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
+++ b/formats/src/test/java/io/parsingdata/metal/format/VarIntTest.java
@@ -34,8 +34,6 @@ import static io.parsingdata.metal.util.ParseStateFactory.stream;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.runners.Parameterized;
-
 import io.parsingdata.metal.token.Token;
 import io.parsingdata.metal.util.ParameterizedParse;
 
@@ -53,8 +51,8 @@ public class VarIntTest extends ParameterizedParse {
                 post(def("decoded", len(decodeVarInt(last(ref("varInt"))))), eq(decodeVarInt(last(ref("varInt")))))
             ), con(4));
 
-    @Parameterized.Parameters(name = "{0} ({4})")
-    public static Collection<Object[]> data() {
+    @Override
+    public Collection<Object[]> data() {
         return List.of(new Object[][] {
             { "[63, 63] 63 (varint) == 63", varIntAndValue(1), stream(63, 63), enc(), true },
             { "[127, 127] 127 (varint) == 127", varIntAndValue(1), stream(127, 127), enc(), true },

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <encoding>UTF-8</encoding>
 
     <junit-jupiter.version>5.9.3</junit-jupiter.version>
-    <junit.version>4.13.2</junit.version>
+    <hamcrest-library.version>2.2</hamcrest-library.version>
 
     <jacoco-plugin.version>0.8.10</jacoco-plugin.version>
     <pmd-plugin.version>3.21.0</pmd-plugin.version>
@@ -102,12 +102,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit-jupiter.version}</version>
@@ -120,9 +114,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit-jupiter.version}</version>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest-library.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
To avoid confusion about which import to pick, decided to convert all tests to JUnit5. The steps consists of the following removals:

* Removal of the @Rule annotations and replaced it with assertThrows() test methods instead
* Removal of the @RunWith(Parameterized) for classes and replaced it with @ParameterizedTest on test methods.
* Changing imports from org.junit.(...) to org.juni.jupiter.api.Assertions.(...).

These steps required some additional changes to be made, especially around the [ParameterizedParse](https://github.com/parsingdata/metal/pull/395/files#diff-c7383c4315c5343a8d14883a0f87de903a6a11883d5d5c1b56b42b27348ac3a2) class.

Note: the old test suite before this branch contained 1147+16 tests and so does this run, so all tests are accounted for.

- [x] Find out why there are 27 more tests. - Checked the wrong commit. :see_no_evil: 
- [x] Change destination to master when #393 is merged.