### PR TITLE
#405 ConcatenatedValueSource performance bug

### DIFF
--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -64,7 +64,7 @@ public class Slice extends ImmutableObject {
     /**
      * Return a part of the data specified by the offset and limit.
      * @param offset the offset to start reading the slice from
-     * @param limit the maximum number of bytes returned. Less bytes are returned if the end of slice is reached.
+     * @param limit the maximum number of bytes returned. Fewer bytes are returned if the end of slice is reached.
      * @return a byte array representing the data.
      */
     public byte[] getData(final BigInteger offset, final BigInteger limit) {

--- a/core/src/main/java/io/parsingdata/metal/data/Slice.java
+++ b/core/src/main/java/io/parsingdata/metal/data/Slice.java
@@ -58,8 +58,19 @@ public class Slice extends ImmutableObject {
     }
 
     public byte[] getData(final BigInteger limit) {
-        final BigInteger calculatedLength = checkNotNegative(limit, "limit").compareTo(length) > 0 ? length : limit;
-        return source.getData(offset, calculatedLength);
+        return getData(ZERO, limit);
+    }
+
+    /**
+     * Return a part of the data specified by the offset and limit.
+     * @param offset the offset to start reading the slice from
+     * @param limit the maximum number of bytes returned. Less bytes are returned if the end of slice is reached.
+     * @return a byte array representing the data.
+     */
+    public byte[] getData(final BigInteger offset, final BigInteger limit) {
+        final BigInteger calculatedOffset = checkNotNegative(offset, "offset").add(this.offset);
+        final BigInteger calculatedLength = checkNotNegative(limit, "limit").min(length.subtract(offset)).max(ZERO);
+        return source.getData(calculatedOffset, calculatedLength);
     }
 
     @Override

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -16,7 +16,6 @@
 
 package io.parsingdata.metal.data;
 
-import static java.math.BigInteger.ZERO;
 import static java.math.BigInteger.valueOf;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -115,16 +114,14 @@ public class ConcatenatedValueSourceTest {
         }
 
         // Create a value that has a ConcatenatedValueSource as source.
-        final Value bigValue = ConcatenatedValueSource.create(values)
-            .flatMap(source -> createFromSource(source, ZERO, valueOf(arraySize)))
-            .map(slice -> new CoreValue(slice, Encoding.DEFAULT_ENCODING)).get();
+        final ConcatenatedValueSource source = ConcatenatedValueSource.create(values).get();
 
-        // Read from the big value.
+        // Read from the source in small parts.
         final int readSize = 512;
         final byte[] valueBytes = new byte[arraySize];
         final long start = System.currentTimeMillis();
         for (int part = 0; part < arraySize / readSize; part++) {
-            final byte[] data = bigValue.slice().source.getData(bigValue.slice().offset.add(valueOf(readSize * part)), valueOf(readSize));
+            final byte[] data = source.getData(valueOf(readSize * part), valueOf(readSize));
             System.arraycopy(data, 0, valueBytes, readSize * part, data.length);
         }
         final long end = System.currentTimeMillis();

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -113,22 +113,22 @@ public class ConcatenatedValueSourceTest {
             values = values.add(new CoreValue(Slice.createFromBytes(Arrays.copyOfRange(bytes, (arraySize / parts) * part, (arraySize / parts) * (part + 1))), Encoding.DEFAULT_ENCODING));
         }
 
-        // Create a value that has a ConcatenatedValueSource as source.
+        // Create a ConcatenatedValueSource to read from.
         final ConcatenatedValueSource source = ConcatenatedValueSource.create(values).get();
 
         // Read from the source in small parts.
         final int readSize = 512;
-        final byte[] valueBytes = new byte[arraySize];
+        final byte[] bytesRead = new byte[arraySize];
         final long start = System.currentTimeMillis();
         for (int part = 0; part < arraySize / readSize; part++) {
             final byte[] data = source.getData(valueOf(readSize * part), valueOf(readSize));
-            System.arraycopy(data, 0, valueBytes, readSize * part, data.length);
+            System.arraycopy(data, 0, bytesRead, readSize * part, data.length);
         }
         final long end = System.currentTimeMillis();
-        System.out.printf("Value read: %ss%n", (end - start) / 1000.0);
+        System.out.printf("Source read: %ss%n", (end - start) / 1000.0);
 
         // Make sure we read the data correctly.
-        assertArrayEquals(bytes, valueBytes);
+        assertArrayEquals(bytes, bytesRead);
     }
 
 }

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -26,7 +26,6 @@ import static io.parsingdata.metal.data.Slice.createFromSource;
 import static io.parsingdata.metal.expression.value.ConstantFactory.createFromBytes;
 import static io.parsingdata.metal.util.EncodingFactory.enc;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
@@ -121,16 +120,14 @@ public class ConcatenatedValueSourceTest {
             .map(slice -> new CoreValue(slice, Encoding.DEFAULT_ENCODING)).get();
 
         // Read from the big value.
-        long start, end;
         final int readSize = 512;
-
         final byte[] valueBytes = new byte[arraySize];
-        start = System.currentTimeMillis();
+        final long start = System.currentTimeMillis();
         for (int part = 0; part < arraySize / readSize; part++) {
             final byte[] data = bigValue.slice().source.getData(bigValue.slice().offset.add(valueOf(readSize * part)), valueOf(readSize));
             System.arraycopy(data, 0, valueBytes, readSize * part, data.length);
         }
-        end = System.currentTimeMillis();
+        final long end = System.currentTimeMillis();
         System.out.printf("Value read: %ss%n", (end - start) / 1000.0);
 
         // Make sure we read the data correctly.

--- a/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
+++ b/core/src/test/java/io/parsingdata/metal/data/ConcatenatedValueSourceTest.java
@@ -107,7 +107,7 @@ public class ConcatenatedValueSourceTest {
         new Random().nextBytes(bytes);
 
         // Split the data in separate CoreValues.
-        int parts = 4;
+        final int parts = 4;
         ImmutableList<Value> values = new ImmutableList<>();
         for (int part = 0; part < parts; part++) {
             values = values.add(new CoreValue(Slice.createFromBytes(Arrays.copyOfRange(bytes, (arraySize / parts) * part, (arraySize / parts) * (part + 1))), Encoding.DEFAULT_ENCODING));


### PR DESCRIPTION
The ConcatenatedValueSource was very inefficient when reading smaller blocks of data from large values. It would copy the entire value in an array first and then copy a small portion in a new array again.

Resolved this by adding a `getData` method to the `Slice` class where you can specify the offset next to the limit. This allows to directly read only that data that is needed.